### PR TITLE
Fix LDS overflow on MI355 when user specifies num_stages

### DIFF
--- a/include/tritonblas/origami.py
+++ b/include/tritonblas/origami.py
@@ -197,18 +197,21 @@ class OrigamiMatmulSelector:
         # Create Origami problem_t based on problem metadata (needed for fallback)
         self._problem = self._make_problem()
 
-        # Filter configs by Triton LDS capacity (async_copy + num_stages + padding).
-        # Origami's check_lds_capacity uses raw tile size only; Triton allocates
-        # num_stages buffers with padding for bank conflicts.
-        # LDS issues only affect largest tiles; smaller configs should always pass.
+        # Filter configs by Triton LDS capacity.
+        # Keep any tile that fits with at least num_stages=2 (minimum useful
+        # pipelining).  After Origami selects the best tile we clamp
+        # self._num_stages to the maximum that fits, so large tiles like
+        # 256x256x128 are not needlessly excluded when only the requested
+        # num_stages is too high for this hardware's LDS.
         bytes_a = self._a_dtype_bitsize / 8
         bytes_b = self._b_dtype_bitsize / 8
         lds_cap = self._hardware.lds_capacity
+        min_stages = 2  # minimum for software pipelining
         self._configs = [
             c
             for c in self._configs
             if check_triton_lds_capacity(
-                c.mt.m, c.mt.n, c.mt.k, bytes_a, bytes_b, lds_cap, self._num_stages
+                c.mt.m, c.mt.n, c.mt.k, bytes_a, bytes_b, lds_cap, min_stages
             )
         ]
         if not self._configs:
@@ -241,19 +244,19 @@ class OrigamiMatmulSelector:
             self._result.config.mt.n = 256
             self._result.config.mt.k = 64
 
-        # Cap num_stages so the selected tile fits in LDS.
-        # The pre-filter above removes tiles that don't fit at the requested
-        # num_stages, but the 256x256x64 heuristic or future changes could
-        # produce a tile/stages combination that exceeds LDS capacity.
-        # Reduce num_stages until the config fits.
+        # Clamp num_stages to the maximum the selected tile can support.
+        # max_stages = floor(lds_capacity / per_stage_bytes) + 1
+        # where the swizzled LDS formula is:
+        #   (num_stages - 1) * (bm*bk*bpe_a + bk*bn*bpe_b)
         sel_m = self._result.config.mt.m
         sel_n = self._result.config.mt.n
         sel_k = self._result.config.mt.k
-        while (self._num_stages > 1 and
-               not check_triton_lds_capacity(
-                   sel_m, sel_n, sel_k, bytes_a, bytes_b,
-                   lds_cap, self._num_stages)):
-            self._num_stages -= 1
+        per_stage = sel_m * sel_k * bytes_a + sel_k * sel_n * bytes_b
+        if per_stage > 0:
+            max_stages = int(lds_cap // per_stage) + 1
+        else:
+            max_stages = self._num_stages
+        self._num_stages = min(self._num_stages, max(1, max_stages))
 
         if streamk:
             self._grid = self._compute_sk_grid()

--- a/include/tritonblas/origami.py
+++ b/include/tritonblas/origami.py
@@ -236,8 +236,12 @@ class OrigamiMatmulSelector:
             self._problem, self._hardware, self._configs
         )
 
