### PR TITLE
Update grid heuristic to gate MI300 specific adaptation

### DIFF
--- a/include/tritonblas/origami.py
+++ b/include/tritonblas/origami.py
@@ -318,7 +318,6 @@ class MatmulHeuristicResult:
 
             # Really bad last wave, which would have originally been compensated for
             # by changing tile size, but triton tile sizes are limited
-            if last_wave_remainder < 128 and last_wave_remainder > 0:
+            if last_wave_remainder < 128 and last_wave_remainder > 0 and self.hardware.N_CU == 304:
                 sk_grid = 256
-
         return sk_grid


### PR DESCRIPTION
## Motivation
Fix weird artifacts in performance graph.
## Technical Details
The last wave remainder heuristic works on MI300 because it is more power constrained and therefore launching 256 workgroups when there is low occupancy in the last wave resulted in no change in total aggregate occupancy but an increase in per CU performance. This does not apply on MI350 the same way.

## Test Plan
Run problems on the weird artifacts in the performance graph.


