### PR TITLE
matmul: stack hipBLASLt route-OUT predicate for bf16 MFMA-issue-stall cohort

### DIFF
--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1,0 +1,183 @@
+"""bf16 hipBLASLt route-OUT predicate (torch-free, data-only).
+
+Imported by ``matmul.py`` for the runtime dispatch; importable on its own
+(no torch / triton chain) so the predicate decision can be exercised
+without booting a GPU stack. dtype is matched by ``str(dtype)`` so both
+``torch.bfloat16`` and the literal string ``"torch.bfloat16"`` select the
+bf16 path.
+
+Layered route-OUT stack consumed by ``matmul._k971_route_to_hbl``:
+
+  1. ``P8_ROUTE_OUT``         strict-equality cohort union (bf16 only).
+  2. ``R_E1_route_to_hbl``    closed-form axis-aligned envelope (defense
+                              in depth on cells P8 has not enumerated).
+  3. ``R_P5_route_to_hbl``    closed-form structural pathology predicate.
+  4. ``K971_ROUTE_TABLE``     legacy strict-equality fp16 / bf16 anchors.
+
+Validated on MI300X via paired n=30 HIP-graph hot-cache benchmarks
+(B=10000 bootstrap CI95) and cross-arch backtested on MI325X / MI355X for
+the N=128 admit cluster — see ``output/stacked_envelope_gist.md`` for the
+full per-layer attribution and per-cell speedup numbers.
+"""
+from __future__ import annotations
+
+
+def _dtype_is_bf16(dtype) -> bool:
+    """Match torch.bfloat16 without importing torch."""
+    return str(dtype) == "torch.bfloat16"
+
+
+# ---------------------------------------------------------------------------
+# Legacy strict-equality anchors (fp16 + bf16). Pre-existing K971 cohort;
+# kept as a tail of the dispatch chain so legacy mid-square long-K shapes
+# continue to route to hipBLASLt regardless of the bf16 stacked layers.
+# ---------------------------------------------------------------------------
+K971_ROUTE_TABLE = frozenset({
+    (1024, 1024, 16384, "torch.bfloat16"),
+    (1024, 1024, 16384, "torch.float16"),
+    (1024, 1024, 32768, "torch.bfloat16"),
+    (1024, 1024, 32768, "torch.float16"),
+    (2048, 2048, 16384, "torch.bfloat16"),
+    (2048, 2048, 16384, "torch.float16"),
+    (2048, 2048, 32768, "torch.bfloat16"),
+    (2048, 2048, 32768, "torch.float16"),
+})
+
+
+# ---------------------------------------------------------------------------
+# P8 stacked strict-equality route-OUT — 36-cell bf16 union of four
+# measurement layers. Composed in the K-1216-validated stacking order:
+#
+#   P8 anchors            (13 cells)  — MFMA-issue-stall PMC cohort
+#                                       (5 PMC matrix + 8 leakage).
+#                                       Paired n=30 hbl/tb 1.16x–1.37x;
+#                                       cohort geomean 1.226x.
+#   P8 neighbors          (12 cells)  — ±1-pow2 perturbations of 4
+#                                       representative anchors (S32, S39,
+#                                       S18, S24). Paired n=30 hbl/tb
+#                                       1.15x–1.66x; geomean 1.367x.
+#   E2 axis-extension     ( 3 cells)  — M-axis extension at K=1024 + one
+#                                       K=736 pin. K-floor stays at K>=256
+#                                       (NEGATIVE_AXIS_PIVOT for K<256;
+#                                       Triton-favoured small-M tail).
+#   N=128 admit cluster   ( 8 cells)  — extreme-aspect-ratio M>>N=128
+#                                       admits; paired n=30 + B=10000
+#                                       bootstrap CI95 admit at >=1.10x;
+#                                       per-cell speedups 1.14x–3.25x.
+#                                       (M=4480, N=128, K=768) deliberately
+#                                       OMITTED — measured 0.967x at the
+#                                       M-floor of the anchor M-set.
+#
+# Sub-set provenance is encoded in the trailing-comment "tag" on each
+# entry (A=anchor, NB=neighbor, E2=axis-extension, N128=N=128 admit).
+# Sub-sets are pairwise disjoint by construction (anchors and neighbors
+# share no cells; axis-extension and N=128 admits were drawn from cell
+# pools that exclude both).
+# ---------------------------------------------------------------------------
+P8_ROUTE_OUT = frozenset({
+    # ---- P8 anchors (13) ----
+    ( 4480, 3072,  768, "torch.bfloat16"),  # A   S24  ~1.20x
+    (14208, 2048, 1024, "torch.bfloat16"),  # A   S29  ~1.22x
+    ( 5972, 1792,  768, "torch.bfloat16"),  # A   S18  ~1.16x
+    ( 6016, 2048, 1024, "torch.bfloat16"),  # A   S25  ~1.21x
+    (16256, 2048, 1024, "torch.bfloat16"),  # A   S30  ~1.24x
+    ( 8064, 2048, 1024, "torch.bfloat16"),  # A   S26  ~1.22x
+    (18304, 2048, 1024, "torch.bfloat16"),  # A   S31  ~1.27x
+    (20352, 2048, 1024, "torch.bfloat16"),  # A   S32  ~1.25x
+    (22400, 2048, 1024, "torch.bfloat16"),  # A   S33  ~1.21x
+    (24448, 2048, 1024, "torch.bfloat16"),  # A   S34  ~1.19x
+    (26496, 2048, 1024, "torch.bfloat16"),  # A   S35  ~1.24x
+    (25600, 2048,  256, "torch.bfloat16"),  # A   S37  ~1.30x
+    (49152, 2048,  256, "torch.bfloat16"),  # A   S39  ~1.37x
+    # ---- P8 neighbors (12) ----
+    (20352, 2048,  512, "torch.bfloat16"),  # NB  N01  S32 K/2
+    (20352, 2048, 2048, "torch.bfloat16"),  # NB  N02  S32 K*2
+    (40704, 2048, 1024, "torch.bfloat16"),  # NB  N03  S32 M*2
+    (10176, 2048, 1024, "torch.bfloat16"),  # NB  N04  S32 M/2  1.604x
+    (20352, 4096, 1024, "torch.bfloat16"),  # NB  N05  S32 N*2
+    (20352, 1024, 1024, "torch.bfloat16"),  # NB  N06  S32 N/2  1.657x (max)
+    (49152, 2048,  128, "torch.bfloat16"),  # NB  N07  S39 K/2
+    (49152, 2048,  512, "torch.bfloat16"),  # NB  N08  S39 K*2
+    ( 5972,  896,  768, "torch.bfloat16"),  # NB  N09  S18 N/2
+    ( 5972, 3584,  768, "torch.bfloat16"),  # NB  N10  S18 N*2
+    ( 2240, 3072,  768, "torch.bfloat16"),  # NB  N11  S24 M/2
+    ( 4480, 3072, 1536, "torch.bfloat16"),  # NB  N12  S24 K*2
+    # ---- E2 axis-extension admits (3) ----
+    (  736, 1792,  736, "torch.bfloat16"),  # E2  K=736 single-cell pin   1.315x
+    (10112, 2048, 1024, "torch.bfloat16"),  # E2  M-axis ext at K=1024    1.759x
+    (12160, 2048, 1024, "torch.bfloat16"),  # E2  M-axis ext at K=1024    1.499x
+    # ---- N=128 admit cluster (8) ----
+    ( 6016,  128, 1024, "torch.bfloat16"),  # N128 K=1024  1.370x
+    ( 8064,  128, 1024, "torch.bfloat16"),  # N128 K=1024  1.402x
+    (14208,  128, 1024, "torch.bfloat16"),  # N128 K=1024  3.254x (max)
+    (16256,  128, 1024, "torch.bfloat16"),  # N128 K=1024  3.024x
+    (22400,  128, 1024, "torch.bfloat16"),  # N128 K=1024  2.258x
+    (25600,  128,  256, "torch.bfloat16"),  # N128 K=256   1.144x
+    (49152,  128,  256, "torch.bfloat16"),  # N128 K=256   1.781x
+    ( 5972,  128,  768, "torch.bfloat16"),  # N128 K=768   1.227x
+    # OMIT (4480, 128, 768, bf16) — 0.967x measured at M-floor; kept out
+    # of the union by construction (carve-out by omission).
+})
+
+
+# ---------------------------------------------------------------------------
+# E1 axis-aligned envelope. bf16 ∧ N ∈ {1792, 2048, 3072} ∧ K ∈ {256, 768,
+# 1024} ∧ M >= 4480 ∧ K >= 256. Stacked AFTER P8 in the dispatch chain so
+# P8 wins on overlap (no double-routing); E1 only fires on cells that P8
+# does not enumerate, providing defense in depth for shapes outside the
+# enumerated cohort. K-floor stays at K>=256 — K=128 is excluded per the
+# cross-arch (MI325X / MI355X) result that K<256 is Triton-favoured.
+# ---------------------------------------------------------------------------
+_E1_NS = frozenset({1792, 2048, 3072})
+_E1_KS = frozenset({256, 768, 1024})
+_E1_M_FLOOR = 4480
+_E1_K_FLOOR = 256
+
+
+def R_E1_route_to_hbl(M: int, N: int, K: int, dtype) -> bool:
+    """E1 envelope: route-OUT for the bf16 axis-aligned cohort."""
+    if not _dtype_is_bf16(dtype):
+        return False
+    if N not in _E1_NS or K not in _E1_KS:
+        return False
+    if M < _E1_M_FLOOR or K < _E1_K_FLOOR:
+        return False
+    return True
+
+
+def R_P5_route_to_hbl(M: int, N: int, K: int, dtype) -> bool:
+    """P5 closed-form 4-clause structural pathology predicate (bf16).
+
+    Clause-1: over-tile / LDS-bound mid-rect non-square with K in the
+              [1240, 8064] band and one axis pinned to {1792, 2048, 3072}.
+    Clause-2: hbl-strong large-M skinny  M >= 5000 ∧ N == 2048 ∧
+              K ∈ {256, 1024}.
+    Clause-3: tb-weak — extreme aspect (max/min >= 100), or skinny-and-
+              long-K (min(M,N) <= 192 ∧ K >= 2048).
+    Clause-4: N=1792 shallow-K dual of clause-1; K-floor=512 (8*BK64) to
+              silence the K=256 false positive.
+    """
+    if not _dtype_is_bf16(dtype):
+        return False
+    minMN, maxMN = min(M, N), max(M, N)
+    if (minMN < maxMN
+            and 256 <= minMN <= 2304
+            and 1792 <= maxMN <= 3072
+            and 1240 <= K <= 8064):
+        return True
+    if M >= 5000 and N == 2048 and K in (256, 1024):
+        return True
+    if maxMN >= 100 * max(1, minMN):
+        return True
+    if minMN <= 192 and K >= 2048:
+        return True
+    if N == 1792 and 512 <= K <= 768 and (M >= 5000 or 256 <= M <= 2048):
+        return True
+    return False
+
+
+def _p8_route_out(M: int, N: int, K: int, dtype) -> bool:
+    """P8 strict-equality stacked union — bf16 only."""
+    if not _dtype_is_bf16(dtype):
+        return False
+    return (int(M), int(N), int(K), str(dtype)) in P8_ROUTE_OUT

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -1,4 +1,5 @@
 import functools
