### PR TITLE
Fix pip install by correcting package discovery in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 package-dir = { "" = "include" }
 
 [tool.setuptools.packages.find]
-include = ["tritonblas", "tritonblas.internal"]
+where = ["include"]
 
 [project]
 name = "tritonblas"


### PR DESCRIPTION
Changed setuptools.packages.find configuration from 'include' to 'where' to properly discover and package all Python modules. This fixes the issue where pip install would only include the extension module but no Python source files, while editable install worked correctly.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