-        # Heuristic to favor 256x256x64 tile when close~
-        if (check_triton_lds_capacity(256, 256, 64, bytes_a, bytes_b, lds_cap, self._num_stages) and
+        # Heuristic to favor 256x256x64 tile when close.
+        # Check LDS capacity at min_stages (not the requested num_stages)
+        # because the post-selection clamping below will adjust num_stages
+        # to fit.  Using the requested value would incorrectly block this
+        # heuristic when num_stages is high but the tile fits after clamping.
+        if (check_triton_lds_capacity(256, 256, 64, bytes_a, bytes_b, lds_cap, min_stages) and
             ((self._result.config.mt.m == 256 and self._result.config.mt.n != 256) or
              (self._result.config.mt.m != 256 and self._result.config.mt.n == 256))):
             self._result.config.mt.m = 256

--- a/include/tritonblas/origami.py
+++ b/include/tritonblas/origami.py
@@ -241,6 +241,20 @@ class OrigamiMatmulSelector:
             self._result.config.mt.n = 256
             self._result.config.mt.k = 64
 
+        # Cap num_stages so the selected tile fits in LDS.
+        # The pre-filter above removes tiles that don't fit at the requested
+        # num_stages, but the 256x256x64 heuristic or future changes could
+        # produce a tile/stages combination that exceeds LDS capacity.
+        # Reduce num_stages until the config fits.
+        sel_m = self._result.config.mt.m
+        sel_n = self._result.config.mt.n
+        sel_k = self._result.config.mt.k
+        while (self._num_stages > 1 and
+               not check_triton_lds_capacity(
+                   sel_m, sel_n, sel_k, bytes_a, bytes_b,
+                   lds_cap, self._num_stages)):
+            self._num_stages -= 1
+
         if streamk:
             self._grid = self._compute_sk_grid()
         else:

--- a/tests/test_lds_estimation.py
+++ b/tests/test_lds_estimation.py
@@ -32,10 +32,10 @@ def _get_hardware():
         return None
     try:
         import origami
-        device_id = torch.cuda.current_device()
-        return origami.get_hardware_for_device(device_id)
-    except Exception:
+    except ImportError:
         return None
+    device_id = torch.cuda.current_device()
+    return origami.get_hardware_for_device(device_id)
 
 
 class TestEstimateTritonLdsBytes:

--- a/tests/test_lds_estimation.py
+++ b/tests/test_lds_estimation.py
@@ -227,6 +227,49 @@ class TestLdsArchitectureDependent:
             f"(LDS={usage}) which exceeds {hardware.lds_capacity} (N_CU={hardware.N_CU})"
         )
 
+    def test_selector_caps_num_stages_when_lds_overflows(self):
+        """num_stages must be capped so the selected tile fits in LDS.
+
+        When num_stages=3 would cause the selected tile to overflow LDS,
+        the selector should reduce num_stages until the config fits.
+        On MI300X (64KB LDS), even num_stages=2 constrains large tiles;
+        on MI355X (160KB LDS), num_stages=3 with 256x256x128 overflows.
+        """
+        hardware = _get_hardware()
+        if hardware is None:
+            pytest.skip("Could not get hardware")
+        from tritonblas import OrigamiMatmulSelector
+        m, n, k = 8192, 8192, 8192
+        dtype = torch.bfloat16
+        device = torch.device(f"cuda:{torch.cuda.current_device()}")
+        selector = OrigamiMatmulSelector(
+            m, n, k, dtype, dtype, dtype, device, num_stages=3
+        )
+        lds_cap = hardware.lds_capacity
+        # The selected config with the (possibly capped) num_stages must fit
+        usage = estimate_triton_lds_bytes(
+            selector.block_m, selector.block_n, selector.block_k,
+            2, 2, selector.num_stages
+        )
+        assert usage <= lds_cap, (
+            f"Selector chose {selector.block_m}x{selector.block_n}x{selector.block_k} "
+            f"ns={selector.num_stages} (LDS={usage}) exceeds capacity={lds_cap}"
+        )
+        # num_stages must have been capped (<=3, possibly reduced)
+        assert selector.num_stages <= 3
+        assert selector.num_stages >= 1
+        # Verify capping was minimal: num_stages+1 should NOT fit (if it was capped)
+        if selector.num_stages < 3:
+            usage_plus1 = estimate_triton_lds_bytes(
+                selector.block_m, selector.block_n, selector.block_k,
+                2, 2, selector.num_stages + 1
+            )
+            assert usage_plus1 > lds_cap, (
+                f"num_stages was reduced to {selector.num_stages} but "
+                f"ns={selector.num_stages + 1} (LDS={usage_plus1}) still fits "
+                f"in {lds_cap} — capping was too aggressive"
+            )
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 class TestLdsVsCompiledKernel:

--- a/tests/test_lds_no_overflow.py
+++ b/tests/test_lds_no_overflow.py
@@ -139,3 +139,60 @@ class TestLdsCheckRejectsOverflow:
         256x256x128 bf16 stages=3 needs 262144 bytes > 163840 (MI355X 160KB).
         """
         assert not check_triton_lds_capacity(256, 256, 128, 2, 2, 163840, 3)
+
+    def test_problematic_config_fits_at_stages_2(self):
+        """256x256x128 bf16 stages=2 should fit in 160KB LDS.
+
+        (2-1) * (256*128*2 + 128*256*2) = 131072 <= 163840.
+        """
+        assert check_triton_lds_capacity(256, 256, 128, 2, 2, 163840, 2)
+
+    def test_max_stages_formula_for_crash_config(self):
+        """max_stages = floor(lds_cap / per_stage) + 1 = floor(163840/131072) + 1 = 2."""
+        per_stage = 256 * 128 * 2 + 128 * 256 * 2  # 131072
+        max_stages = int(163840 // per_stage) + 1
+        assert max_stages == 2, f"Expected max_stages=2, got {max_stages}"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU required")
+class TestClampingWith160KBLDS:
+    """Simulate MI355X 160KB LDS on any GPU to exercise the clamping path.
+
+    The original crash: Origami selects 256x256x128 with stages=3 on MI355X,
+    needing 262KB — far exceeding the 160KB LDS limit. The fix clamps
+    num_stages after tile selection. This test patches hardware.lds_capacity
+    to 160KB to exercise that code path on any available GPU.
+    """
+
+    @pytest.fixture(autouse=True)
+    def patch_lds_capacity(self):
+        """Patch hardware LDS to 160KB for the test, restore afterwards."""
+        import origami
+        device = torch.device(f"cuda:{torch.cuda.current_device()}")
+        hw = origami.get_hardware_for_device(device.index)
+        real_lds = hw.lds_capacity
+        hw.lds_capacity = 163840  # 160KB, same as MI355X
+        yield hw
+        hw.lds_capacity = real_lds
+
+    @pytest.mark.parametrize("num_stages", [2, 3, 4], ids=[f"s{s}" for s in [2, 3, 4]])
+    def test_8192_clamp_at_160kb(self, num_stages, patch_lds_capacity):
+        """8192^3 bf16 at 160KB LDS must never overflow, regardless of stages."""
+        dtype = torch.bfloat16
+        bpe = _bytes_per_elem(dtype)
+        device = torch.device(f"cuda:{torch.cuda.current_device()}")
+
+        sel = OrigamiMatmulSelector(
+            8192, 8192, 8192, dtype, dtype, dtype, device, num_stages=num_stages
+        )
+        usage = estimate_triton_lds_bytes(
+            sel.block_m, sel.block_n, sel.block_k, bpe, bpe, sel.num_stages
+        )
+        assert usage <= 163840, (
+            f"OVERFLOW at 160KB: {sel.block_m}x{sel.block_n}x{sel.block_k} "
+            f"s={sel.num_stages} (requested {num_stages}) uses {usage} > 163840"
+        )
+        # num_stages must be at most the requested value
+        assert sel.num_stages <= num_stages, (
+            f"num_stages increased: requested {num_stages}, got {sel.num_stages}"
+        )

--- a/tests/test_lds_no_overflow.py
+++ b/tests/test_lds_no_overflow.py
@@ -1,0 +1,128 @@
+"""Property test: Origami must NEVER select a tile config that overflows LDS.
+
+For every combination of:
+- GEMM shape (M, N, K) covering small, medium, large, and the problematic 8192^3
+- dtype (fp16, bf16, fp8)
+- num_stages (2, 3, 4)
+- architecture (MI300X 64KB, MI350X 160KB)
+
+...the selected (tile, stages) config must fit in the hardware LDS limit.
+
+This test catches the bug where Origami selects 256x256x128 stages=3 on MI355X
+(needs 262KB, limit is 160KB) and similar overflow cases.
+"""
+
+import itertools
+import pytest
+import torch
+
+from tritonblas.origami import (
+    OrigamiMatmulSelector,
+    estimate_triton_lds_bytes,
+    check_triton_lds_capacity,
+)
+
+
+SHAPES = [
+    (128, 128, 128),
+    (256, 256, 256),
+    (512, 512, 512),
+    (1024, 1024, 1024),
+    (2048, 2048, 2048),
+    (4096, 4096, 4096),
+    (8192, 8192, 8192),
+    (1024, 1024, 8192),
+    (8192, 8192, 1024),
+    (128, 256, 512),
+    (4096, 4096, 8192),
+    (16384, 16384, 4096),
+]
+
+DTYPES = [torch.float16, torch.bfloat16]
+
+NUM_STAGES_VALUES = [2, 3, 4]
+
+LDS_LIMITS = {
+    "MI300X_64KB": 65536,
+    "MI350X_160KB": 163840,
+}
+
+
+def _bytes_per_elem(dtype):
+    return torch.tensor([], dtype=dtype).element_size()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU required")
+class TestOrigamiNeverOverflowsLDS:
+    """Origami must never select a config that exceeds the hardware LDS limit."""
+
+    @pytest.fixture
+    def hardware_lds(self):
+        """Get the actual LDS capacity from the hardware."""
+        try:
+            import origami
+            hw = origami.get_hardware_for_device(torch.cuda.current_device())
+            return hw.lds_capacity
+        except Exception:
+            pytest.skip("origami hardware detection unavailable")
+
+    @pytest.mark.parametrize(
+        "M,N,K",
+        SHAPES,
+        ids=[f"{m}x{n}x{k}" for m, n, k in SHAPES],
+    )
+    @pytest.mark.parametrize("dtype", DTYPES, ids=["fp16", "bf16"])
+    @pytest.mark.parametrize("num_stages", NUM_STAGES_VALUES, ids=[f"s{s}" for s in NUM_STAGES_VALUES])
+    def test_selected_tile_fits_in_lds(self, M, N, K, dtype, num_stages, hardware_lds):
+        """The tile Origami selects must fit in the actual hardware LDS."""
+        bpe = _bytes_per_elem(dtype)
+
+        try:
+            selector = OrigamiMatmulSelector(M, N, K, dtype, dtype, num_stages=num_stages)
+        except Exception:
+            pytest.skip("Origami selector failed to initialize")
+
+        bm = selector._result.config.mt.m
+        bn = selector._result.config.mt.n
+        bk = selector._result.config.mt.k
+
+        actual_lds = estimate_triton_lds_bytes(bm, bn, bk, bpe, bpe, num_stages)
+
+        assert actual_lds <= hardware_lds, (
+            f"Origami selected {bm}x{bn}x{bk} stages={num_stages} for {M}x{N}x{K} {dtype} "
+            f"which needs {actual_lds} bytes LDS, but hardware limit is {hardware_lds} bytes "
+            f"({hardware_lds // 1024} KB). "
+            f"Origami must cap num_stages or reject this tile."
+        )
+
+    @pytest.mark.parametrize("lds_limit_name,lds_limit", LDS_LIMITS.items())
+    @pytest.mark.parametrize(
+        "M,N,K",
+        SHAPES,
+        ids=[f"{m}x{n}x{k}" for m, n, k in SHAPES],
+    )
+    @pytest.mark.parametrize("dtype", DTYPES, ids=["fp16", "bf16"])
+    @pytest.mark.parametrize("num_stages", NUM_STAGES_VALUES, ids=[f"s{s}" for s in NUM_STAGES_VALUES])
+    def test_lds_check_rejects_overflow(self, lds_limit_name, lds_limit, M, N, K, dtype, num_stages):
+        """check_triton_lds_capacity must reject configs that exceed the limit.
+
+        This is a pure formula test — no GPU needed.
+        """
+        bpe = _bytes_per_elem(dtype)
+
+        for bm in [64, 128, 256]:
+            for bn in [64, 128, 256]:
+                for bk in [32, 64, 128, 256]:
+                    lds_needed = estimate_triton_lds_bytes(bm, bn, bk, bpe, bpe, num_stages)
+                    passes_check = check_triton_lds_capacity(bm, bn, bk, bpe, bpe, lds_limit, num_stages)
+
+                    if lds_needed > lds_limit:
+                        assert not passes_check, (
+                            f"check_triton_lds_capacity WRONGLY PASSED {bm}x{bn}x{bk} "
+                            f"stages={num_stages} on {lds_limit_name}: needs {lds_needed} > {lds_limit}"
+                        )
+                    else:
+                        assert passes_check, (
+                            f"check_triton_lds_capacity WRONGLY REJECTED {bm}x{bn}x{bk} "
+                            f"stages={num_stages} on {lds_limit_name}: needs {lds_needed} <= {lds_limit}"
+                        )

--- a/tests/test_lds_no_overflow.py
+++ b/tests/test_lds_no_overflow.py
@@ -2,7 +2,7 @@
 
 For every combination of:
 - GEMM shape (M, N, K) covering small, medium, large, and the problematic 8192^3
-- dtype (fp16, bf16, fp8)
+- dtype (fp16, bf16, and fp8 when available)
 - num_stages (2, 3, 4)
 - architecture (MI300X 64KB, MI350X 160KB)
 
@@ -38,6 +38,11 @@ SHAPES = [
 ]
 
 DTYPES = [torch.float16, torch.bfloat16]
+# Add FP8 coverage when available (requires ROCm with FP8 support)
+if hasattr(torch, "float8_e4m3fnuz"):
+    DTYPES.append(torch.float8_e4m3fnuz)
+elif hasattr(torch, "float8_e4m3fn"):
+    DTYPES.append(torch.float8_e4m3fn)
 
 NUM_STAGES_VALUES = [2, 3, 4]
 
@@ -45,6 +50,16 @@ LDS_LIMITS = {
     "MI300X_64KB": 65536,
     "MI350X_160KB": 163840,
 }
+
+
+_DTYPE_NAMES = {
+    torch.float16: "fp16",
+    torch.bfloat16: "bf16",
+}
+if hasattr(torch, "float8_e4m3fnuz"):
+    _DTYPE_NAMES[torch.float8_e4m3fnuz] = "fp8"
+if hasattr(torch, "float8_e4m3fn"):
+    _DTYPE_NAMES[torch.float8_e4m3fn] = "fp8"
 
 
 def _bytes_per_elem(dtype):
@@ -60,29 +75,26 @@ class TestOrigamiNeverOverflowsLDS:
         """Get the actual LDS capacity from the hardware."""
         try:
             import origami
-            hw = origami.get_hardware_for_device(torch.cuda.current_device())
-            return hw.lds_capacity
-        except Exception:
-            pytest.skip("origami hardware detection unavailable")
+        except ImportError:
+            pytest.skip("origami not installed")
+        hw = origami.get_hardware_for_device(torch.cuda.current_device())
+        return hw.lds_capacity
 
     @pytest.mark.parametrize(
         "M,N,K",
         SHAPES,
         ids=[f"{m}x{n}x{k}" for m, n, k in SHAPES],
     )
-    @pytest.mark.parametrize("dtype", DTYPES, ids=["fp16", "bf16"])
+    @pytest.mark.parametrize("dtype", DTYPES, ids=[_DTYPE_NAMES[d] for d in DTYPES])
     @pytest.mark.parametrize("num_stages", NUM_STAGES_VALUES, ids=[f"s{s}" for s in NUM_STAGES_VALUES])
     def test_selected_tile_fits_in_lds(self, M, N, K, dtype, num_stages, hardware_lds):
         """The tile Origami selects must fit in the actual hardware LDS."""
         bpe = _bytes_per_elem(dtype)
         device = torch.device(f"cuda:{torch.cuda.current_device()}")
 
-        try:
-            selector = OrigamiMatmulSelector(
-                M, N, K, dtype, dtype, dtype, device, num_stages=num_stages
-            )
-        except Exception:
-            pytest.skip("Origami selector failed to initialize")
+        selector = OrigamiMatmulSelector(
+            M, N, K, dtype, dtype, dtype, device, num_stages=num_stages
+        )
 
         bm = selector._result.config.mt.m
         bn = selector._result.config.mt.n
@@ -106,7 +118,7 @@ class TestLdsCheckRejectsOverflow:
     """Pure formula tests — no GPU needed."""
 
     @pytest.mark.parametrize("lds_limit_name,lds_limit", LDS_LIMITS.items())
-    @pytest.mark.parametrize("dtype", DTYPES, ids=["fp16", "bf16"])
+    @pytest.mark.parametrize("dtype", DTYPES, ids=[_DTYPE_NAMES[d] for d in DTYPES])
     @pytest.mark.parametrize("num_stages", NUM_STAGES_VALUES, ids=[f"s{s}" for s in NUM_STAGES_VALUES])
     def test_lds_check_consistent_with_estimate(self, lds_limit_name, lds_limit, dtype, num_stages):
         """check_triton_lds_capacity must agree with estimate_triton_lds_bytes.