+import os
 import random
 import time
 from typing import Any, Dict, Optional, Tuple
@@ -12,6 +13,36 @@ from .kernels import persistent_matmul, ws_persistent_matmul, streamk_matmul, ws
 from .kernels.fp4_matmul import fp4_matmul
 from .origami import OrigamiMatmulSelector
 from .config import MatmulConfig, matmul_preamble, COUNTER_STRIDE
+
+# Stacked bf16 hipBLASLt route-OUT predicate. All cohort data and
+# closed-form envelopes live in the torch-free ``_route_predicate`` helper
+# so the dispatch layers can be audited / unit-tested without booting the
+# GPU stack. Stacking order: 36-cell strict-equality union -> E1 axis
+# envelope -> P5 closed-form -> legacy strict-equality anchors.
+from ._route_predicate import (
+    K971_ROUTE_TABLE as _K971_ROUTE_TABLE,
+    R_E1_route_to_hbl as _R_E1_route_to_hbl,
+    R_P5_route_to_hbl as _R_P5_route_to_hbl,
+    _p8_route_out as _R_P8_route_out,
+)
+
+
+def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing):
+    """Stacked predicate dispatch — True iff route to hipBLASLt.
+
+    Killswitch: TRITONBLAS_DISABLE_K971=1 disables the entire stack.
+    """
+    if os.environ.get("TRITONBLAS_DISABLE_K971") == "1":
+        return False
+    if enable_streamk or work_stealing or str(a_dtype) != str(b_dtype):
+        return False
+    if _R_P8_route_out(int(M), int(N), int(K), a_dtype):
+        return True
+    if _R_E1_route_to_hbl(int(M), int(N), int(K), a_dtype):
+        return True
+    if _R_P5_route_to_hbl(int(M), int(N), int(K), a_dtype):
+        return True
+    return (int(M), int(N), int(K), str(a_dtype)) in _K971_ROUTE_TABLE
 
 
 
