### PR TITLE
Update setup.py to use origami factored out from tensilelite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,5 @@ cython_debug/
 *.hatchet
 *.csv
 _origami
+*.amdgcn
+datasets/*.yaml

--- a/include/tritonblas/origami.py
+++ b/include/tritonblas/origami.py
@@ -37,7 +37,7 @@ class MatmulHeuristicResult:
         self.k = k
         
         # Instantiate hardare information object
-        self.hardware = origami.getHardwareForDevice(0)
+        self.hardware = origami.get_hardware_for_device(0)
         self.block_mn_range = [16, 32, 64, 128, 256]
         self.block_k_range = [16, 32, 64]
         

--- a/setup.py
+++ b/setup.py
@@ -26,20 +26,18 @@ class CustomBuildExt(build_ext):
         print("Cloning hipBLASLt...")
         subprocess.check_call([
             "git", "clone", "--depth", "1", "--filter=blob:none", "--sparse",
-            "--branch", "develop", "https://github.com/ROCm/rocm-libraries.git", "_origami"
+            "--branch", "users/ibrahimw1/origami-standalone", "https://github.com/ROCm/rocm-libraries.git", "_origami"
         ])
 
         # Use custom chdir context manager to run sparse-checkout
         with chdir("_origami"):
             subprocess.check_call([
                 "git", "sparse-checkout", "set",
-                "projects/hipblaslt/tensilelite/Tensile/Source/lib/source/analytical",
-                "projects/hipblaslt/tensilelite/Tensile/Utilities/origami",
-                "projects/hipblaslt/tensilelite/Tensile/Source/lib/include/Tensile/analytical"
+                "shared/origami"
             ])
 
         # Build the nested origami setup.py
-        origami_setup_path = os.path.join("_origami", "projects", "hipblaslt", "tensilelite", "Tensile", "Utilities", "origami")
+        origami_setup_path = os.path.join("_origami", "shared", "origami", "python")
         print(f"Building origami setup.py in {origami_setup_path}...")
         subprocess.check_call([sys.executable, "setup.py", "install"], cwd=origami_setup_path)
 


### PR DESCRIPTION
## Motivation

Origami is moving to a standalone folder in the rocm-libraries repository/shared. The build for tritonBLAS needs to be updated to represent this.

## Technical Details
[Current Origami Standalone branch for testing](https://github.com/ROCm/rocm-libraries/tree/users/ibrahimw1/origami-standalone)


## Test Plan
Ran a simple benchmark on 8192x8192x8192

## Test Result

Test shows expected performance.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