--- a/tests/test_lds_no_overflow.py
+++ b/tests/test_lds_no_overflow.py
@@ -12,7 +12,6 @@ This test catches the bug where Origami selects 256x256x128 stages=3 on MI355X
 (needs 262KB, limit is 160KB) and similar overflow cases.
 """
 
-import itertools
 import pytest
 import torch
 
@@ -76,37 +75,44 @@ class TestOrigamiNeverOverflowsLDS:
     def test_selected_tile_fits_in_lds(self, M, N, K, dtype, num_stages, hardware_lds):
         """The tile Origami selects must fit in the actual hardware LDS."""
         bpe = _bytes_per_elem(dtype)
+        device = torch.device(f"cuda:{torch.cuda.current_device()}")
 
         try:
-            selector = OrigamiMatmulSelector(M, N, K, dtype, dtype, num_stages=num_stages)
+            selector = OrigamiMatmulSelector(
+                M, N, K, dtype, dtype, dtype, device, num_stages=num_stages
+            )
         except Exception:
             pytest.skip("Origami selector failed to initialize")
 
         bm = selector._result.config.mt.m
         bn = selector._result.config.mt.n
         bk = selector._result.config.mt.k
+        # Use the clamped num_stages, not the requested value — the selector
+        # may have reduced it to fit within the hardware LDS budget.
+        clamped_stages = selector.num_stages
 
-        actual_lds = estimate_triton_lds_bytes(bm, bn, bk, bpe, bpe, num_stages)
+        actual_lds = estimate_triton_lds_bytes(bm, bn, bk, bpe, bpe, clamped_stages)
 
         assert actual_lds <= hardware_lds, (
-            f"Origami selected {bm}x{bn}x{bk} stages={num_stages} for {M}x{N}x{K} {dtype} "
+            f"Origami selected {bm}x{bn}x{bk} stages={clamped_stages} "
+            f"(requested {num_stages}) for {M}x{N}x{K} {dtype} "
             f"which needs {actual_lds} bytes LDS, but hardware limit is {hardware_lds} bytes "
             f"({hardware_lds // 1024} KB). "
             f"Origami must cap num_stages or reject this tile."
         )
 
+
+class TestLdsCheckRejectsOverflow:
+    """Pure formula tests — no GPU needed."""
+
     @pytest.mark.parametrize("lds_limit_name,lds_limit", LDS_LIMITS.items())
-    @pytest.mark.parametrize(
-        "M,N,K",
-        SHAPES,
-        ids=[f"{m}x{n}x{k}" for m, n, k in SHAPES],
-    )
     @pytest.mark.parametrize("dtype", DTYPES, ids=["fp16", "bf16"])
     @pytest.mark.parametrize("num_stages", NUM_STAGES_VALUES, ids=[f"s{s}" for s in NUM_STAGES_VALUES])
-    def test_lds_check_rejects_overflow(self, lds_limit_name, lds_limit, M, N, K, dtype, num_stages):
-        """check_triton_lds_capacity must reject configs that exceed the limit.
+    def test_lds_check_consistent_with_estimate(self, lds_limit_name, lds_limit, dtype, num_stages):
+        """check_triton_lds_capacity must agree with estimate_triton_lds_bytes.
 
-        This is a pure formula test — no GPU needed.
+        For every (tile, stages, lds_limit) combination, check_triton_lds_capacity
+        must return True iff estimate_triton_lds_bytes <= lds_limit.
         """
         bpe = _bytes_per_elem(dtype)
 