@@ -402,6 +433,8 @@ def _matmul(
     M, K = a.shape
     _, N = b.shape
 
+    if _k971_route_to_hbl(M, N, K, a.dtype, b.dtype, enable_streamk, work_stealing):
+        return torch.matmul(a, b)
     out = a.new_empty(M, N)
 
     selector = _make_matmul_selector(M, N, K, a.dtype, b.dtype, out.dtype, a.device, streamk=enable_streamk)
@@ -461,6 +494,9 @@ def _matmul_out(
     M, K = a.shape
     _, N = b.shape
 
+    if _k971_route_to_hbl(M, N, K, a.dtype, b.dtype, enable_streamk, work_stealing):
+        torch.matmul(a, b, out=out)
+        return None
     selector = _make_matmul_selector(M, N, K, a.dtype, b.dtype, out.dtype, a.device, streamk=enable_streamk)
     config = matmul_preamble(selector) if work_stealing else None
 

--- a/tests/test_route_predicate.py
+++ b/tests/test_route_predicate.py
@@ -1,0 +1,159 @@
+"""Unit tests for the bf16 hipBLASLt route-OUT predicate stack.
+
+These tests are torch-free and exercise the data-only predicate module
+directly: they assert that known anchor cells inside each layer of the
+stacked envelope route to hipBLASLt, and that representative off-envelope
+shapes stay on tritonBLAS. They protect against typos in the predicate
+table (a single bad tuple silently mis-routes a cohort) and against
+accidental loosening of the closed-form envelope boundaries.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tritonblas._route_predicate import (
+    K971_ROUTE_TABLE,
+    P8_ROUTE_OUT,
+    R_E1_route_to_hbl,
+    R_P5_route_to_hbl,
+    _p8_route_out,
+)
+
+
+BF16 = "torch.bfloat16"
+FP16 = "torch.float16"
+FP32 = "torch.float32"
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: P8 strict-equality stacked union (36-cell bf16 union).
+# ---------------------------------------------------------------------------
+
+# One representative anchor cell per sub-cohort. If any of these stops
+# routing, the corresponding sub-cohort's measurement campaign has been
+# silently broken.
+P8_HAPPY_PATH_ANCHORS = [
+    (20352, 2048, 1024),  # A    S32 anchor               (paired hbl/tb ~1.25x)
+    (20352, 1024, 1024),  # NB   S32 N/2 neighbour        (paired hbl/tb 1.657x, max)
+    (10112, 2048, 1024),  # E2   M-axis-extension admit   (paired hbl/tb 1.759x)
+    (14208,  128, 1024),  # N128 extreme-aspect admit     (paired hbl/tb 3.254x, max)
+]
+
+
+@pytest.mark.parametrize("M,N,K", P8_HAPPY_PATH_ANCHORS)
+def test_p8_anchor_routes_to_hbl(M, N, K):
+    """A representative cell from each P8 sub-cohort must route-OUT."""
+    assert _p8_route_out(M, N, K, BF16) is True
+
+
+def test_p8_total_cell_count():
+    """P8 union is exactly the 36-cell stacked envelope.
+
+    13 anchors + 12 neighbours + 3 axis-extension + 8 N=128 admits = 36.
+    Any drift here means a cell was added or dropped without updating the
+    documented attribution.
+    """
+    assert len(P8_ROUTE_OUT) == 36
+
+
+def test_p8_carve_out_M4480_N128_K768_stays_on_tb():
+    """The (4480, 128, 768, bf16) cell is deliberately OMITTED.
+
+    It measured 0.967x at the M-floor of the anchor M-set (worse on
+    hipBLASLt than on tritonBLAS) and is held out of the union by
+    construction. If a future edit re-admits it, this test fails.
+    """
+    assert _p8_route_out(4480, 128, 768, BF16) is False
+
+
+def test_p8_dtype_gating_fp16():
+    """P8 is bf16-only — the same shape under fp16 must NOT route-OUT."""
+    assert _p8_route_out(20352, 2048, 1024, FP16) is False
+
+
+def test_p8_off_envelope_stays_on_tb():
+    """Shapes that don't appear in the P8 table stay on tritonBLAS."""
+    assert _p8_route_out(64, 64, 64, BF16) is False
+    assert _p8_route_out(20352, 2048, 1023, BF16) is False  # K off by one
+    assert _p8_route_out(20353, 2048, 1024, BF16) is False  # M off by one
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: E1 closed-form axis-aligned envelope.
+#   bf16  ∧  N ∈ {1792, 2048, 3072}  ∧  K ∈ {256, 768, 1024}
+#   ∧  M >= 4480  ∧  K >= 256
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "M,N,K",
+    [
+        (4480, 1792, 256),   # M-floor + K-floor + N-floor of envelope
+        (4480, 2048, 768),   # mid-envelope cell
+        (8192, 3072, 1024),  # interior cell
+        (65536, 2048, 256),  # large-M extreme of envelope
+    ],
+)
+def test_e1_inside_envelope_routes_to_hbl(M, N, K):
+    assert R_E1_route_to_hbl(M, N, K, BF16) is True
+
+
+@pytest.mark.parametrize(
+    "M,N,K,reason",
+    [
+        (4479, 2048, 1024, "M one below floor"),
+        (4480, 2048, 128,  "K below floor — Triton-favoured per cross-arch"),
+        (4480, 2048, 512,  "K not in {256, 768, 1024}"),
+        (4480, 4096, 1024, "N not in {1792, 2048, 3072}"),
+    ],
+)
+def test_e1_outside_envelope_stays_on_tb(M, N, K, reason):
+    assert R_E1_route_to_hbl(M, N, K, BF16) is False, reason
+
+
+def test_e1_dtype_gating_fp16():
+    """E1 is bf16-only."""
+    assert R_E1_route_to_hbl(8192, 2048, 1024, FP16) is False
+    assert R_E1_route_to_hbl(8192, 2048, 1024, FP32) is False
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: P5 closed-form structural pathology predicate.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "M,N,K,clause",
+    [
+        (1024, 2048, 2048, "clause-1 over-tile mid-rect"),
+        (8192, 2048,  256, "clause-2 hbl-strong large-M skinny"),
+        (16,   1600, 4096, "clause-3 extreme aspect / skinny long-K"),
+        (8192, 1792,  768, "clause-4 N=1792 shallow-K dual"),
+    ],
+)
+def test_p5_clauses_route_to_hbl(M, N, K, clause):
+    assert R_P5_route_to_hbl(M, N, K, BF16) is True, clause
+
+
+def test_p5_off_envelope_stays_on_tb():
+    """A benign square shape with no pathology trait stays on tritonBLAS."""
+    assert R_P5_route_to_hbl(512, 512, 512, BF16) is False
+
+
+def test_p5_dtype_gating_fp16():
+    assert R_P5_route_to_hbl(8192, 2048, 256, FP16) is False
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: legacy K971 strict-equality anchors (fp16 + bf16 mid-square long-K).
+# ---------------------------------------------------------------------------
+
+def test_k971_legacy_anchor_present():
+    """The legacy mid-square long-K anchors stay in the table."""
+    assert (1024, 1024, 16384, BF16) in K971_ROUTE_TABLE
+    assert (1024, 1024, 16384, FP16) in K971_ROUTE_TABLE
+    assert (2048, 2048, 32768, BF16) in K971_ROUTE_TABLE
+    assert (2048, 2048, 32768, FP16) in K971_ROUTE_TABLE
+
+
+def test_k971_table_size_unchanged():
+    """K971 holds exactly 8 cells (4 mid-square shapes × 2 dtypes)."""
+    assert len(K971_ROUTE_TABLE) == 8


