### PR TITLE
Chiplet swizzling with non-uniform XCD assignment

### DIFF
--- a/benchmarks/benchmark_autotuning.py
+++ b/benchmarks/benchmark_autotuning.py
@@ -49,7 +49,13 @@ def persistent_matmul(
 ):
     pid = tl.program_id(0)
     if NUM_XCDS != 1:
-        pid = (pid % NUM_XCDS) * (NUM_SMS // NUM_XCDS) + (pid // NUM_XCDS)
+        xcd = pid % NUM_XCDS
+        pos_in_xcd = pid // NUM_XCDS
+        min_per_xcd = NUM_SMS // NUM_XCDS
+        extra_sms = NUM_SMS % NUM_XCDS
+        offset = xcd * min_per_xcd + min(xcd, extra_sms)
+        pid = offset + pos_in_xcd
+
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
     total_tiles = num_pid_m * num_pid_n

--- a/include/tritonblas/internal/persistent_matmul.py
+++ b/include/tritonblas/internal/persistent_matmul.py
@@ -31,7 +31,13 @@ def persistent_matmul(
 ):
     pid = tl.program_id(0)
     if NUM_XCDS != 1:
-        pid = (pid % NUM_XCDS) * (NUM_SMS // NUM_XCDS) + (pid // NUM_XCDS)
+        xcd = pid % NUM_XCDS
+        pos_in_xcd = pid // NUM_XCDS
+        min_per_xcd = NUM_SMS // NUM_XCDS
+        extra_sms = NUM_SMS % NUM_XCDS
+        offset = xcd * min_per_xcd + min(xcd, extra_sms)
+        pid = offset + pos_in_xcd
+
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
     total_tiles = num_pid_m * num_pid_n

--- a/include/tritonblas/internal/streamk_matmul.py
+++ b/include/tritonblas/internal/streamk_matmul.py
@@ -32,7 +32,13 @@ def streamk_matmul(
 ):
     pid = tl.program_id(0)
     if NUM_XCDS != 1:
-        pid = (pid % NUM_XCDS) * (NUM_SMS // NUM_XCDS) + (pid // NUM_XCDS)
+        xcd = pid % NUM_XCDS
+        pos_in_xcd = pid // NUM_XCDS
+        min_per_xcd = NUM_SMS // NUM_XCDS
+        extra_sms = NUM_SMS % NUM_XCDS
+        offset = xcd * min_per_xcd + min(xcd, extra_sms)
+        pid = offset + pos_in_xcd
+
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
     iters_per_tile = tl.cdiv(K, BLOCK_SIZE_K)


### PR DESCRIPTION
The current way that chiplet swizzling is implemented:

`pid = (pid % NUM_XCDS) * (NUM_SMS // NUM_XCDS) + (pid // NUM_XCDS)`

will not work when `NUM_SMS` is not divisible by `NUM_XCDS`. The current transformation assumes that each XCD gets the same number of workgroups, and the resulting mapping will not be bijective if this assumption does not hold. 

The current implementation for chiplet swizzling is correct for persistent-style kernels where `NUM_SMS % NUM_XCDS == 0`, however, my changes correctly implement chiplet swizzling in all cases. 

I'm having issues getting the repo to work on my machine, so I wasn't able to test my changes. But the logic is translated from swizzling transformation code I've implemented and is very similar to the approach that [aiter](https://github.com/ROCm/aiter/blob/508c0b69bdd284a0c17eb8c77dd90a1a0b0563dd/aiter/ops/triton/utils/pid_preprocessing.py#L28) utililizes.