@@ -126,3 +132,10 @@ class TestOrigamiNeverOverflowsLDS:
                             f"check_triton_lds_capacity WRONGLY REJECTED {bm}x{bn}x{bk} "
                             f"stages={num_stages} on {lds_limit_name}: needs {lds_needed} <= {lds_limit}"
                         )
+
+    def test_problematic_config_rejected(self):
+        """The specific config that caused the MI355X crash must be rejected.
+
+        256x256x128 bf16 stages=3 needs 262144 bytes > 163840 (MI355X 160KB).
+        """
+        assert not check_triton_lds_capacity(256, 256, 128, 2, 2, 163840, 3)


### PR DESCRIPTION
## Summary

Fix LDS (Local Data Share) overflow on MI355X by changing the Origami tile selection filter to use `min_stages=2` instead of the requested `num_stages`, and clamping `num_stages` after tile selection to the maximum that fits in hardware LDS. This prevents crashes for large tiles like 256x256x128 on MI355X (160KB LDS) where `num_stages=3` requires 262KB.

## Problem

On MI355X (gfx950, 160KB LDS per CU), requesting `num_stages=3` for large GEMM shapes (e.g. 8192x8192x8192) caused an LDS overflow crash. Origami selected high-performance tiles like 256x256x128 that could physically fit with 2 stages but not with 3, and the kernel launched with the original `num_stages=3`, exceeding the 160KB LDS limit.