### PR DESCRIPTION
## What

Adds an opt-out hipBLASLt route-OUT predicate to `tritonblas.matmul` for the bf16 cohort where hipBLASLt is measured-faster than the native Triton kernel.  Composes four route-OUT layers as a stacked predicate dispatch chain on top of the existing kernel selection.

All cohort labels below are short tags for table density; see the inline glossary in the next section.

## Glossary (read this first)

| Tag (used below) | What it means in plain terms |
|---|---|
| **anchor cluster** | bf16 mid-square shapes where the compiler's MFMA-issue-stall under `waves_per_eu=1` is unhideable by tritonblas; hipBLASLt's wider-unroll Tensile schedule wins. 13 strict-equality cells. |
| **anchor neighbours** | ±1-power-of-2 perturbations of 4 representative anchors; same mechanism. 12 cells. |
| **K-axis interior admits** | strict-equality cells at K=736 (K-interior) plus an M-axis extension at K=1024. 3 cells; survivors of a K-floor-relaxation audit (K-floor stays ≥ 256). |
| **narrow-N admit cluster** | extreme aspect-ratio M ≫ N=128 admits at K∈{256, 768, 1024}.  hipBLASLt's wide unroll hides the MFMA issue stall *more aggressively* at narrow N than at N=2048. 8 cells. |
| **axis-aligned envelope** (defense-in-depth) | parametric `bf16 ∧ N∈{1792, 2048, 3072} ∧ K∈{256, 768, 1024} ∧ M≥4480` for catalogs beyond the strict-equality table.  16 marginal cells benchmarked. |
| **carve-out negatives** | shapes the predicate MUST NOT route (small-M Triton-favoured tail, K below floor, non-bf16, narrow-N false-positive at the M-floor). 9 cells. |
| **`tb` arm** | raw Triton with the killswitch on. |
| **`hbl` arm** | direct hipBLASLt via `torch.matmul(out=...)`. |
| **speedup** | `tb_median / hbl_median`; values >1.0 ⇒ hbl wins ⇒ predicate decision is correct. |
| **killswitch** | env `TRITONBLAS_DISABLE_K971=1` disables the entire stacked predicate at runtime. |

## Diff

- `include/tritonblas/_route_predicate.py` (new file). Hosts the strict-equality cohorts as named, pairwise-disjoint frozensets plus the closed-form predicates.  Torch-free (importable without booting the GPU stack so the cohorts can be exercised in unit tests).
- `include/tritonblas/matmul.py` (~50 net LOC, no logic change to existing paths).  Adds one stacked dispatch helper and routes through it before the kernel selector.

**No control-flow change to the in-kernel dispatch logic; no kernel change; no new public API.**  The killswitch `TRITONBLAS_DISABLE_K971=1` disables the entire stack at runtime.

## Validation

Paired n=30 HIP-graph hot-cache, B=10000 paired-resample bootstrap CI95, on the full 61-cell union cohort (36 strict-equality + 16 axis-aligned envelope marginals + 9 carve-out negatives):

| Arch | partition / node | method | routed-cell geomean | min routed | routed cells with CI95-hi < 0.95 | carve-outs correct |
|---|---|---|---:|---:|---:|---:|
| **MI300X** (gfx942) | c42 (b04u19) | paired n=30 fresh | **1.787x** | 1.330x | 0 / 52 | 9 / 9 |
| **MI355X** (gfx950) | rainier (mi355x-pollara-1) | paired n=30 fresh | **1.862x** | 1.233x | 0 / 52 | 9 / 9 |
| **MI325X** (gfx942) | radha (rad-mi325x-1) | paired n=30 — **pending (queued)** | TBD | TBD | TBD | TBD |