The crash manifested as a HIP runtime error during kernel launch with no clear indication that LDS was the constraint.

## Root Cause

The LDS capacity filter in `OrigamiMatmulSelector.__init__` used the user-requested `num_stages` to filter candidate tiles:

```python
check_triton_lds_capacity(m, n, k, bytes_a, bytes_b, lds_cap, self._num_stages)
```

This was too aggressive: it excluded tiles that could deliver excellent performance at a lower stage count. For example, 256x256x128 with bf16 needs:
- `num_stages=2`: 131,072 bytes (fits in MI355X 160KB)
- `num_stages=3`: 262,144 bytes (overflows MI355X 160KB)

The filter rejected the 256x256x128 tile entirely when `num_stages=3` was requested, even though it could work with 2 stages. Worse, post-selection heuristics (like the 256x256x64 override) could produce tile/stages combinations that bypassed the filter entirely.

## Fix

**Two-part fix in `origami.py`**:

1. **Pre-selection filter**: Changed from filtering at the requested `num_stages` to filtering at `min_stages=2` (the minimum for useful software pipelining). This keeps high-performance large tiles in the candidate set even when the requested stage count would overflow.

2. **Post-selection clamp**: After Origami selects the optimal tile, compute the maximum stages that fit:
   ```
   max_stages = floor(lds_capacity / per_stage_bytes) + 1
   ```
   Then clamp: `num_stages = min(requested, max(1, max_stages))`. This replaces an earlier iterative while-loop approach with a direct formula (single division, no loop).

**Tests added**:
- `test_lds_estimation.py`: Added `test_selector_caps_num_stages_when_lds_overflows` verifying that the selector reduces `num_stages` when needed and that the capping is minimal (num_stages+1 would overflow).
- `test_lds_no_overflow.py` (new file): Parametric property test covering 12 shapes x 2 dtypes x 3 stage counts, asserting that the selected tile always fits in hardware LDS. Also includes a pure-formula test verifying `check_triton_lds_capacity` consistency against `estimate_triton_lds_bytes` across all tile/stage combinations.

## Testing

- 8192x8192x8192 bf16 `num_stages=3` on MI355X (160KB LDS): selector now picks 256x256x128 with `num_stages=2` (clamped from 3), fits in 131KB
- All 72 parametric test cases pass (12 shapes x 2 dtypes x 3 stage counts)
- Formula consistency verified across 36 tile configurations x 2 LDS limits (MI300X 64KB, MI350X 160KB)
- No regressions on MI300X (64KB LDS) -- smaller tiles are unaffected by the clamp

## Files Changed

- `include/tritonblas/origami.py` -- Changed LDS filter from `self._num_stages` to `min_stages=2`; added post-selection `num_stages` clamping via `max_stages = floor(lds_cap / per_stage_bytes) + 1`; updated comments explaining the two-phase approach
- `tests/test_lds_estimation.py` -- Added `test_selector_caps_num_stages_when_lds_overflows` test case verifying capping behavior and minimality
- `tests/test_lds_no_overflow.py` -- New file: parametric property test ensuring Origami never selects a tile that overflows LDS, covering 12 shapes, 2 dtypes, 3 stage counts, and 2 architecture LDS limits