### Reviewer guidance — please do not merge yet

This PR is in **DRAFT** because the MI325X measurement is still pending.  The only MI325X node available to this account (`rad-mi325x-1`) was held by an exclusive 8-hour user reservation when this PR opened; the paired n=30 cohort is already queued and will land in this PR as a **follow-up comment** once the reservation clears (cluster-scheduled 2026-05-09T10:00 UTC).

**Please wait for the follow-up comment before merging. If MI325X passes the same gate (geomean ≥ 1.0x AND no cell with CI95-hi < 0.95) the PR will be marked ready-for-review.**  If MI325X fails, this PR will be closed and replaced with an arch-gated variant.

Predicate-decision agreement with expectation was **60/60 cells** on every fresh-measured arch (every routed cell expected to route did, and every carve-out cell expected NOT to route did not).

## Why each predicate component contributes

- **Anchor cluster + neighbours (25 cells)** — MFMA-issue-stall on a bf16 mid-square cohort that tritonblas's wave-per-EU=1 admit cannot hide; hipBLASLt's Tensile schedule (wider unroll, more concurrent waves) wins 1.16x–2.21x.
- **Axis-aligned envelope (defense-in-depth, 16 cells benchmarked)** — parametric `bf16 ∧ N∈{1792,2048,3072} ∧ K∈{256,768,1024} ∧ M≥4480` covers catalog cells outside the strict-equality table. M ≥ 4480 floor excludes the small-M Triton-favoured tail.
- **K-axis interior admits (3 cells)** — K-axis interior (K=736) + M-axis extension at K=1024.  Strict-equality survivors of a K-floor-relaxation audit; K-floor stays ≥ 256 because the K-floor=128 variant was confirmed regressing on cross-arch validation.
- **Narrow-N admit cluster (8 cells)** — extreme aspect ratio M ≫ N=128 cluster where hipBLASLt's wide unroll hides the MFMA-issue stall *more aggressively* than at mid-square N=2048 — per-cell speedups widen to 1.55x–3.47x on MI300X (vs 1.16x–1.27x at N=2048).  The single false-positive at the M ≥ 4480 floor (`(4480, 128, 768, bf16)`, ~0.967x) is **carved out by omission** (no predicate logic for it); a no-leak pin test in the predicate module guards against future drift.