### PR TITLE
matmul: K-1397 productionize P13 skinny_N256 K-COMPLEMENT route-OUT (73 -> 85)

### DIFF
--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -938,7 +938,7 @@ def _k1361_p12_square_mid_routeout(M: int, N: int, K: int, dtype) -> bool:
 # K-1367 (S-002) — P13 `skinny_N128` K-COMPLEMENT route-OUT (7th-position).
 #
 # K-1379 productionises the K-1367 RETRY-winning 18-cell cohort as
-# `_K1367_P13_SKINNY_N128_ROUTEOUT_18`, layered as the
+# `_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18`, layered as the
 # 7th-position envelope in the dispatch precedence chain on top of the
 # K-1361 P12 55-cell baseline (envelope grows 55 → 73 cells; +18 admits).
 #
@@ -1005,7 +1005,7 @@ def _k1361_p12_square_mid_routeout(M: int, N: int, K: int, dtype) -> bool:
 #   * K-1361 P12 — uses M=N=K ∈ {2048, 4096} with N != 128; no collision.
 # All asserted at module load.
 # ---------------------------------------------------------------------------
-_K1367_P13_SKINNY_N128_ROUTEOUT_18 = frozenset({
+_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 = frozenset({
     # M=2048 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
     (2048, 128,  4096, "torch.bfloat16"),
     (2048, 128,  4096, "torch.float16"),
@@ -1028,14 +1028,14 @@ _K1367_P13_SKINNY_N128_ROUTEOUT_18 = frozenset({
     (8192, 128, 16384, "torch.bfloat16"),
     (8192, 128, 16384, "torch.float16"),
 })
-assert len(_K1367_P13_SKINNY_N128_ROUTEOUT_18) == 18, (
+assert len(_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18) == 18, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT frozenset must be exactly 18 cells "
     "(M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,8192,16384} × {bf16,fp16}); "
     "any deviation indicates an authoring typo against the K-1308 bucket rule "
     "or the K-1227 wrapper-bound K-COMPLEMENT scoping.")
 # Cross-frozenset disjointness — P13 vs prior envelopes.
 _K1367_P13_VS_P8_DISJOINT = (
-    _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
 assert _K1367_P13_VS_P8_DISJOINT, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps the K-1322 51-cell P8 "
     "envelope; P8's K-1205 N=128 sub-frozenset uses K ∈ {2048, 8192} with "
@@ -1044,14 +1044,14 @@ assert _K1367_P13_VS_P8_DISJOINT, (
     "tuples must be enumerated to overlap; disjointness verified by frozenset "
     "intersection at module load).")
 _K1367_P13_VS_K971_DISJOINT = (
-    _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE))
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE))
 assert _K1367_P13_VS_K971_DISJOINT, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps K971_ROUTE_TABLE; "
     "K971_ROUTE_TABLE (K-905/K-971 + K-1335) uses M=N ∈ {1024, 2048}; "
     "P13 cells all use N=128 — natural disjointness, but assert as cheap "
     "insurance per R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.")
 _K1367_P13_VS_P12_DISJOINT = (
-    _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
 assert _K1367_P13_VS_P12_DISJOINT, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps K-1361 P12 square_mid; "
     "P12 cells use M=N=K ∈ {2048, 4096}; P13 cells all use N=128 — natural "
@@ -1060,7 +1060,7 @@ assert _K1367_P13_VS_P12_DISJOINT, (
 
 def _k1367_p13_skinny_n128_routeout(M: int, N: int, K: int, dtype) -> bool:
     """K-1367 P13 — direct hipBLASLt route-OUT for the 18-cell skinny_N128
-    K-COMPLEMENT cohort (`_K1367_P13_SKINNY_N128_ROUTEOUT_18`).
+    K-COMPLEMENT cohort (`_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18`).
 
     Returns True iff (M, N, K, dtype) matches one of the 18 strict-equality
     keys: M ∈ {2048, 4096, 8192} × N = 128 × K ∈ {4096, 8192, 16384} ×
@@ -1080,7 +1080,7 @@ def _k1367_p13_skinny_n128_routeout(M: int, N: int, K: int, dtype) -> bool:
     """
     return (
         (int(M), int(N), int(K), str(dtype))
-        in _K1367_P13_SKINNY_N128_ROUTEOUT_18
+        in _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18
     )
 
 

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1,0 +1,1150 @@
+"""K-1003 R-K979 P5 Gate-0 admission predicate (torch-free).
+
+Hosts the closed-form structural-pathology predicate plus the K-905/K-971
+mid-square long-K strict-equality anchors. Imported by ``matmul.py`` for the
+runtime dispatch; importable on its own (no torch / triton chain) so unit
+and integration tests can exercise it without booting a GPU stack.
+
+The predicate keys solely on ``(M, N, K, dtype)`` where ``dtype`` is matched by
+``str(dtype) == "torch.bfloat16"``; any object whose ``str()`` repr is
+``"torch.bfloat16"`` (i.e. ``torch.bfloat16`` itself, or the literal string
+``"torch.bfloat16"`` used in tests) selects the bf16 path.
+"""
+from __future__ import annotations
+
+import os
+
+# fp16 K-905/K-971 anchors stay as exact-tuple lookups because their shapes
+# structurally collide with K-950 LAND cells (e.g. (1024,1024,16384,bf16) is
+# both a K-912 LAND and a K-905 route-OUT — only an exact tuple can express
+# "fire on this exact shape but not on its baseline-LAND twin").
+_K905_K971_LDS_BC_ANCHORS_8 = frozenset({
+    (1024, 1024, 16384, "torch.bfloat16"),  # K-905 baseline
+    (1024, 1024, 16384, "torch.float16"),
+    (1024, 1024, 32768, "torch.bfloat16"),  # K-971 (K-905 N4: hbl/off=1.73x)
+    (1024, 1024, 32768, "torch.float16"),
+    (2048, 2048, 16384, "torch.bfloat16"),  # K-971 (K-905 N2: hbl/off=1.37x)
+    (2048, 2048, 16384, "torch.float16"),
+    (2048, 2048, 32768, "torch.bfloat16"),  # K-971 (K-905 N5: hbl/off=1.38x)
+    (2048, 2048, 32768, "torch.float16"),
+})
+
+# ---------------------------------------------------------------------------
+# K-1335 / K-1326 (S-002) — longK_smallSquare bf16 route-OUT extension
+# (the 5th-position dispatch predicate; K971_ROUTE_TABLE).
+#
+# K-1335 productionizes K-1326's `P9_longK_smallSquare_routeOUT` proposal as
+# a 4-cell strict-equality extension to the K-905/K-971 LDS-bank-conflict
+# (LDS-BC) anchor family.  Cells were identified by K-1308's per-shape
+# residual decomposition of the K-1322 51-cell P8 envelope sweep:
+# `longK_smallSquare` (M=N∈{1024, 2048}, K∈{4096, 8192}, bf16; 4 cells,
+# residual mean 0.695, aggregate gap 2.779) is the worst residual bucket
+# AND zero admit predicate fires on any of these cells (any-pred-fired = N
+# for the bucket).  K-1326 then attributed the bottleneck via PMC features
+# carried over from the K-913 baseline triage:
+#
+#   LDS_BC      1.78 cyc/inst  (vs 0.00 on hbl baseline)
+#   MFMA%       9.33%          (vs 15.85% on hbl baseline)
+#   SQ_INSTS_LDS  4.00x inflated vs hbl
+#
+# This is the same LDS-bank-conflict fingerprint as K-905 / K-930 / K-971
+# (mechanism-shape-invariant per K-913 §3, ±19% across the 4-cell
+# neighborhood) — NOT the K-1144 P8 MFMA-issue-stall pathology (different
+# counter signature).  Per R-1329.MECHANISTIC-DISAMBIGUATION-OF-PREDICATE-
+# ATTACHMENT-POINT, the attachment site must match the mechanism, so the 4
+# K-1335 admits attach to the K-905/K-971 LDS-BC envelope (the 5th-position
+# dispatch predicate `K971_ROUTE_TABLE`), NOT to the K-1322 51-cell P8
+# `_P8_MFMA_ISSUE_STALL_ROUTEOUT` envelope.  The K-1322 P8 envelope and its
+# 6 named sub-frozensets remain byte-identical; the dispatch ladder
+# precedence is unchanged.
+#
+# The autotune in-kernel path has converged on a single config that is
+# structurally LDS-bank-conflict-bound — K-1308's cross-branch ratio
+# invariant (4-pred ratio == main ratio within paired-n30 ±3% CV) holds
+# on these 4 cells, ruling out any (BM, BN, BK, WPEU, NS, NW) catalog
+# perturbation that could close the gap.  Route-OUT is the only remaining
+# mechanism (R-1329.CROSS-BRANCH-RATIO-INVARIANT-IMPLIES-ROUTE-OUT-ONLY).
+#
+# Verification (paired n=30 HIP-graph hot-cache, B=10000 paired bootstrap,
+# MI300X / gfx942 dedicated, 4 admit cells + 4 K-axis-neighbor controls):
+#   - 4-cell admit-set geomean: ~1.30x route-OUT win (CI95 strictly > 1.0)
+#   - 4-cell neighbor controls: no significant regression (CI95-hi >= 0)
+# Per R-1329.ADMIT-ON-DEDICATED-GPU-NOT-COTENANT, paired n=30 selection
+# uses dedicated-GPU measurement; co-tenant measurements admissible only
+# as the regression-firewall lower bound.
+#
+# Disjointness (K-axis projection per R-1329.K-AXIS-PROJECTION-DISJOINTNESS-
+# ASSERTS-ARE-CHEAP-INSURANCE): K-1335 K∈{4096, 8192}; K-905/K-971
+# K∈{16384, 32768} — natural K-axis separator, asserted at module load.
+# bf16-only by design (K-913 anchor + K-1326 bucket are bf16; fp16 parity
+# tracked separately on the K-1093 / K-1125 line).
+# ---------------------------------------------------------------------------
+_K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4 = frozenset({
+    (1024, 1024,  4096, "torch.bfloat16"),  # K-1326 A1; K-913 PMC anchor neighborhood (LDS_BC 1.78 cyc/inst)
+    (1024, 1024,  8192, "torch.bfloat16"),  # K-1326 A2; K-913 PMC anchor (1024,1024,8192) bf16
+    (2048, 2048,  4096, "torch.bfloat16"),  # K-1326 A3; same LDS-BC fingerprint per K-913 §3 ±19%
+    (2048, 2048,  8192, "torch.bfloat16"),  # K-1326 A4; same LDS-BC fingerprint per K-913 §3 ±19%
+})
+
+# Composed K-905/K-971/K-1335 LDS-BC route-OUT table (the 5th-position
+# dispatch predicate).  Two named provenance frozensets; consulted as a
+# strict-equality union by `_k971_route_to_hbl` after P8 / E1 / P6 / P5.
+# Per R-1144.DUAL-FROZENSET-PROVENANCE (lifted to the LDS-BC envelope per
+# R-1329.MECHANISTIC-DISAMBIGUATION-OF-PREDICATE-ATTACHMENT-POINT), each
+# measurement campaign keeps its own named set with a runtime cardinality
+# pin and a K-axis-projection disjointness assert.
+K971_ROUTE_TABLE = (
+    _K905_K971_LDS_BC_ANCHORS_8
+    | _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4
+)
+assert len(K971_ROUTE_TABLE) == 12, (
+    "K-1335 unified LDS-BC route-OUT table must be exactly 12 cells "
+    "(8 K-905/K-971 anchors + 4 K-1335 longK_smallSquare admits); a "
+    "duplicate or stray entry has crept in.")
+assert len(_K905_K971_LDS_BC_ANCHORS_8) == 8
+assert len(_K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4) == 4
+# K-axis-projection disjointness: K-1335 K∈{4096, 8192}; K-905/K-971
+# K∈{16384, 32768}.  Cheap module-load-time assert per R-1329.K-AXIS-
+# PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.
+assert _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4.isdisjoint(
+    _K905_K971_LDS_BC_ANCHORS_8), (
+    "K-1335 longK_smallSquare admits overlap K-905/K-971 LDS-BC anchors; "
+    "K-axis-projection disjointness (K-1335 K∈{4096, 8192} vs K-905/K-971 "
+    "K∈{16384, 32768}) is the structural separator and a violation "
+    "indicates an authoring typo in one of the two frozensets.")
+
+
+def _dtype_is_bf16(dtype) -> bool:
+    """Match torch.bfloat16 without importing torch.
+
+    Both the ``torch.bfloat16`` singleton and the literal string
+    ``"torch.bfloat16"`` (used by tests) pass; anything else fails.
+    """
+    return str(dtype) == "torch.bfloat16"
+
+
+def R_K979_P5_route_to_hbl(M: int, N: int, K: int, dtype) -> bool:
+    """R-K979 v3 / P5 — closed-form 4-clause structural pathology predicate.
+
+    Returns True when shape (M, N, K, dtype) sits in the NO-LAND-for-Triton-
+    override regime (i.e. tritonblas should route to hipBLASLt). Translates
+    P5's PMC predicate into structural (M, N, K, dtype) proxies:
+
+      Clause-1 (over-tile / LDS-bound mid-rect):
+          mid-rect non-square with K in the [1240, 8064] LDS-pressure band
+          and one axis pinned to the {1792, 2048, 3072} LDS-bound family.
+      Clause-2 (hbl-strong / LMhead projection):
+          large-M skinny  M >= 5000, N == 2048, K in {256, 1024}.
+      Clause-3 (tb-weak / extreme aspect or tiny):
+          aspect ratio max(M,N)/min(M,N) >= 100, or min(M,N) <= 192 AND
+          K >= 2048 (waves under-utilised on the small axis).
+      Clause-4 (over-tile dual / N=1792 shallow-K):
+          N == 1792 and 512 <= K <= 768 (K-1062 raised the K floor from
+          0 to 512 = 8*BK64 to silence the K=256 false-positive surfaced
+          by the K-1017 PMC sweep and confirmed by the K-1043 per-clause
+          confusion matrix; S07=(2048,1792,256,bf16) gap_x=1.044 is
+          inside the per-engine ~5% CV noise floor — routing buys a
+          measured-zero-gain dispatch detour), with M either large-
+          skinny (>= 5000) or in the K-984/K-989 mid-rect band
+          [256, 2048].  K-984/K-989 anchors S06 (K=736) and S18 (K=768)
+          both have K >= 736 so neither is regressed.
+
+    bf16-only: K-984/K-989 ship cohort and K-931 measurement scope are bf16;
+    fp16 K-905/K-971 anchors stay in :data:`K971_ROUTE_TABLE`.
+
+    Verification (K-1003):
+      - K-984+K-989 union (14 unique shapes): 14/14 FIRE
+      - K-950 LAND set (9 cells): 0/9 FIRE (zero leakage)
+      - K-931 top-40: 29/40 FIRE (15 net beyond strict-equality)
+    """
+    if not _dtype_is_bf16(dtype):
+        return False
+    minMN = min(M, N)
+    maxMN = max(M, N)
+    # Clause-1: over-tile, LDS-bound, mid-rect non-square with mid-band K.
+    if (minMN < maxMN
+            and 256 <= minMN <= 2304
+            and 1792 <= maxMN <= 3072
+            and 1240 <= K <= 8064):
+        return True
+    # Clause-2: hbl-strong LMhead-style large-M skinny.
+    if M >= 5000 and N == 2048 and K in (256, 1024):
+        return True
+    # Clause-3: tb-weak — extreme aspect or skinny-and-long-K.
+    if maxMN >= 100 * max(1, minMN):
+        return True
+    if minMN <= 192 and K >= 2048:
+        return True
+    # Clause-4: N=1792 shallow-K dual of clause-1.  K-1062 K-floor=512
+    # (8*BK64) — see docstring; closes the K=256 S07 false positive
+    # without affecting the K=736 / K=768 K-984+K-989 anchors.
+    if N == 1792 and 512 <= K <= 768 and (M >= 5000 or 256 <= M <= 2048):
+        return True
+    return False
+
+
+# K-1109 (S-002) brief deliverable (1): explicit shape-key allowlist for
+# the K-1074 MFMA-issue-stall candidate cells (originally 8 cells: S26,
+# S31-S35, S37, S39).  Brief asked for "minimal diff (<30 LOC) gated behind
+# explicit shape-key allowlist initially, with strict-equality fallback for
+# the validated 8-cell set as a safety net".
+#
+# Gated by env var (default OFF) because the only paired n=30 round-robin
+# timing on c42/MI300X available at PR time (k1109_k1074_timing.json,
+# derived from K-1074/output/rr_summary.csv) showed 0/8 cells clear the
+# K-901 +2% LAND margin.  Set TRITONBLAS_K1109_P6_ALLOWLIST=1 in the
+# runtime env to enable for further validation.
+#
+# REGRESSION CARVE-OUT (per K-1109 reviewer consensus, 4/4 REVISE votes):
+# Two of the original 8 cells — S32 (20352,2048,1024) and S37
+# (25600,2048,256) — are CI95-confirmed REGRESSIONS in the same n=30 paired
+# timing (S32: mean -0.51%, CI95 [-0.872, -0.148]; S37: mean -0.68%, CI95
+# [-1.129, -0.232]).  Shipping a "safety net" allowlist that admits known-
+# regressing cells, even default-OFF, is a hazard not a safety net — the
+# gate exists precisely so operators can flip it on without a code change,
+# so the contents must never include cells where paired evidence already
+# proves harm.  S32 and S37 are therefore EXCLUDED.  The
+# K1074_REGRESSION_CARVE_OUT_PINS test in tests/test_k971_route_predicate.py
+# documents this with the exact CI95 numbers so any silent re-add of those
+# cells fails CI loudly.
+#
+# Pin tests exercise both gate states so any change to the allowlist or
+# gate semantics surfaces in CI.
+_K1109_P6_K1074_ALLOWLIST = frozenset({
+    ( 8064, 2048, 1024, "torch.bfloat16"),  # S26  mean +0.51%, CI95 [+0.13,+0.88]
+    (18304, 2048, 1024, "torch.bfloat16"),  # S31  mean -2.96%, CI95 [-7.06,+1.14]  (overlaps zero)
+    (22400, 2048, 1024, "torch.bfloat16"),  # S33  mean +1.34%, CI95 [-0.06,+2.75]
+    (24448, 2048, 1024, "torch.bfloat16"),  # S34  mean +0.65%, CI95 [+0.47,+0.83]
+    (26496, 2048, 1024, "torch.bfloat16"),  # S35  mean +0.77%, CI95 [-0.15,+1.69]
+    (49152, 2048,  256, "torch.bfloat16"),  # S39  mean +0.24%, CI95 [-0.18,+0.66]
+    # EXCLUDED — CI95-confirmed regressions in K-1074 paired n=30 timing:
+    #   S32 (20352,2048,1024): mean -0.51%, CI95 [-0.872, -0.148]
+    #   S37 (25600,2048, 256): mean -0.68%, CI95 [-1.129, -0.232]
+})
+_K1109_P6_ALLOWLIST_ENV = "TRITONBLAS_K1109_P6_ALLOWLIST"
+
+# Pinned regression evidence for the two cells excluded from the allowlist.
+# Re-adding either cell to _K1109_P6_K1074_ALLOWLIST without first refuting
+# this evidence will fail the K1074_REGRESSION_CARVE_OUT_PINS test.
+_K1109_P6_K1074_REGRESSION_EXCLUSIONS = frozenset({
+    (20352, 2048, 1024, "torch.bfloat16"),  # S32
+    (25600, 2048,  256, "torch.bfloat16"),  # S37
+})
+
+
+def _k1109_p6_allowlist_admit(M: int, N: int, K: int, dtype) -> bool:
+    """K-1109 brief deliverable (1) — strict-equality safety-net allowlist.
+
+    Returns True iff the env gate is set AND (M, N, K, dtype) is one of the
+    6 K-1074 MFMA-issue-stall candidate cells whose paired n=30 timing did
+    NOT fall entirely below the zero line (S32 and S37 carved out per
+    reviewer consensus — see comment block above the allowlist). Default-OFF;
+    see module-level docstring above the allowlist for the rationale.
+    """
+    if os.environ.get(_K1109_P6_ALLOWLIST_ENV) != "1":
+        return False
+    return (int(M), int(N), int(K), str(dtype)) in _K1109_P6_K1074_ALLOWLIST
+
+
+def R_K1037_P6_admit_wpeu1(M: int, N: int, K: int, dtype) -> bool:
+    """K-1089 — Structural surrogate of K-1037 P6 MFMA-issue-stall classifier.
+
+    Returns True iff the (M, N, K, dtype) shape's structural fingerprint
+    matches K-1037's paired-PMC P6 admit condition
+
+        waves_per_CU_ratio (tb/hbl) < 1.70x
+        AND MFMA_pct_tb >= 1.0%
+        AND LDS_BC_cyc_per_inst_tb < 1.5
+
+    K-1037 verified perfect 18/18 agreement of the 3-clause PMC predicate
+    against K-1017's `route_action_table.csv` (TP=2/2 on S24, S29; TN=16/16
+    on the remaining 15 occupancy + 1 HBM-L2-stall cells). K-1051 separately
+    confirmed via 4-iter PMC research that wpeu=1 wins are predictable from
+    2-3 counter clauses on K-1032 cells.
+
+    K-1037's P6 reads paired runtime PMC (`pmc_view.tb` AND `pmc_view.hbl`)
+    so it cannot run in a hot dispatch path (R-1037.A-PRIORI-PMC-CLASSIFIERS-
+    LAND-AS-OFFLINE-CLASSIFIED-SHAPE-TABLES-NOT-LIVE-PMC-PREDICATES). This
+    function regresses each PMC clause onto structural shape features so the
+    same admit decision can be taken at dispatch time on the four fields
+    (M, N, K, dtype) available without instrumentation.
+
+    Surrogate-C2 (MFMA_pct_tb >= 1.0%):
+        Translated to K >= 512. K-1037 P6 positives have MFMA% in
+        [3.79, 4.79]; K-1017 cell S38 (K=200, MFMA%=0.07) is the only
+        false-positive risk and is excluded by this floor.
+    Surrogate-C3 (LDS_BC_cpi_tb < 1.5):
+        Translated to "not in P5 LDS-bound regime". Composition: caller
+        consults R_K979_P5_route_to_hbl first; this admit only fires on
+        shapes NOT already silenced by P5 clauses 1+3 (LDS-port-contention
+        and asymmetric-aspect axes).
+    Surrogate-C1 (waves_per_CU_ratio < 1.70x — load-bearing):
+        Two regression envelopes drawn from K-1017 + K-1032 + K-1044
+        paired-PMC corpus:
+
+        Envelope A (S29 wide-rect family):
+            N == 2048 AND K == 1024 AND 13000 <= M <= 14999.
+            Catches S29 (M=14208, ratio=1.51) only. Bounded above by S30
+            (M=16256, ratio=1.75 — OCC) and below by K-984/K-989 LAND
+            anchors S25 (M=6016), S27 (M=10112), S28 (M=12160) which all
+            route-OUT cleanly under the existing P5 Clause-2 and gain
+            5.31x-5.63x speedup; tightening to M>=13000 preserves those
+            anchors while admitting only the K-1037-verified positive.
+            (K-1044 B3b=(6016, 2048, 1024) collides with S25 anchor — it
+            stays route-OUT under K-989's strict-equality table; the
+            streamk-LAND verdict K-1044 reports is orthogonal to wpeu=1.)
+        Envelope B (S24 + K-1044 B3a moderate-square mid-K family):
+            minMN >= 2048 AND maxMN <= 4500 AND 512 <= K <= 1024.
+            Catches S24 (4480, 3072, 768) (ratio=1.53). Bounded above by
+            maxMN<=4500 to preserve K-984/K-989 LAND anchors (S18 maxMN=5972
+            and S25 maxMN=6016 sit clear above).
+
+    bf16-only by design (K-1037 / K-1017 / K-1044 ground truth scope).
+
+    Composition with K-1062-style hardening: like P5 Clause-4's K-floor=512
+    architectural bound, both envelopes are bounded BELOW by floors tied to
+    the calibration set's lowest M/K positives. The ROUTE_OUT_HBL effect
+    is delegated upstream to caller (matmul.py); this function only reports
+    the structural P6 admit verdict.
+
+    Calibration verification on K-1017 18-cell set:
+        S24 -> True   (P6 positive, ratio=1.532)        ENVELOPE B
+        S29 -> True   (P6 positive, ratio=1.514)        ENVELOPE A
+        all 16 negatives -> False                       neither envelope
+
+    K-1031 NO-LAND set (K-1017 cells where P5 does not fire) regression:
+        S07 (2048, 1792, 256)  -> False (K=256<512 / N=1792)
+        S16 (256, 256, 2048)   -> False (minMN=256<2048)
+        S38 (384, 128, 200)    -> False (K=200<512)
+
+    K-1104 NULL-RESULT (do not relax these envelopes):
+        K-1098 4-iteration RESEARCH (primary-source-verified) showed that
+        the 8 K-1074 candidate cells (S26, S31, S32, S33, S34, S35, S37,
+        S39) fire P6 on **0/8** under K-1037's paired-PMC classifier --
+        all 8 fail load-bearing C1 with waves_per_CU_ratio (tb/hbl) in
+        [1.753, 2.740]. The K-1074 paired n=30 round-robin on c42/MI300X
+        confirmed: 0/8 cells clear the K-901 +2% LAND margin under wpeu=1,
+        2/8 (S32, S37) are confirmed regressions (CI95 hi < 0), cohort
+        geomean ~= 1.000x. P5 Clause-2 already routes the K=1024 family
+        OUT to hipBLASLt with 2.6x-3.1x measured speedup on K-989 anchors
+        (S25, S27, S28), which is the structurally-correct production
+        behaviour for those cells.
+
+        Hard separation wall blocks any C1 relaxation: K-1037 NEG cell
+        S30 (M=16256, waves_ratio=1.7530) and K-1074 candidate S34
+        (M=24448, waves_ratio=1.7530) collide exactly on C1, so no cutoff
+        in the (1.5320, 1.7530) feasibility band can admit S34 without
+        producing a false-positive on S30.
+
+        Envelope A's M-band [13000, 14999] is therefore architecturally
+        bounded -- the upper bound (14999) sits below S30's M=16256, and
+        the lower bound (13000) sits above K-984/K-989 LAND anchors
+        S25/S27/S28 (M in {6016, 10112, 12160}) which carry verified
+        2.6x-3.1x P5 Clause-2 routing speedup.
+
+        References: K-1098 backtest (output/p6_clause_by_clause_k1074.csv),
+        K-1074 paired n=30 (rr_summary.csv), K-1049/K-1055/K-1062 adversarial
+        gate (FAIL: zero NEW NO-LAND-leak gain).
+
+    K-1109 reproduction (productionizes the K-1066 lock-the-envelope pattern):
+        Independently re-derived K-1037 P6 from the primary-source paired-
+        PMC CSV for all 8 K-1074 cohort-extension cells + the 4 K-1044
+        anchor cells called out in the K-1109 brief + 8 K-1017 held-out
+        OCC/HBM negatives.  Result: 0/8 K-1074 FIRE (brief premise of 8/8
+        FALSIFIED), 2/2 K-1037 P6 positives still FIRE (S24, S29), 0/8
+        K-1017 NEG false positives, S30/S34 C1 collinearity wall confirmed
+        at waves_ratio=1.7530.  K-1044 B3a (S18, 5972,1792,768) and B3b
+        (S25, 6016,2048,1024) fire exact PMC P6 but the surrogate's
+        Envelope-A M>=13000 floor and Envelope-B minMN>=2048 floor
+        correctly preserve them as K-989 LAND anchors (5.31x-5.63x
+        routing speedup).  Envelopes A and B are LOCKED -- pin tests in
+        tests/test_k971_route_predicate.py (P6_NEGATIVES_K1074,
+        P6_NEGATIVES_K1044_ANCHORS, test_p6_c1_collinearity_wall_*)
+        gate any future relaxation through CI.
+
+        Reproduction artifact: /home/ryaswann/mc2-workspaces/K-1109/output/
+        k1109_p6_audit.csv (re-derivable via scripts/k1109_p6_verification.py).
+    """
+    if not _dtype_is_bf16(dtype):
+        return False
+    # K-1109 brief deliverable (1): strict-equality safety-net allowlist
+    # (env-gated, default OFF). Consulted FIRST so it can admit cells that
+    # the structural envelopes reject (the K-1074 cohort fails C1 by design,
+    # so it would never fire through the envelope path below).
+    if _k1109_p6_allowlist_admit(M, N, K, dtype):
+        return True
+    if K < 512:
+        return False  # Surrogate-C2: insufficient MFMA work density
+    minMN, maxMN = min(M, N), max(M, N)
+    # Envelope A: K-931 wide-rect (N=2048, K=1024) family at moderate M.
+    # K-1017 paired ratios: S26 M=8064 (2.03x — OCC), S29 M=14208 (1.51x —
+    # P6+), S30 M=16256 (1.75x — OCC). K-984/K-989 LAND anchors S25 M=6016
+    # / S27 M=10112 / S28 M=12160 sit clear below the M>=13000 floor and
+    # remain route-OUT under P5 Clause-2 with 5.31x-5.63x routing speedup.
+    if N == 2048 and K == 1024 and 13000 <= M <= 14999:
+        return True
+    # Envelope B: moderate-square mid-K family (S24 fingerprint).
+    # Ceiling maxMN<=4500 preserves K-984 anchor S18 (5972,1792,768) and
+    # K-989 anchor S25 (6016,2048,1024) which both sit clear above.
+    if 2048 <= minMN and maxMN <= 4500 and 512 <= K <= 1024:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# K-1144 P8 — MFMA-issue-stall direct hipBLASLt route-OUT (productionizes
+# K-1121 + K-1131).
+#
+# Brief context: K-1074 paired n=30 LAND audit on c42/MI300X falsified the
+# K-1089 wpeu=1 in-kernel admit for the 13-cell MFMA-issue-stall cohort
+# (5 K-1051 + 8 K-1031 leakage); 0/13 cells cleared the K-901 +2% margin
+# (2/13 — S32, S37 — were CI95-confirmed regressions, see K-1109's carve-
+# out documentation).  K-1121 measured paired n=30 HIP-graph hot-cache on
+# the same 13 cells with `OFF=tritonblas`/`ON=hipBLASLt` and reported
+# 13/13 admit at hbl/tb >= 1.10x (cohort geomean 1.226x, range
+# 1.158x-1.365x; CI95-lower clears the K-1007 >=1.05x admission floor on
+# every cell).  K-1127 then adversarially backtested the 13-cell envelope
+# against the K-931 always-uncovered top-40 production catalog and reported
+# 0 false positives at n=20.  K-1131 perturbed the 13 anchors along
+# +/-1 power-of-2 in M, N, K and admitted all 12/12 neighbors at the
+# stricter generalization gate (ratio >= 1.15x AND CI95-lo > 1.00; geomean
+# 1.367x, max 1.657x, scatter 0.0%).  Triple-validated: original cohort
+# (K-1121) + adversarial backtest (K-1127) + neighbor envelope (K-1131).
+#
+# Composition with the existing predicate stack (no overlap, no precedence
+# inversion):
+#   * P8 fires BEFORE the K-1089 R_K1037_P6_admit_wpeu1 admit-back-to-kernel
+#     check, because S24 (4480, 3072, 768) and S29 (14208, 2048, 1024) sit
+#     inside K-1089 Envelopes B and A respectively and would otherwise be
+#     short-circuited back to in-kernel by P6 -- but K-1074's paired n=30
+#     evidence falsified that admit and K-1121's paired n=30 confirms
+#     hipBLASLt wins on these exact cells (S24 ratio ~1.20x, S29 ratio
+#     ~1.22x).  K-1131 neighbor N11 (2240, 3072, 768) is also inside
+#     P6 Envelope B and is similarly reverted to route-OUT by P8.  This
+#     is the "no precedence inversion vs K-1089" composition rule
+#     codified.
+#   * P8 is independent of (composes safely with) K-1062 P5 Clause-4
+#     K-floor=512: P8 cells either don't hit Clause-4 at all (none use
+#     N=1792 with 512<=K<=768 except S18, see below) or already route-OUT
+#     via Clause-4 (S18 = 5972, 1792, 768; K=768 is in-band).  Strict-
+#     equality dispatch on P8 returns True regardless, so even on overlap
+#     the routing decision is identical -- no double-routing.
+#   * P8 is also independent of K-1066 R-K979 P5 generalized clauses.
+#     Cells covered by both P5 (Clause-2 large-M skinny) and P8 simply
+#     return True via whichever check fires first; the dispatch outcome
+#     is unchanged ("route to hipBLASLt").  Strict-equality is a frozenset
+#     hash; lookup cost is O(1) per K-1060 round-robin harness analysis.
+#   * P8 is also independent of the K-1109 env-gated allowlist.  The
+#     K-1109 allowlist (default OFF) admits 6 of the K-1074 cells back
+#     to in-kernel; with the env unset (production default) those cells
+#     route via P5 Clause-2.  P8 makes the route-OUT explicit and does
+#     not depend on the K-1109 env state.  When the K-1109 env IS set,
+#     P8's BEFORE-P6 placement still wins -- the brief's "no double-
+#     routing" guarantee holds in both env states.
+#
+# Anti-overshoot discipline (R-1131): the route table is STRICT-EQUALITY
+# only.  K-1131 deliberately did NOT widen to a parametric envelope despite
+# 12/12 + zero-scatter neighbor admission, because the K-1097->K-1115 PMC
+# classifier exhaustion chain forecloses any non-strict-equality predicate
+# on this cohort that hasn't survived held-out validation.  Future shape-
+# class consolidation (R-1121.SHAPE-CLASS-PREDICATE-CANDIDATE-WHEN-COHORT-
+# SHARES-NK-SIGNATURE-WITH-M-SWEEP) is filed as a follow-up; it must
+# re-derive thresholds from already-admitted P8 cells (not raw counter
+# data) to avoid re-opening the predicate-fit trap.
+#
+# 25 cells = 13 K-1121 anchors + 12 K-1131 neighbors, all bf16.
+# K-1121 admission gate: hbl/tb >= 1.10x mean AND CI95-lo >= 1.05x (K-1007).
+# K-1131 generalization gate: ratio >= 1.15x AND CI95-lo > 1.00.
+# All cells satisfy both gates per source manifests.
+# ---------------------------------------------------------------------------
+
+# K-1121 anchors (5 K-1051 PMC counter-matrix cells + 8 K-1031 leakage
+# cohort cells).  Per-cell mean speedup (hbl/tb) annotated from K-1121's
+# paired n=30 HIP-graph hot-cache on rad-mi300x-1 / MI300X / ROCm 7.2;
+# range 1.158x-1.365x; cohort geomean 1.226x.
+_K1121_P8_ANCHORS_13 = frozenset({
+    # ----- K-1051 PMC counter-matrix cells (overlap with K-1089 P6) -----
+    ( 4480, 3072,  768, "torch.bfloat16"),  # S24  ~1.20x  (P6 Env-B overlap)
+    (14208, 2048, 1024, "torch.bfloat16"),  # S29  ~1.22x  (P6 Env-A overlap)
+    ( 5972, 1792,  768, "torch.bfloat16"),  # S18  ~1.16x  (P5 C4 K=768)
+    ( 6016, 2048, 1024, "torch.bfloat16"),  # S25  ~1.21x  (P5 C2)
+    (16256, 2048, 1024, "torch.bfloat16"),  # S30  ~1.24x  (P5 C2)
+    # ----- K-1031 leakage MFMA-issue-stall candidates -----
+    ( 8064, 2048, 1024, "torch.bfloat16"),  # S26  ~1.22x  (P5 C2)
+    (18304, 2048, 1024, "torch.bfloat16"),  # S31  ~1.27x  (P5 C2)
+    (20352, 2048, 1024, "torch.bfloat16"),  # S32  ~1.25x  (P5 C2; K-1109 carve-out)
+    (22400, 2048, 1024, "torch.bfloat16"),  # S33  ~1.21x  (P5 C2)
+    (24448, 2048, 1024, "torch.bfloat16"),  # S34  ~1.19x  (P5 C2)
+    (26496, 2048, 1024, "torch.bfloat16"),  # S35  ~1.24x  (P5 C2)
+    (25600, 2048,  256, "torch.bfloat16"),  # S37  ~1.30x  (P5 C2; K-1109 carve-out)
+    (49152, 2048,  256, "torch.bfloat16"),  # S39  ~1.37x  (P5 C2)
+})
+
+# K-1131 held-out neighbors (12 cells perturbed +/-1 power-of-2 from 4
+# representative anchors: S32 peak, S39 extreme-M / shallow-K, S18 only-
+# non-2K-N, S24 only-N=3072).  Per-cell mean speedup (hbl/tb) annotated
+# from K-1131's paired n=30 + 10k-resample paired bootstrap on rad-mi300x-1;
+# range 1.15x-1.657x; cohort geomean 1.367x; envelope-edge cells N04/N06.
+_K1131_P8_NEIGHBORS_12 = frozenset({
+    # ----- S32 (20352, 2048, 1024) family — full 6-axis coverage -----
+    (20352, 2048,  512, "torch.bfloat16"),  # N01 S32 K/2  IN_COHORT
+    (20352, 2048, 2048, "torch.bfloat16"),  # N02 S32 K*2  IN_COHORT
+    (40704, 2048, 1024, "torch.bfloat16"),  # N03 S32 M*2  IN_COHORT
+    (10176, 2048, 1024, "torch.bfloat16"),  # N04 S32 M/2  ratio 1.604x (envelope edge)
+    (20352, 4096, 1024, "torch.bfloat16"),  # N05 S32 N*2  IN_COHORT
+    (20352, 1024, 1024, "torch.bfloat16"),  # N06 S32 N/2  ratio 1.657x (cohort MAX)
+    # ----- S39 (49152, 2048, 256) family — K-axis only (extreme-M) -----
+    (49152, 2048,  128, "torch.bfloat16"),  # N07 S39 K/2  IN_COHORT
+    (49152, 2048,  512, "torch.bfloat16"),  # N08 S39 K*2  IN_COHORT
+    # ----- S18 (5972, 1792, 768) family — N-axis only (only non-2K N) -----
+    ( 5972,  896,  768, "torch.bfloat16"),  # N09 S18 N/2  IN_COHORT
+    ( 5972, 3584,  768, "torch.bfloat16"),  # N10 S18 N*2  IN_COHORT
+    # ----- S24 (4480, 3072, 768) family — M/2 + K*2 (only N=3072) -----
+    ( 2240, 3072,  768, "torch.bfloat16"),  # N11 S24 M/2  IN_COHORT (P6 Env-B overlap)
+    ( 4480, 3072, 1536, "torch.bfloat16"),  # N12 S24 K*2  IN_COHORT
+})
+
+# K-1175 / K-1161 E2 axis extension admits.  K-1161 paired n=30 HIP-graph
+# hot-cache validation of the K-axis extension envelope
+#   E2 := N in {1792, 2048, 3072} AND K in {96, 128, 192, 256, 512, 768, 1024}
+# returned a **NEGATIVE_AXIS_PIVOT** verdict overall (3/8 = 37.5% admit,
+# below the 50% pivot threshold; well below the 80% landing threshold).
+# In particular:
+#   - K-floor relaxation (K < 256: E2_K1=512x2048x96, E2_K2=512x2048x192):
+#       0/2 admit -- both are TB-favoured (small-M Triton-win tail).
+#   - K=512 interior fill (E2_I1=192x2048x512, E2_I2=156x1792x512,
+#       E2_I3=160x3072x512): 0/3 admit -- all TB-favoured (small-M tail).
+#   - K=736 interior fill (E2_I4=736x1792x736): 1/1 admits at hbl/tb=1.315x
+#       CI95=[1.313, 1.317].  Sole K-interior route-OUT-safe cell.
+#   - M-axis extension at K=1024 (E2_M1=10112x2048x1024,
+#       E2_M2=12160x2048x1024, both at K-1121 anchor K-set): 2/2 admit at
+#       hbl/tb 1.759x and 1.499x respectively.  Orthogonal axis, not in
+#       K-floor=128 / K=512 scope but K-1161 uncovered.
+#
+# Per K-1161 R-1161.K-FLOOR-RELAXATION-SURFACES-TB-FAVOURED-SMALL-M-TAIL:
+# the K-1121 MFMA-issue-stall cohort's small-M corner (M <= 512) of the
+# (M, K) plane is a Triton win region; K-1142's (M >= 4480) carve-out
+# already excluded these cells by M-floor regardless of K-floor strictness.
+# K-floor=128 is NOT hipBLASLt-favourable for this regime; only the M-axis
+# extension and the K=736 single-cell pin are landed here.  The K-floor
+# of any future structural extension MUST remain at K >= 256 unless paired
+# with a strict M-floor strictly above the small-M Triton-favoured tail.
+#
+# Strict-equality only (R-1131): no parametric envelope -- each cell was
+# directly measured at paired n=30 with hbl/tb >= 1.315x and CI95-lo > 1.05x.
+_K1161_E2_ADMITS_3 = frozenset({
+    # ----- K-interior single-cell admit (only K-axis cell that survived) -----
+    (  736, 1792,  736, "torch.bfloat16"),  # E2_I4 hbl/tb=1.315x CI95=[1.313, 1.317] (K=736 upper edge)
+    # ----- M-axis extension at K-1121 anchor K=1024 (orthogonal axis) -----
+    (10112, 2048, 1024, "torch.bfloat16"),  # E2_M1 hbl/tb=1.759x CI95=[1.753, 1.770]
+    (12160, 2048, 1024, "torch.bfloat16"),  # E2_M2 hbl/tb=1.499x CI95=[1.496, 1.504]
+})
+
+# K-1231 / K-1205 E_N3 N-axis extension admits.  Productionised on top of
+# K-1216's stacked dispatch chain (fix/K-1209-stacked @ fb9461f).  Paired
+# n=30 HIP-graph hot-cache validation on rad-mi300x-1 fallback (c42 SSH
+# plane outage continued through K-1216's 10th recurrence and was still
+# refused on the K-1231 verification window) of the N-floor relaxation:
+#   E_N3 := N = 128 (one power-of-2 tier below the natural sub-1024 N floor)
+#           AND K in {256, 768, 1024} (K-1144 K-set held fixed -- NOT a
+#               K-axis relaxation; K-1161/K-1176 already established
+#               K-floor < 256 is NEGATIVE on this cohort)
+#           AND M in K-1121 anchor M-set (mirrored projection per K-1131)
+#           AND bf16
+# returned a clean POSITIVE landing verdict: 8/9 = 88.9% admit, well above
+# the 75% landing threshold, and decisively diverging from K-1161's K-axis
+# NEGATIVE (1/6 = 16.7%) on adjacent cells / same hardware / same protocol
+# -- empirically REFUTING K-1199's analytical (M<->N) symmetry prediction.
+#
+# Mechanistic reading: at extreme aspect ratios with M >> N=128, hipBLASLt's
+# Tensile schedule (wide unroll + many waves) hides the same MFMA-issue-
+# stall bottleneck more aggressively than at K-1121 mid-square N=2048 tiles
+# -- per-cell speedups widen 1.14x-3.25x at N=128 vs 1.16x-1.27x at N=2048.
+# The single rejection EN_K768_S24 (M=4480 K=768 N=128 bf16 hbl/tb=0.967x
+# CI95=[0.94, 1.00]) sits exactly at the K-1142 M-floor; the same small-M
+# Triton-favoured tail surfaced by K-1161 along the K-axis is active here
+# at the M-floor of the K-1121 anchor M-set (R-1205.SMALL-M-TRITON-
+# FAVOURED-TAIL-IS-AXIS-AGNOSTIC-AT-COHORT-M-FLOOR).  The strict-equality
+# posture EXCLUDES this false positive by construction (carve-out by
+# omission); see K1205_EN3_REJECTED_1_LIST in the pin tests for an
+# explicit no-leak regression trap.
+#
+# Strict-equality only (R-1131 / R-1175): no parametric envelope -- each
+# cell was directly measured at paired n=30 with hbl/tb >= 1.144x and
+# CI95-lo > 1.05x.  N=128 keeps the four sub-frozensets pairwise disjoint
+# by construction (no prior P8 cell has N < 896).
+_K1205_EN3_ADMITS_8 = frozenset({
+    # ----- N=128 K=1024 cluster (5 admits; speedups 1.37x-3.25x) -----
+    ( 6016,  128, 1024, "torch.bfloat16"),  # EN_K1024_S25 hbl/tb=1.370x CI95=[1.362, 1.374]
+    ( 8064,  128, 1024, "torch.bfloat16"),  # EN_K1024_S26 hbl/tb=1.402x CI95=[1.396, 1.415]
+    (14208,  128, 1024, "torch.bfloat16"),  # EN_K1024_S29 hbl/tb=3.254x CI95=[3.234, 3.267] (cohort MAX)
+    (16256,  128, 1024, "torch.bfloat16"),  # EN_K1024_S30 hbl/tb=3.024x CI95=[3.011, 3.056]
+    (22400,  128, 1024, "torch.bfloat16"),  # EN_K1024_S33 hbl/tb=2.258x CI95=[2.234, 2.269]
+    # ----- N=128 K=256 cluster (2 admits; extreme-M; speedups 1.14x-1.78x) -----
+    (25600,  128,  256, "torch.bfloat16"),  # EN_K256_S37  hbl/tb=1.144x CI95=[1.140, 1.149] (cohort MIN admit)
+    (49152,  128,  256, "torch.bfloat16"),  # EN_K256_S39  hbl/tb=1.781x CI95=[1.768, 1.803]
+    # ----- N=128 K=768 cluster (1 admit; M=4480 carve-out via omission) -----
+    ( 5972,  128,  768, "torch.bfloat16"),  # EN_K768_S18  hbl/tb=1.227x CI95=[1.226, 1.227]
+    # NOTE: EN_K768_S24 (M=4480 N=128 K=768 bf16 hbl/tb=0.967x) is
+    # DELIBERATELY OMITTED -- this is the K-1205 N-axis false-positive
+    # carve-out at the K-1142 M-floor.  See K1205_EN3_REJECTED_1_LIST
+    # in tests/test_k971_route_predicate.py for the no-leak pin.
+})
+
+# ---------------------------------------------------------------------------
+# K-1219 / K-1240 -- E3 N-floor=256 anchor-projected admits (7 cells).
+# K-1131-style +/-1-power-of-2 N-axis projection of K-1121 PMC anchors
+# {S18, S24, S25, S30, S37, S39} + K-1175 E2_M1 admit, projected to
+# N=256 (one tier below the K-1131 N09 N=896 natural floor).  Per K-1142
+# carve-out, M >= 4480 on every cell.  Validated independently in K-1219
+# (commit f110d64 on fix/K-1219-n256, branch productionised pre-K-1282)
+# at paired n=30 HIP-graph hot-cache MI300X with cohort geomean
+# tb-over-hbl 1.505x; admitted to the unified K-1282 P8 envelope.
+#
+# K-1303 (S-002) layers this set onto the K-1275 baseline (K-1216 stacked
+# dispatch chain @ fb9461f extended by K-1227's _K1205_EN3_ADMITS_8 to
+# 36 cells).  N=256 sits on a disjoint N-axis tier below the K-1131
+# N09 N=896 natural floor and above K-1227's N=128 tier, so the union
+# is pairwise-disjoint with all four prior provenance frozensets by
+# construction (asserted below).
+# ---------------------------------------------------------------------------
+_K1219_E3_NFLOOR256_ADMITS_7 = frozenset({
+    # ----- E3 N=256 anchor-projected admits (M >= 4480 per K-1142) -----
+    ( 5972,  256,  768, "torch.bfloat16"),  # E3_S18_N256
+    ( 4480,  256,  768, "torch.bfloat16"),  # E3_S24_N256
+    ( 6016,  256, 1024, "torch.bfloat16"),  # E3_S25_N256  MI300X tb/hbl 1.215 CI95=[1.206,1.224]
+    (16256,  256, 1024, "torch.bfloat16"),  # E3_S30_N256  MI300X tb/hbl 2.274 CI95=[2.260,2.291]
+    (25600,  256,  256, "torch.bfloat16"),  # E3_S37_N256
+    (49152,  256,  256, "torch.bfloat16"),  # E3_S39_N256
+    (10112,  256, 1024, "torch.bfloat16"),  # E3_E2M1_N256 MI300X tb/hbl 2.926 CI95=[2.911,2.942]
+})
+
+# ---------------------------------------------------------------------------
+# K-1283 / K-1297 (S-002) -- A1 sub-cohort targeted P8 admit-cell extension
+# (8 cells).  K-1283 classified the K-1132 wpeu=1 13-cell residual into A1
+# (LDS-wait-starvation, MFMA-issue-stall dominated) and A2 (occupancy-bound,
+# paired waves ratio >= 1.7) sub-cohorts.  All five A1 *parent* cells (S18,
+# S24, S25, S29 in `_K1121_P8_ANCHORS_13`; N11 in `_K1131_P8_NEIGHBORS_12`)
+# are already routed.  K-1131 only perturbed S32 (A2), S39 (A2), S18 (A1),
+# and S24 (A1) -- leaving S25 and S29 (A1 anchors) with **zero**
+# +/-1-power-of-2 perturbation coverage, plus several un-covered axes on
+# S18 / S24.
+#
+# K-1297 closes the A1-only perturbation gap with a strict-equality
+# extension validated under paired n=30 HIP-graph hot-cache (V2 protocol;
+# see K-1297 PR / fix/K-1283-A1 @ f4cc5cf for the V1-vs-V2 audit).  V2
+# admits 8 cells at CI95-lo > 1.0x on rad-mi300x-1; cohort geomean =
+# 1.389x.  All admits respect the K-1142 M-floor (M >= 4480) and the
+# K-1161 K-floor (K >= 256).
+#
+# K-1322 (S-002) layers this set onto the K-1303 unified envelope (which
+# already contains K-1121 + K-1131 + K-1161 E2 + K-1205 N=128 + K-1219
+# N=256 = 43 cells), growing the unified envelope to 51 cells.  K-1283
+# A1 perturbations are K-1131-style perturbations of A1 anchors that
+# K-1131 itself did NOT enumerate (S25, S29, plus un-covered M/K axes of
+# S18 / S24).  Disjointness with all five prior sub-frozensets is by
+# construction (asserted at module load).
+# ---------------------------------------------------------------------------
+_K1283_A1_PERTURBATIONS_8 = frozenset({
+    # ----- S25 (6016, 2048, 1024) family -- A1 anchor, 5/5 axes admit -----
+    (12032, 2048, 1024, "torch.bfloat16"),  # A1_S25_Mx2
+    ( 6016, 4096, 1024, "torch.bfloat16"),  # A1_S25_Nx2
+    ( 6016, 1024, 1024, "torch.bfloat16"),  # A1_S25_N/2
+    ( 6016, 2048, 2048, "torch.bfloat16"),  # A1_S25_Kx2
+    ( 6016, 2048,  512, "torch.bfloat16"),  # A1_S25_K/2
+    # ----- S29 (14208, 2048, 1024) family -- A1 anchor, 3/6 axes admit -----
+    (28416, 2048, 1024, "torch.bfloat16"),  # A1_S29_Mx2
+    (14208, 4096, 1024, "torch.bfloat16"),  # A1_S29_Nx2
+    (14208, 2048,  512, "torch.bfloat16"),  # A1_S29_K/2
+    # NOTE: 7 K-1297 candidates were rejected (CI95-lo <= 1.0x) under V2
+    # and are DELIBERATELY OMITTED here (S29 boundary rejects, S18_Mx2
+    # noise-floor straddler, S18/S24 K-axis rejects).  See K-1297 PR
+    # body and tests/test_k971_route_predicate.py K-1283 no-leak pins.
+})
+
+# Composed 51-cell P8 envelope (K-1322 unified).  Six named provenance
+# frozensets (K-1121 anchors, K-1131 neighbors, K-1175/K-1161 E2 admits,
+# K-1231/K-1205 E_N3 N=128 admits, K-1219 E3 N=256 admits, K-1283/K-1297
+# A1 perturbations) -- the dispatch path consults the union.  Per
+# R-1144.DUAL-FROZENSET-PROVENANCE and its K-1175 / K-1205 / K-1219 /
+# K-1297 extensions, source-ticket lineage is load-bearing for future
+# reviewers (precedence-inversion debugging, PMC re-classifier work, ADR
+# audits) so each measurement campaign keeps its own named set with a
+# runtime size + pairwise-disjointness check.
+_P8_MFMA_ISSUE_STALL_ROUTEOUT = (
+    _K1121_P8_ANCHORS_13
+    | _K1131_P8_NEIGHBORS_12
+    | _K1161_E2_ADMITS_3
+    | _K1205_EN3_ADMITS_8
+    | _K1219_E3_NFLOOR256_ADMITS_7
+    | _K1283_A1_PERTURBATIONS_8
+)
+assert len(_P8_MFMA_ISSUE_STALL_ROUTEOUT) == 51, (
+    "K-1322 unified P8 envelope must be exactly 51 cells (13 K-1121 "
+    "anchors + 12 K-1131 neighbors + 3 K-1161 E2 admits + 8 K-1205 E_N3 "
+    "N=128 admits + 7 K-1219 E3 N=256 admits + 8 K-1283/K-1297 A1 "
+    "perturbations); a duplicate or stray entry has crept in.")
+# Cross-check: the five sub-sets must be pairwise disjoint by construction.
+# K-1131 perturbed AWAY from K-1121 anchors; K-1161 E2 admits were
+# selected from the K-931 always-uncovered top-40 catalog minus all
+# K-1121 anchors and minus all K-1131 neighbors; K-1205 E_N3 admits use
+# N=128 (no prior P8 cell has N < 896 -- disjointness by N-axis projection);
+# K-1219 E3 admits use N=256 (disjoint from N=128 K-1205 by construction
+# and below the K-1131 N09 N=896 natural floor).
+assert _K1121_P8_ANCHORS_13.isdisjoint(_K1131_P8_NEIGHBORS_12), (
+    "K-1144 P8 anchors and neighbors overlap; K-1131 neighbor generation "
+    "rules require strict disjointness from the 13 K-1121 anchors.")
+assert _K1121_P8_ANCHORS_13.isdisjoint(_K1161_E2_ADMITS_3), (
+    "K-1175 K-1161 E2 admits overlap with K-1121 anchors; the K-1161 "
+    "candidate generator excluded all K-1121 anchors by construction.")
+assert _K1131_P8_NEIGHBORS_12.isdisjoint(_K1161_E2_ADMITS_3), (
+    "K-1175 K-1161 E2 admits overlap with K-1131 neighbors; the K-1161 "
+    "candidate generator excluded all K-1131 neighbors by construction.")
+assert _K1205_EN3_ADMITS_8.isdisjoint(_K1121_P8_ANCHORS_13), (
+    "K-1205 E_N3 admits overlap with K-1121 anchors; E_N3 candidates "
+    "have N=128 by construction and no K-1121 anchor has N=128.")
+assert _K1205_EN3_ADMITS_8.isdisjoint(_K1131_P8_NEIGHBORS_12), (
+    "K-1205 E_N3 admits overlap with K-1131 neighbors; E_N3 candidates "
+    "have N=128 by construction and no K-1131 neighbor has N=128.")
+assert _K1205_EN3_ADMITS_8.isdisjoint(_K1161_E2_ADMITS_3), (
+    "K-1205 E_N3 admits overlap with K-1161 E2 admits; E_N3 candidates "
+    "have N=128 by construction and no K-1161 E2 admit has N=128.")
+# K-1219 (N=256) cross-disjointness with the prior 36-cell envelope.
+assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1121_P8_ANCHORS_13), (
+    "K-1219 E3 N=256 admit overlaps a K-1121 anchor; the K-1131-style "
+    "anchor projection excluded all K-1121 anchors by construction.")
+assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1131_P8_NEIGHBORS_12), (
+    "K-1219 E3 N=256 admit overlaps a K-1131 neighbor; the K-1131 "
+    "perturbation set's smallest N is 896, well above the N=256 tier.")
+assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1161_E2_ADMITS_3), (
+    "K-1219 E3 N=256 admit overlaps a K-1161 E2 admit; the K-1161 "
+    "K-axis admits all sit at N in {1792, 2048}, not N=256.")
+# K-1303 cross-band disjointness: K-1227 N=128 vs K-1219 N=256.
+assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1205_EN3_ADMITS_8), (
+    "K-1303 composition error: K-1219 N=256 admits overlap K-1205 E_N3 "
+    "N=128 admits.  The two campaigns operate on disjoint N axes by "
+    "construction; an overlap indicates an authoring typo in one of "
+    "the two frozensets.")
+# K-1322 / K-1297 A1 cross-disjointness with the prior five sub-frozensets.
+# K-1283 A1 perturbations are perturbations of A1 anchors that K-1131 did
+# not enumerate; their N values are in {1024, 2048, 4096} (S25/S29 family),
+# overlapping the K-1131 / K-1121 N axis (N in {896, 1024, 2048}) on the N
+# coordinate but always differing on (M, K) by construction.  N=128 / N=256
+# tiers (K-1205 / K-1219) are trivially disjoint.
+assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1121_P8_ANCHORS_13), (
+    "K-1283 A1 perturbation overlaps a K-1121 anchor; the K-1131-style "
+    "+/-1-power-of-2 perturbation generator excludes the parent anchor "
+    "by construction.")
+assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1131_P8_NEIGHBORS_12), (
+    "K-1283 A1 perturbation overlaps a K-1131 neighbor; K-1297 selected "
+    "only A1-anchor perturbations on axes K-1131 did NOT enumerate (S25, "
+    "S29, plus un-covered M/K axes of S18/S24).")
+assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1161_E2_ADMITS_3), (
+    "K-1283 A1 perturbation overlaps a K-1161 E2 admit; the three E2 "
+    "admits ({(736,1792,736), (10112,2048,1024), (12160,2048,1024)}) are "
+    "structurally distinct from the K-1297 A1 perturbation cells.")
+assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1205_EN3_ADMITS_8), (
+    "K-1283 A1 perturbation overlaps a K-1205 E_N3 admit; K-1297 cells "
+    "all have N >= 1024; K-1205 cells all have N=128.")
+assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1219_E3_NFLOOR256_ADMITS_7), (
+    "K-1283 A1 perturbation overlaps a K-1219 E3 N=256 admit; K-1297 "
+    "cells all have N >= 1024; K-1219 cells all have N=256.")
+# K-1335 cross-predicate disjointness: K-1335 longK_smallSquare admits live
+# on the LDS-BC `K971_ROUTE_TABLE` (5th-position dispatch predicate) and
+# MUST NOT collide with any K-1322 P8 sub-frozenset.  K-1335 cells have
+# M=N∈{1024,2048} and K∈{4096,8192}; every K-1322 P8 sub-frozenset's M-axis
+# floor or N-axis selector excludes this region by construction (K-1121 /
+# K-1131 / K-1161 / K-1283 use M >= 4480 with shape constraints; K-1205
+# uses N=128; K-1219 uses N=256).  Disjointness is asserted on the
+# (M,N,K,dtype) tuple after stripping the dtype back to a 4-tuple
+# representation since both frozensets share the same key shape.
+_K1335_VS_P8_DISJOINT = _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4.isdisjoint(
+    _P8_MFMA_ISSUE_STALL_ROUTEOUT)
+assert _K1335_VS_P8_DISJOINT, (
+    "K-1335 longK_smallSquare admit overlaps the K-1322 51-cell P8 "
+    "MFMA-issue-stall envelope; the two predicates target distinct "
+    "hardware bottlenecks (LDS-BC vs MFMA-issue-stall per K-913 / "
+    "K-1326 / R-1329) and must remain disjoint by construction.")
+
+
+# ---------------------------------------------------------------------------
+# K-1209-stacked / K-1216 (S-002): E1 axis-aligned envelope productionised
+# from K-1151 / K-1142 stacked AFTER the P8 28-cell strict-equality route.
+# K-1209 ablation on K-931 always-uncovered top-40 confirmed E1 is fully
+# dominated by P8+K-1175 on this cohort (0 marginal cells, 0 marginal FPs);
+# E1 is retained as defense-in-depth for cohorts beyond K-931 where the
+# audit chain has not yet enumerated every K-1142-envelope-admittable cell.
+# E1 ships with the K-1142 (M >= 4480) ∧ (K >= 256) carve-out which holds
+# at 0 FPs across all 4 stacked configurations on K-931 top-40 (K-1209).
+# E2 K-floor=128 is EXCLUDED per K-1176 cross-arch failure (0/8 cells on
+# MI325X/MI355X) — no K-axis relaxation past K=256.
+# ---------------------------------------------------------------------------
+K1142_E1_NS = frozenset({1792, 2048, 3072})
+K1142_E1_KS = frozenset({256, 768, 1024})
+K1142_E1_M_FLOOR = 4480  # K-1121 anchor S24's M (margin 0; excludes FP1=256x2048x256)
+K1142_E1_K_FLOOR = 256   # K-1161 NEGATIVE_AXIS_PIVOT pin; do NOT relax to 128
+
+
+def R_K1142_E1_route_to_hbl(M: int, N: int, K: int, dtype) -> bool:
+    """K-1151 E1 envelope route-OUT — bf16 ∧ N∈{1792,2048,3072} ∧
+    K∈{256,768,1024} ∧ M≥4480 ∧ K≥256. Stacked AFTER P8 in K-1209-stacked
+    so P8 wins on overlap (no double-routing); E1 only fires on cells P8
+    does not already enumerate. K-1209 confirmed 0 marginal coverage on
+    K-931 top-40 beyond P8+K-1175 — E1 is defense-in-depth for non-K-931
+    catalogs where the audit chain has not converged.
+    """
+    if not _dtype_is_bf16(dtype):
+        return False
+    if N not in K1142_E1_NS or K not in K1142_E1_KS:
+        return False
+    if M < K1142_E1_M_FLOOR or K < K1142_E1_K_FLOOR:
+        return False
+    return True
+
+
+def _p8_mfma_issue_stall_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1144 P8 (extended by K-1175 / K-1231-K-1205 / K-1219 / K-1297 --
+    unified in K-1303 then K-1322) — direct hipBLASLt route-OUT for the
+    sextuply-validated MFMA-issue-stall cohort (K-1121 anchors + K-1131
+    neighbors + K-1175/K-1161 E2 admits + K-1231/K-1205 E_N3 N=128 admits +
+    K-1219 E3 N=256 admits + K-1283/K-1297 A1 perturbations).
+
+    Returns True iff (M, N, K, dtype) matches one of the 51 strict-equality
+    keys in :data:`_P8_MFMA_ISSUE_STALL_ROUTEOUT`.  bf16-only by design
+    (the entire K-1121 / K-1131 source measurement scope is bf16; fp16
+    parity is tracked separately on the K-1093 / K-1125 line).
+
+    This predicate is consulted **before** the K-1089 P6 admit-back-to-
+    kernel check inside ``_k971_route_to_hbl`` so K-1121's measurement
+    evidence (hipBLASLt wins on S24, S29 at ~1.20x, ~1.22x respectively)
+    overrides the K-1089 envelope admit for the small subset of cells
+    where the two envelopes overlap (S24 and S29 inside P6 Env-B and
+    Env-A; K-1131 N11 inside P6 Env-B).  K-1074's paired n=30 LAND audit
+    plus K-1098's clause-by-clause backtest established that the K-1089
+    admit was falsified for these cells -- P8 codifies the correction.
+
+    For cells that are NOT in any P6 envelope, P8's strict-equality match
+    is functionally identical to the existing P5 Clause-2 route-OUT
+    decision (both return True -> route to hipBLASLt).  The dispatch
+    outcome is unchanged for those cells; P8 just makes the routing
+    rationale source-of-truth attributable to the K-1121 + K-1131
+    measurement campaign rather than P5's structural pathology heuristic.
+    """
+    if not _dtype_is_bf16(dtype):
+        return False
+    return (int(M), int(N), int(K), str(dtype)) in _P8_MFMA_ISSUE_STALL_ROUTEOUT
+
+
+# ---------------------------------------------------------------------------
+# K-1361 (S-002) — P12 `square_mid` PMC-driven route-OUT (6th-position envelope).
+#
+# K-1361 productionises K-1345's Predicate-Q (square_mid 2048³) and Predicate-R
+# (square_mid 4096³) as a 4-cell strict-equality frozenset
+# `_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4`, layered as the 6th-position envelope
+# in the dispatch precedence chain ABOVE the K971 LDS-BC table (5th-position)
+# and BELOW the new K-1367 P13 skinny_N128 K-COMPLEMENT (7th-position).
+#
+# Source measurement chain:
+#   * S1 (2048³ bf16): K-1295 paired n=30 + K-877 S1b direct PMC anchor
+#                      (LDS_BC 0.889 cyc/inst, MFMA% gap 1.25 pp).
+#   * S2 (4096³ bf16): K-1295 paired n=30 + K-913 §3 5-anchor PMC triangulation
+#                      (K-655 / K-818 C2 / K-837 N1a / N1b / K-879).
+#   * S1f (2048³ fp16): K-877 S1a direct fp16 PMC anchor (LDS_BC 0.889,
+#                       MFMA% gap 1.27 pp) + K-1295 inheritance via K-913 §3
+#                       dtype invariance.
+#   * S2f (4096³ fp16): K-913 §3 dtype invariance from S1f extended to 4096³
+#                       (INFERRED-DTYPE-PAIR; no direct 4096³ fp16 anchor).
+# 8192³ bf16 is DROP'd (K-1308 F4 HBM-bound, K-879 N2a confirms zero LDS_BC
+# on both engines; out of route-OUT scope per
+# R-1345.HBM-ASYMPTOTE-BOUND-IS-NOT-PREDICATE-ADDRESSABLE).
+#
+# Bucket-rule scoping (per K-1345 RANKED_BUCKETS_v2 authoritative diagonal-only
+# rule, NOT the PRD textual 4-combo enumeration): square_mid = M==N==K diagonal
+# in {2048,4096}; off-diagonal combos (e.g. M=N=2048, K=4096) belong to K-1313
+# WIDE bucket already P10-covered — admitting them would violate A4
+# no-double-admit.  RETRY iteration=2 corrected the PRD ambiguity per
+# R-1361.PRD-TEXTUAL-ENUMERATION-MUST-RESOLVE-AGAINST-AUTHORITATIVE-BUCKET-RULE.
+#
+# Verification (paired n=30 inherited from K-1295; PMC anchors direct + 5-anchor
+# triangulation; B=10000 paired bootstrap CI95):
+#   S1  bf16 paired tb/hbl med 0.258 [0.257, 0.260]  inv 3.87×  ROUTE-OUT
+#   S2  bf16 paired tb/hbl med 0.550 [0.544, 0.552]  inv 1.82×  ROUTE-OUT
+#   S1f fp16 paired tb/hbl med 0.258 (n/a-INFERRED)  inv 3.87×  ROUTE-OUT-INFERRED
+#   S2f fp16 paired tb/hbl med 0.550 (n/a-INFERRED)  inv 1.82×  ROUTE-OUT-INFERRED
+#
+# Disjointness: P12 cells (M=N=K∈{2048,4096}, both dtypes) are pairwise disjoint
+# with all P8 sub-frozensets (P8 uses M≥4480 for K-1121/K-1131/K-1161/K-1283 or
+# fixed N∈{128,256} for K-1205/K-1219), with K971_ROUTE_TABLE (which uses
+# K∈{16384,32768}, while P12 uses K∈{2048,4096}), and with K-1335 (K-1335 uses
+# K∈{4096,8192} with M=N∈{1024,2048}; the only shape-collision candidate is
+# (2048,2048,4096,bf16) which IS in K-1335 — by construction P12 omits this
+# diagonal anchor since it is already route-OUT'd at the 5th position).
+# ---------------------------------------------------------------------------
+_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4 = frozenset({
+    # S1: 2048³ bf16 — K-877 S1b direct PMC anchor + K-1295 paired n=30
+    (2048, 2048, 2048, "torch.bfloat16"),
+    # S2: 4096³ bf16 — K-913 §3 5-anchor triangulation + K-1295 paired n=30
+    (4096, 4096, 4096, "torch.bfloat16"),
+    # S1f: 2048³ fp16 — K-877 S1a direct fp16 anchor + K-913 §3 inheritance
+    (2048, 2048, 2048, "torch.float16"),
+    # S2f: 4096³ fp16 — INFERRED-DTYPE-PAIR (K-913 §3 from S1f, no 4096³ fp16 anchor)
+    (4096, 4096, 4096, "torch.float16"),
+})
+assert len(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4) == 4, (
+    "K-1361 P12 square_mid frozenset must be exactly 4 cells (S1, S2, S1f, S2f); "
+    "any deviation indicates an authoring typo against the K-1345 "
+    "RANKED_BUCKETS_v2 diagonal-only authoritative bucket rule.")
+# Cross-frozenset disjointness — P12 vs prior envelopes.
+_K1361_P12_VS_P8_DISJOINT = (
+    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+assert _K1361_P12_VS_P8_DISJOINT, (
+    "K-1361 P12 square_mid cell overlaps the K-1322 51-cell P8 envelope; "
+    "P8 sub-frozensets gate on M >= 4480 (K-1121/K-1131/K-1161/K-1283) or "
+    "fixed N ∈ {128, 256} (K-1205/K-1219), neither of which can match "
+    "M=N=K ∈ {2048, 4096}. Investigate before relaxing this assert.")
+_K1361_P12_VS_K971_DISJOINT = (
+    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4.isdisjoint(K971_ROUTE_TABLE))
+assert _K1361_P12_VS_K971_DISJOINT, (
+    "K-1361 P12 square_mid cell overlaps K971_ROUTE_TABLE; K971 (K-905/K-971 "
+    "anchors + K-1335 longK_smallSquare) covers K ∈ {4096, 8192, 16384, 32768} "
+    "with M=N ∈ {1024, 2048}; P12's M=N=K ∈ {2048, 4096} diagonal does not "
+    "intersect that K-axis range with M=N=4096 and excludes the K-1335 "
+    "(2048,2048,4096) cell by construction (already 5th-position route-OUT).")
+
+
+def _k1361_p12_square_mid_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1361 P12 — direct hipBLASLt route-OUT for the 4-cell square_mid
+    PMC-driven cohort (`_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 4 strict-equality
+    keys: M=N=K ∈ {2048, 4096} × dtype ∈ {bf16, fp16}.
+
+    Source measurement quality varies per cell (MEASURED-DIRECT for S1 + S1f
+    via K-877; MEASURED-VIA-TRIANGULATION for S2 via K-913 §3 5-anchor;
+    INFERRED-DTYPE-PAIR for S2f via K-913 §3 dtype invariance from S1f).
+    The runtime predicate behaviour is identical for all 4 cells; the
+    quality grading is preserved as comments + the K-1361-FOLLOW-A0 fresh
+    capture remediation.
+
+    Stacked AFTER K971_ROUTE_TABLE (5th-position) and BEFORE K-1367 P13
+    skinny_N128 K-COMPLEMENT (7th-position) per K-1175 stacked-predicate
+    convention.  Disjoint by construction with all P1–P11 sub-frozensets
+    via the cross-frozenset asserts above.
+    """
+    return (int(M), int(N), int(K), str(dtype)) in _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
+
+
+# ---------------------------------------------------------------------------
+# K-1367 (S-002) — P13 `skinny_N128` K-COMPLEMENT route-OUT (7th-position).
+#
+# K-1379 productionises the K-1367 RETRY-winning 18-cell cohort as
+# `_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18`, layered as the
+# 7th-position envelope in the dispatch precedence chain on top of the
+# K-1361 P12 55-cell baseline (envelope grows 55 → 73 cells; +18 admits).
+#
+# Bucket scope: K-1308's 4-bucket residual decomposition surfaced
+# `skinny_N128` (raw aggregate gap 3.294) as the rank-#1 predicate-addressable
+# residual; K-1345 demoted it to "wrapper-bound, already covered by K-1227's
+# N=128 envelope".  K-1367 then proved that the demotion is K-bounded: at
+# K ≥ 4096, TB compute time dominates the ~30 µs `triton_op` wrapper-overhead
+# ceiling and the wrapper-bound argument no longer applies (codified as
+# R-1367.WRAPPER-OVERHEAD-CEILING-DISAPPEARS-AT-LARGE-K-WHERE-TB-TIME-DOMINATES-30US-TRITONOP).
+# The 18-cell K-COMPLEMENT region is exactly that K ≥ 4096 sub-region of the
+# `skinny_N128` bucket K-1227 does NOT already cover.
+#
+# K-COMPLEMENT region:
+#   M ∈ {2048, 4096, 8192}  (3 anchors)
+#   N = 128                  (column-narrow regime)
+#   K ∈ {4096, 8192, 16384}  (above the 30 µs wrapper-overhead ceiling)
+#   dtype ∈ {bf16, fp16}     (K-913 §3 dtype invariance for both)
+# = 3 × 1 × 3 × 2 = 18 cells.
+#
+# PMC mechanism (rocprofv3 4-pass capture on 7 representative cells):
+#   TB persistent_matmul SQ_LDS_BANK_CONFLICT/inst ≈ 1.45
+#   HBL Cijk_*           SQ_LDS_BANK_CONFLICT/inst = 0     (sharp discriminator)
+#   n_dispatches = 22 per (cell, engine)  (positive-filter-check passed; the
+#                                          HBL LDS_BC=0 is real measurement,
+#                                          not a silent kernel-name-filter miss)
+# This is the SAME K-913 §3 LDS-bank-conflict mechanism that anchored K-1335
+# / K-1338 / K-1361, specialised to the N=128 column-narrow regime.  The
+# persistent_matmul tile pattern systematically conflicts on bf16/fp16 N=128
+# LDS layouts; hipBLASLt's tile selection avoids the bank-conflict geometry
+# entirely.  Codified as
+# R-1367.K913-LDS-BC-MECHANISM-IS-SHARPLY-DISCRIMINATING-FOR-SKINNY-N128.
+#
+# Verification (paired n=30 HIP-graph hot-cache, B=10000 vectorised paired
+# bootstrap CI95 — vectorised per R-1367.VECTORIZED-BOOTSTRAP-IS-DEFAULT-VALIDATION-GATE):
+#   18/18 ROUTE-OUT  (every cell CI95-lo > 1.0)
+#   cohort geomean tb/hbl = 1.678×        (HBL is 1.678× faster ⇒ route-OUT win)
+#   min CI95-lo            = 1.124         (worst cell still strictly route-OUT)
+#   no regressions on the 55-cell K-1361 P12 envelope (paired-arm stable)
+#
+# Projected K-1247 cohort lift: the 18-cell K-COMPLEMENT cohort is fully
+# inside the K-1247 61-cell backtest corpus; cohort geomean 1.678× contributes
+# directly to the realisable cohort lift; measurement deferred to
+# K-1367-FOLLOW-B once the productionised branch is on dedicated MI300X.
+#
+# Why N=128 is hipBLASLt-favoured (mechanistic — answers task brief Q3):
+#   The MFMA tile efficiency threshold for the persistent_matmul kernel sits
+#   at N >= 256 for waves_per_CU >= 2; at N=128 the column-narrow tile under-
+#   utilises the MFMA throughput and incurs systematic LDS-bank-conflicts on
+#   the persistent tile schedule (TB SQ_LDS_BC/inst ≈ 1.45 vs HBL = 0).  At
+#   K >= 4096 the compute time amortises the wrapper-overhead floor, so the
+#   raw HBL win (1.678× cohort geomean) is realisable end-to-end.
+#
+# Disjointness: P13 cells use N=128, M ∈ {2048, 4096, 8192}, K ∈ {4096, 8192,
+# 16384}.  Disjoint with:
+#   * P8 sub-frozensets — K-1121/K-1131/K-1161/K-1283 use M ≥ 4480 (P13
+#     allows M ≥ 2048; would collide on M ∈ {4096, 8192} but those P8 cohorts
+#     never use N=128); K-1205 uses N=128 BUT K ∈ {2048, 8192} with M ≥ 4480;
+#     the only on-paper collision candidates are M=8192,N=128,K=8192 cells;
+#     verified disjoint by frozenset.isdisjoint at module load.
+#   * K971_ROUTE_TABLE — K-905/K-971 anchors use M=N ∈ {1024, 2048};
+#     K-1335 uses M=N ∈ {1024, 2048} with K ∈ {4096, 8192}; neither has
+#     N=128, so no collision.
+#   * K-1361 P12 — uses M=N=K ∈ {2048, 4096} with N != 128; no collision.
+# All asserted at module load.
+# ---------------------------------------------------------------------------
+_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 = frozenset({
+    # M=2048 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (2048, 128,  4096, "torch.bfloat16"),
+    (2048, 128,  4096, "torch.float16"),
+    (2048, 128,  8192, "torch.bfloat16"),
+    (2048, 128,  8192, "torch.float16"),
+    (2048, 128, 16384, "torch.bfloat16"),
+    (2048, 128, 16384, "torch.float16"),
+    # M=4096 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (4096, 128,  4096, "torch.bfloat16"),
+    (4096, 128,  4096, "torch.float16"),
+    (4096, 128,  8192, "torch.bfloat16"),
+    (4096, 128,  8192, "torch.float16"),
+    (4096, 128, 16384, "torch.bfloat16"),
+    (4096, 128, 16384, "torch.float16"),
+    # M=8192 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (8192, 128,  4096, "torch.bfloat16"),
+    (8192, 128,  4096, "torch.float16"),
+    (8192, 128,  8192, "torch.bfloat16"),
+    (8192, 128,  8192, "torch.float16"),
+    (8192, 128, 16384, "torch.bfloat16"),
+    (8192, 128, 16384, "torch.float16"),
+})
+assert len(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18) == 18, (
+    "K-1367 P13 skinny_N128 K-COMPLEMENT frozenset must be exactly 18 cells "
+    "(M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,8192,16384} × {bf16,fp16}); "
+    "any deviation indicates an authoring typo against the K-1308 bucket rule "
+    "or the K-1227 wrapper-bound K-COMPLEMENT scoping.")
+# Cross-frozenset disjointness — P13 vs prior envelopes.
+_K1367_P13_VS_P8_DISJOINT = (
+    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+assert _K1367_P13_VS_P8_DISJOINT, (
+    "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps the K-1322 51-cell P8 "
+    "envelope; P8's K-1205 N=128 sub-frozenset uses K ∈ {2048, 8192} with "
+    "M ≥ 4480 — no admitted P13 cell satisfies BOTH selectors simultaneously "
+    "(P13 K=8192 cells exist at M ∈ {2048, 4096, 8192} but K-1205 specific "
+    "tuples must be enumerated to overlap; disjointness verified by frozenset "
+    "intersection at module load).")
+_K1367_P13_VS_K971_DISJOINT = (
+    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE))
+assert _K1367_P13_VS_K971_DISJOINT, (
+    "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps K971_ROUTE_TABLE; "
+    "K971_ROUTE_TABLE (K-905/K-971 + K-1335) uses M=N ∈ {1024, 2048}; "
+    "P13 cells all use N=128 — natural disjointness, but assert as cheap "
+    "insurance per R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.")
+_K1367_P13_VS_P12_DISJOINT = (
+    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
+assert _K1367_P13_VS_P12_DISJOINT, (
+    "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps K-1361 P12 square_mid; "
+    "P12 cells use M=N=K ∈ {2048, 4096}; P13 cells all use N=128 — natural "
+    "disjointness, asserted for completeness (A4 no-double-admit).")
+
+
+def _k1367_p13_skinny_n128_kcomplement_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1367 P13 — direct hipBLASLt route-OUT for the 18-cell skinny_N128
+    K-COMPLEMENT cohort (`_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 18 strict-equality
+    keys: M ∈ {2048, 4096, 8192} × N = 128 × K ∈ {4096, 8192, 16384} ×
+    dtype ∈ {torch.bfloat16, torch.float16}.
+
+    Source measurement: paired n=30 HIP-graph hot-cache benchmarks on
+    MI300X / gfx942 with B=10000 vectorised paired bootstrap (numpy
+    advanced-indexing per R-1298 / R-1367); 18/18 ROUTE-OUT, cohort geomean
+    tb/hbl = 1.678×, min CI95-lo = 1.124.  PMC mechanism confirmed via
+    rocprofv3 4-pass capture on 7 representative cells (TB SQ_LDS_BC/inst
+    ≈ 1.45 vs HBL = 0; positive-filter-check + fail-loud sweep verified
+    HBL LDS_BC = 0 is real measurement).
+
+    Stacked LAST (7th-position) per K-1175 stacked-predicate convention;
+    disjoint by construction with all P1–P12 sub-frozensets via the
+    cross-frozenset asserts above.
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18
+    )
+
+
+def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
+                        work_stealing, disable_env_set: bool = False) -> bool:
+    """Pure routing decision — same logic as ``matmul._k971_route_to_hbl``
+    but without reading the environment (caller passes ``disable_env_set``).
+
+    Useful for tests that want to exercise the *full* dispatch decision
+    (predicate + strict-equality + streamk/work-stealing/dtype carve-outs)
+    without monkey-patching ``os.environ``.
+
+    Precedence (top-down, first match wins):
+      1. K-1144 P8 strict-equality MFMA-issue-stall route-OUT (overrides
+         K-1089 P6 admit for S24/S29/N11; identity for cells already
+         routed by P5; see _p8_mfma_issue_stall_routeout docstring).
+      2. K-1151 / K-1142 E1 axis-aligned envelope route-OUT (defense-in-depth
+         after P8; K-1209 ablation 0-marginal on K-931 top-40).
+      3. K-1089 P6 admit gate -> in-kernel wpeu=1 dispatch (returns False
+         from this function so caller falls through to in-kernel).
+      4. K-1066 R-K979 P5 closed-form structural pathology -> hipBLASLt.
+      5. K-905 / K-971 / K-1335 strict-equality LDS-BC anchor table -> hipBLASLt.
+      6. K-1361 P12 square_mid 4-cell strict-equality -> hipBLASLt.
+      7. K-1367 P13 skinny_N128 K-COMPLEMENT 18-cell strict-equality -> hipBLASLt.
+    """
+    if disable_env_set:
+        return False
+    if enable_streamk or work_stealing or str(a_dtype) != str(b_dtype):
+        return False
+    # K-1144 + K-1175 + K-1231/K-1205 + K-1219 + K-1297 (K-1322 unified):
+    # P8 51-cell strict-equality (13 K-1121 anchors + 12 K-1131 neighbors +
+    # 3 K-1161 E2 admits + 8 K-1205 E_N3 N=128 admits + 7 K-1219 E3
+    # N=256 admits + 8 K-1283/K-1297 A1 perturbations) takes precedence
+    # over P6 admit so K-1121's paired n=30 evidence overrides K-1089
+    # envelope admit for the S24/S29/N11 overlap.  K-1205's 8 N=128 and
+    # K-1219's 7 N=256 additions are disjoint from K-1089 P6 envelope
+    # (P6 has no N<896 cells); K-1297's 8 A1 perturbations are S25/S29
+    # K-1131-style perturbations, structurally identical to K-1131's
+    # routing rationale.
+    if _p8_mfma_issue_stall_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1209-stacked / K-1216: E1 axis-aligned envelope as defense-in-depth
+    # AFTER P8. K-1209 ablation showed E1 is fully dominated by P8+K-1175 on
+    # K-931 top-40 (0 marginal cells / 0 marginal FPs); E1 only fires on
+    # non-K-931 cohort cells the K-1142->K-1161->K-1175 audit chain has not
+    # yet enumerated. E2 K-floor=128 EXCLUDED (K-1176 cross-arch failure).
+    if R_K1142_E1_route_to_hbl(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1089: P6 admit overrides P5 route-OUT for MFMA-stall structural
+    # signature; cells fall through to in-kernel dispatch.
+    if R_K1037_P6_admit_wpeu1(int(M), int(N), int(K), a_dtype):
+        return False
+    if R_K979_P5_route_to_hbl(int(M), int(N), int(K), a_dtype):
+        return True
+    if (int(M), int(N), int(K), str(a_dtype)) in K971_ROUTE_TABLE:
+        return True
+    # K-1361 P12 (6th-position): square_mid PMC-driven 4-cell route-OUT.
+    # Stacks AFTER K971_ROUTE_TABLE per K-1175 stacked-predicate convention.
+    if _k1361_p12_square_mid_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1367 P13 (7th-position): skinny_N128 K-COMPLEMENT 18-cell route-OUT.
+    # Stacks AFTER K-1361 P12 per K-1175 stacked-predicate convention; closes
+    # the K-1308 skinny_N128 K-COMPLEMENT region (K >= 4096 above the 30 µs
+    # triton_op wrapper-overhead ceiling) at cohort geomean tb/hbl = 1.678×.
+    if _k1367_p13_skinny_n128_kcomplement_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -938,7 +938,7 @@ def _k1361_p12_square_mid_routeout(M: int, N: int, K: int, dtype) -> bool:
 # K-1367 (S-002) — P13 `skinny_N128` K-COMPLEMENT route-OUT (7th-position).
 #
 # K-1379 productionises the K-1367 RETRY-winning 18-cell cohort as
-# `_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18`, layered as the
+# `_K1367_P13_SKINNY_N128_ROUTEOUT_18`, layered as the
 # 7th-position envelope in the dispatch precedence chain on top of the
 # K-1361 P12 55-cell baseline (envelope grows 55 → 73 cells; +18 admits).
 #
@@ -1005,7 +1005,7 @@ def _k1361_p12_square_mid_routeout(M: int, N: int, K: int, dtype) -> bool:
 #   * K-1361 P12 — uses M=N=K ∈ {2048, 4096} with N != 128; no collision.
 # All asserted at module load.
 # ---------------------------------------------------------------------------
-_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 = frozenset({
+_K1367_P13_SKINNY_N128_ROUTEOUT_18 = frozenset({
     # M=2048 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
     (2048, 128,  4096, "torch.bfloat16"),
     (2048, 128,  4096, "torch.float16"),
@@ -1028,14 +1028,14 @@ _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 = frozenset({
     (8192, 128, 16384, "torch.bfloat16"),
     (8192, 128, 16384, "torch.float16"),
 })
-assert len(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18) == 18, (
+assert len(_K1367_P13_SKINNY_N128_ROUTEOUT_18) == 18, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT frozenset must be exactly 18 cells "
     "(M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,8192,16384} × {bf16,fp16}); "
     "any deviation indicates an authoring typo against the K-1308 bucket rule "
     "or the K-1227 wrapper-bound K-COMPLEMENT scoping.")
 # Cross-frozenset disjointness — P13 vs prior envelopes.
 _K1367_P13_VS_P8_DISJOINT = (
-    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+    _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
 assert _K1367_P13_VS_P8_DISJOINT, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps the K-1322 51-cell P8 "
     "envelope; P8's K-1205 N=128 sub-frozenset uses K ∈ {2048, 8192} with "
@@ -1044,23 +1044,23 @@ assert _K1367_P13_VS_P8_DISJOINT, (
     "tuples must be enumerated to overlap; disjointness verified by frozenset "
     "intersection at module load).")
 _K1367_P13_VS_K971_DISJOINT = (
-    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE))
+    _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE))
 assert _K1367_P13_VS_K971_DISJOINT, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps K971_ROUTE_TABLE; "
     "K971_ROUTE_TABLE (K-905/K-971 + K-1335) uses M=N ∈ {1024, 2048}; "
     "P13 cells all use N=128 — natural disjointness, but assert as cheap "
     "insurance per R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.")
 _K1367_P13_VS_P12_DISJOINT = (
-    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
+    _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
 assert _K1367_P13_VS_P12_DISJOINT, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps K-1361 P12 square_mid; "
     "P12 cells use M=N=K ∈ {2048, 4096}; P13 cells all use N=128 — natural "
     "disjointness, asserted for completeness (A4 no-double-admit).")
 
 
-def _k1367_p13_skinny_n128_kcomplement_routeout(M: int, N: int, K: int, dtype) -> bool:
+def _k1367_p13_skinny_n128_routeout(M: int, N: int, K: int, dtype) -> bool:
     """K-1367 P13 — direct hipBLASLt route-OUT for the 18-cell skinny_N128
-    K-COMPLEMENT cohort (`_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18`).
+    K-COMPLEMENT cohort (`_K1367_P13_SKINNY_N128_ROUTEOUT_18`).
 
     Returns True iff (M, N, K, dtype) matches one of the 18 strict-equality
     keys: M ∈ {2048, 4096, 8192} × N = 128 × K ∈ {4096, 8192, 16384} ×
@@ -1080,7 +1080,7 @@ def _k1367_p13_skinny_n128_kcomplement_routeout(M: int, N: int, K: int, dtype) -
     """
     return (
         (int(M), int(N), int(K), str(dtype))
-        in _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18
+        in _K1367_P13_SKINNY_N128_ROUTEOUT_18
     )
 
 
@@ -1145,6 +1145,6 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # Stacks AFTER K-1361 P12 per K-1175 stacked-predicate convention; closes
     # the K-1308 skinny_N128 K-COMPLEMENT region (K >= 4096 above the 30 µs
     # triton_op wrapper-overhead ceiling) at cohort geomean tb/hbl = 1.678×.
-    if _k1367_p13_skinny_n128_kcomplement_routeout(int(M), int(N), int(K), a_dtype):
+    if _k1367_p13_skinny_n128_routeout(int(M), int(N), int(K), a_dtype):
         return True
     return False

--- a/include/tritonblas/guarded_override.py
+++ b/include/tritonblas/guarded_override.py
@@ -1,0 +1,922 @@
+"""Guarded-override harness — reusable pre-merge gate for narrow tile overrides.
+
+K-883 analyzed why narrow-cohort overrides keep failing to generalize
+(K-836->K-851->K-854->K-864->K-867->K-874 NO-LAND streak) and produced a
+9-layer "guarded-override" design pattern. This module operationalizes that
+pattern as a Python API: every future narrow override (env-gated cohort
+override, strict-equality tile table, etc.) wraps itself in this harness so
+it cannot land without passing the K-883 §5 acceptance gates.
+
+The harness has three responsibilities:
+
+  1.  Strict-key gating.  Wrap a candidate override behind a strict-equality
+      shape-key gate (M, N, K, dtype[, batch]).  Defends against range-predicate
+      bleed (the K-654 87% OOC regression failure mode).  Layers 1-6 of the
+      K-883 pattern are enforced structurally:
+
+        L1 strict-equality dispatch table on (M,N,K,dtype[,batch])
+        L2 dtype allowlist guard
+        L3 env-var killswitch read every call (paired-audit hook)
+        L4 LDS-budget guard at call-site (default 64KB; arch-overridable)
+        L5 composability guard (e.g. work_stealing)
+        L6 routing-trace counters (fire_total / nonfire_total / per-key)
+
+  2.  Paired ON/OFF benchmarking.  Run any registered override through the
+      K-867 paired-interleaved single-process HIP-graph kernel-only protocol
+      against the composite-14 baseline AND a third reference (default
+      hipBLASLt) on c42 / MI300X.  n>=30 paired replicates, kernel-only,
+      shared-allocator state, CUDA-event timing per replay.  Per-cell
+      paired_t deltas + 95% CIs.
+
+  3.  Verdict.  Apply the K-883 §5 LAND/NO-LAND gates:
+
+        in-cohort:  geomean ON vs OFF >= +5%, 8/10 cells net-positive
+        out-of-cohort (K-790 92-shape gap profile + K-832 production sample):
+          0 cells regress beyond max(2pp, paired_spread/2)
+        routing trace: per-key fires == cohort enumeration (1:1, 0 OOC)
+
+A PR with all gates GREEN is empirically very unlikely to leak (K-835 v3 /
+K-867 verification template).  A PR with any gate RED is NO-LAND.
+
+Usage:
+
+    from tritonblas.guarded_override import (
+        GuardedOverride, OverrideRegistry, run_falsification,
+    )
+
+    # Define a candidate override (this lives in CI / on the author's
+    # branch — NEVER in the production tree until run_falsification(...)
+    # returns LAND).
+    GUARD = GuardedOverride(
+        ticket="K-XYZ",
+        env_var="TB_KXYZ_ENABLE",
+        cohort_keys=[(2048, 2048, 4096, torch.float16), ...],
+        dtype_allowlist=(torch.float16, torch.bfloat16),
+        override_fn=lambda M, N, K, dtype: {"num_stages": 2, ...},
+    )
+    OverrideRegistry.register(GUARD)
+
+    # Pre-merge gate (CI / dev box).
+    verdict = run_falsification(
+        override=GUARD,
+        shapes=load_shapes(...),
+        out_dir="output/",
+        n_rounds=30,                # paired n>=30 (PRD requirement)
+    )
+    assert verdict.land, verdict.report
+
+The harness is dispatcher-host-agnostic.  matmul.py calls
+``OverrideRegistry.apply(M, N, K, dtype, work_stealing, lds_bytes_per_elem)``
+inside ``persistent_matmul_lt`` to merge any active override into the
+tile spec; outside that one call site the rest of the package is
+override-naive.
+
+Author trail: K-883 (design pattern), K-867 (paired-audit harness), K-835 v3
+(reference clean implementation), K-882 (first override exercised against
+this harness, NO-LAND verdict, kept as a fixture in tests/ to guarantee the
+harness keeps catching this class of structural-no-op overrides).
+"""
+
+from __future__ import annotations
+
+import csv
+import gc
+import json
+import math
+import os
+import statistics
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# K-883 Layer 4 — LDS budget per architecture.  Used by the LDS-guard check.
+# Override per-arch via ``set_arch_lds_budget(name, bytes)`` if needed.
+# ---------------------------------------------------------------------------
+_ARCH_LDS_BUDGET: Dict[str, int] = {
+    "gfx942": 65536,   # MI300X / MI300A
+    "gfx950": 65536,   # MI350X / MI355X
+}
+_DEFAULT_LDS_BUDGET = 65536
+
+
+def set_arch_lds_budget(name: str, nbytes: int) -> None:
+    """Override the LDS-budget constant for a given gfx target."""
+    _ARCH_LDS_BUDGET[name] = int(nbytes)
+
+
+def lds_budget_for(arch: Optional[str] = None) -> int:
+    """Return the per-CU LDS budget in bytes for ``arch`` (or default)."""
+    if arch is None:
+        try:
+            dev = torch.cuda.get_device_properties(torch.cuda.current_device())
+            arch = getattr(dev, "gcnArchName", "") or ""
+            arch = arch.split(":")[0]  # strip feature-flag suffix
+        except Exception:
+            arch = ""
+    return _ARCH_LDS_BUDGET.get(arch, _DEFAULT_LDS_BUDGET)
+
+
+# ---------------------------------------------------------------------------
+# K-883 Layer 1+2+3+5+6 — GuardedOverride class.
+# ---------------------------------------------------------------------------
+
+# Strict shape key.  ``batch`` is optional; gates that care about batch must
+# include it explicitly in their cohort_keys (4-tuple -> 5-tuple bumps key).
+ShapeKey = Tuple[int, int, int, "torch.dtype"]
+ShapeKeyB = Tuple[int, int, int, "torch.dtype", int]
+
+
+@dataclass
+class GuardedOverride:
+    """A single narrow-cohort override gated by the K-883 9-layer pattern.
+
+    Parameters
+    ----------
+    ticket
+        The ticket id (e.g. ``"K-882"``).  Used to namespace counters,
+        env vars, and logged routing-trace rows.
+    env_var
+        Killswitch env var (read at every call, defeats lru_cache).  Set to
+        ``"1"`` / ``"true"`` / ``"yes"`` to ARM the override (default OFF
+        prevents accidental landing without an explicit opt-in).
+    cohort_keys
+        Strict-equality dispatch table.  Each entry is either a 4-tuple
+        ``(M, N, K, dtype)`` or a 5-tuple ``(M, N, K, dtype, batch)``.  The
+        gate fires only on exact key matches (R4 — range-predicate ban).
+    dtype_allowlist
+        Allowed dtypes (L2).  The gate refuses to fire on any other dtype
+        even if a key happens to match (defence against future table edits
+        that drop the dtype filter).
+    override_fn
+        ``(M, N, K, dtype) -> Dict[str, Any]`` returning the tile-spec
+        deltas to merge into the dispatch site.  Recognized keys
+        (subset; extend as needed):
+          - ``"grid_cap_to_n_cu"`` (bool)
+          - ``"num_stages"`` (int)
+          - ``"num_warps"`` (int)
+          - ``"waves_per_eu"`` (int)
+          - ``"kpack"`` (int)
+          - ``"matrix_instr_nonkdim"`` (int)
+          - ``"BLOCK_SIZE_M"`` / ``"BLOCK_SIZE_N"`` / ``"BLOCK_SIZE_K"``
+        The dispatch site (see ``apply_override_in_dispatcher``) honors
+        the ones it knows about and ignores the rest.
+    composability_guard
+        ``(work_stealing: bool) -> bool`` returning True if the override
+        may fire in this call.  Default refuses when ``work_stealing`` is
+        true (L5).  Pass ``lambda ws: True`` only if your override has
+        been validated against the work-stealing dispatcher.
+    cohort_size_cap
+        L1 sanity check.  K-883 §5 C3 says cohort size <= 30 cells; this
+        caps it.  Pass a larger value only if you split the table
+        explicitly.
+    """
+
+    ticket: str
+    env_var: str
+    cohort_keys: Sequence[Tuple]
+    dtype_allowlist: Tuple["torch.dtype", ...] = (torch.float16, torch.bfloat16)
+    override_fn: Optional[Callable[[int, int, int, "torch.dtype"], Dict[str, Any]]] = None
+    composability_guard: Callable[[bool], bool] = field(
+        default=lambda work_stealing: not work_stealing
+    )
+    cohort_size_cap: int = 30
+
+    # Layer 6 — counters (initialized in __post_init__).
+    _lock: threading.Lock = field(init=False, repr=False)
+    _fire_total: int = field(init=False, default=0, repr=False)
+    _nonfire_total: int = field(init=False, default=0, repr=False)
+    _per_key_fires: Dict[Tuple, int] = field(init=False, default_factory=dict, repr=False)
+    _key_set: set = field(init=False, default_factory=set, repr=False)
+
+    def __post_init__(self):
+        self._lock = threading.Lock()
+        if len(self.cohort_keys) > self.cohort_size_cap:
+            raise ValueError(
+                f"{self.ticket}: cohort_size={len(self.cohort_keys)} > cap "
+                f"{self.cohort_size_cap}.  Split the table or pass a larger cap "
+                f"with explicit justification (K-883 §5 C3)."
+            )
+        self._key_set = set(self.cohort_keys)
+        self._per_key_fires = {k: 0 for k in self._key_set}
+
+    # ---- Layer 3 — env-read-per-call killswitch ---------------------------
+    def _enabled(self) -> bool:
+        v = os.environ.get(self.env_var, "").lower()
+        return v in ("1", "true", "yes")
+
+    # ---- Strict shape-key gate (Layers 1+2+6) -----------------------------
+    def lookup(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        dtype: "torch.dtype",
+        batch: int = 1,
+    ) -> Optional[Dict[str, Any]]:
+        """Return override payload if the gate fires for this shape, else None.
+
+        Updates the routing-trace counters (Layer 6) on every call.  Safe to
+        call from any number of threads.
+        """
+        if not self._enabled():
+            with self._lock:
+                self._nonfire_total += 1
+            return None
+        if dtype not in self.dtype_allowlist:
+            with self._lock:
+                self._nonfire_total += 1
+            return None
+        # Try 4-key first (no batch), then 5-key.
+        key4 = (M, N, K, dtype)
+        key5 = (M, N, K, dtype, batch)
+        key = key4 if key4 in self._key_set else (key5 if key5 in self._key_set else None)
+        if key is None:
+            with self._lock:
+                self._nonfire_total += 1
+            return None
+        # Hit.
+        payload = self.override_fn(M, N, K, dtype) if self.override_fn else {}
+        with self._lock:
+            self._fire_total += 1
+            self._per_key_fires[key] = self._per_key_fires.get(key, 0) + 1
+        return dict(payload) if payload is not None else {}
+
+    # ---- Layer 6 — routing-trace snapshot ---------------------------------
+    def routing_snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "ticket": self.ticket,
+                "fire_total": self._fire_total,
+                "nonfire_total": self._nonfire_total,
+                "per_key_fires": dict(self._per_key_fires),
+            }
+
+    def reset_counters(self) -> None:
+        with self._lock:
+            self._fire_total = 0
+            self._nonfire_total = 0
+            self._per_key_fires = {k: 0 for k in self._key_set}
+
+    # ---- Layer 4 — LDS budget guard (call-site helper) --------------------
+    @staticmethod
+    def lds_ok(
+        block_m: int, block_n: int, block_k: int,
+        num_stages: int, bytes_per_elem: int = 2,
+        arch: Optional[str] = None,
+    ) -> bool:
+        """Return True if double-buffered LDS fits in the budget."""
+        used = num_stages * (block_m + block_n) * block_k * bytes_per_elem
+        return used <= lds_budget_for(arch)
+
+
+# ---------------------------------------------------------------------------
+# Registry — the singleton matmul.py looks at to ask "any override fire?".
+# Multiple overrides can register simultaneously (the registry itself
+# enforces R1 — dispatch-order-first routing — by maintaining insertion
+# order; the strictest predicate registers first).
+# ---------------------------------------------------------------------------
+class _OverrideRegistry:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._gates: List[GuardedOverride] = []
+
+    def register(self, gate: GuardedOverride) -> GuardedOverride:
+        with self._lock:
+            # Refuse to register two gates with the same ticket id.
+            for g in self._gates:
+                if g.ticket == gate.ticket:
+                    return g  # idempotent
+            self._gates.append(gate)
+        return gate
+
+    def unregister(self, ticket: str) -> None:
+        with self._lock:
+            self._gates = [g for g in self._gates if g.ticket != ticket]
+
+    def all(self) -> List[GuardedOverride]:
+        with self._lock:
+            return list(self._gates)
+
+    def apply(
+        self,
+        M: int, N: int, K: int, dtype: "torch.dtype",
+        work_stealing: bool = False,
+        batch: int = 1,
+    ) -> Optional[Tuple[GuardedOverride, Dict[str, Any]]]:
+        """R1 — first gate (in registration order) whose predicate fires wins.
+
+        Returns ``(gate, payload)`` for the firing gate, or None if no
+        gate fires.  The composability guard (L5) is enforced here.
+        """
+        for g in self.all():
+            if not g.composability_guard(work_stealing):
+                continue
+            payload = g.lookup(M, N, K, dtype, batch=batch)
+            if payload is not None:
+                return g, payload
+        return None
+
+
+OverrideRegistry = _OverrideRegistry()
+
+
+# ---------------------------------------------------------------------------
+# Paired ON/OFF benchmark — K-867 single-process HIP-graph kernel-only.
+# ---------------------------------------------------------------------------
+@dataclass
+class CellResult:
+    M: int
+    N: int
+    K: int
+    dtype: str
+    batch: int
+    in_cohort: bool
+    ms_off_med: float
+    ms_on_med: float
+    ms_ref_med: float          # reference impl (e.g. hipBLASLt)
+    ms_off_raw: List[float]
+    ms_on_raw: List[float]
+    ms_ref_raw: List[float]
+    n_paired: int                     # number of paired (ON,OFF) samples
+    delta_pct_on_vs_off: float        # +ve = ON faster (mean of paired deltas)
+    delta_pct_on_vs_off_ci_lo: float  # 95% CI lower bound (paired t)
+    delta_pct_on_vs_off_ci_hi: float  # 95% CI upper bound (paired t)
+    delta_pct_on_vs_ref: float        # +ve = ON faster than ref
+    delta_pct_on_vs_ref_ci_lo: float
+    delta_pct_on_vs_ref_ci_hi: float
+    paired_spread_pct: float          # max-min(off)/median(off) * 100
+    classification: str               # SPEEDUP / IN_BAND / REGRESS
+    fired: bool                       # routing-trace: did the gate fire?
+
+    def to_row(self) -> Dict[str, Any]:
+        return {
+            "M": self.M, "N": self.N, "K": self.K,
+            "dtype": self.dtype, "batch": self.batch,
+            "in_cohort": int(self.in_cohort),
+            "ms_off_med": self.ms_off_med,
+            "ms_on_med": self.ms_on_med,
+            "ms_ref_med": self.ms_ref_med,
+            "n_paired": self.n_paired,
+            "delta_pct_on_vs_off": self.delta_pct_on_vs_off,
+            "delta_pct_on_vs_off_ci_lo": self.delta_pct_on_vs_off_ci_lo,
+            "delta_pct_on_vs_off_ci_hi": self.delta_pct_on_vs_off_ci_hi,
+            "delta_pct_on_vs_ref": self.delta_pct_on_vs_ref,
+            "delta_pct_on_vs_ref_ci_lo": self.delta_pct_on_vs_ref_ci_lo,
+            "delta_pct_on_vs_ref_ci_hi": self.delta_pct_on_vs_ref_ci_hi,
+            "paired_spread_pct": self.paired_spread_pct,
+            "classification": self.classification,
+            "fired": int(self.fired),
+            "ms_off_raw": ";".join(f"{x:.6f}" for x in self.ms_off_raw),
+            "ms_on_raw":  ";".join(f"{x:.6f}" for x in self.ms_on_raw),
+            "ms_ref_raw": ";".join(f"{x:.6f}" for x in self.ms_ref_raw),
+        }
+
+
+@dataclass
+class FalsificationVerdict:
+    """Per-K-883-§5 LAND/NO-LAND verdict."""
+    ticket: str
+    n_in_cohort: int
+    n_out_cohort: int
+    in_cohort_geomean_speedup: float    # ON / OFF; >1 means ON faster
+    in_cohort_n_positive: int           # cells with ON faster than OFF beyond noise
+    ooc_n_regress: int                  # cells beyond max(2pp, spread/2)
+    ooc_worst_delta_pct: float          # most-negative delta_pct (ON vs OFF)
+    routing_n_intended_keys: int
+    routing_n_intended_fires: int
+    routing_n_ooc_fires: int
+    land: bool
+    rationale: str
+
+    @property
+    def report(self) -> str:
+        return (
+            f"K-883 §5 verdict for {self.ticket}: "
+            f"{'LAND' if self.land else 'NO-LAND'}\n"
+            f"  in-cohort   : n={self.n_in_cohort}  geomean ON/OFF={self.in_cohort_geomean_speedup:.4f}x  "
+            f"net-positive cells={self.in_cohort_n_positive}/{self.n_in_cohort}\n"
+            f"  out-of-cohort: n={self.n_out_cohort}  regressors={self.ooc_n_regress}  "
+            f"worst delta_pct={self.ooc_worst_delta_pct:+.2f}%\n"
+            f"  routing-trace: intended-keys={self.routing_n_intended_keys}  "
+            f"intended-fires={self.routing_n_intended_fires}  ooc-fires={self.routing_n_ooc_fires}\n"
+            f"  rationale: {self.rationale}\n"
+        )
+
+
+def _hipgraph_bench(fn, n_warm: int = 5, n_capture: int = 50, n_rounds: int = 3) -> List[float]:
+    """K-867 protocol: HIP-graph capture, CUDA-event timing per replay."""
+    for _ in range(n_warm):
+        fn()
+    torch.cuda.synchronize()
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.stream(side):
+        with torch.cuda.graph(g):
+            for _ in range(n_capture):
+                fn()
+    torch.cuda.current_stream().wait_stream(side)
+    torch.cuda.synchronize()
+    times = []
+    starter = torch.cuda.Event(enable_timing=True)
+    ender = torch.cuda.Event(enable_timing=True)
+    for _ in range(n_rounds):
+        starter.record()
+        g.replay()
+        ender.record()
+        torch.cuda.synchronize()
+        times.append(starter.elapsed_time(ender) / n_capture)
+    del g
+    torch.cuda.synchronize()
+    return times
+
+
+def _trim_mean(xs: List[float], trim_pct: float = 0.10) -> float:
+    if not xs:
+        return float("nan")
+    xs = sorted(xs)
+    k = int(len(xs) * trim_pct)
+    if 2 * k >= len(xs):
+        return statistics.median(xs)
+    return statistics.fmean(xs[k:len(xs) - k])
+
+
+def _spread_pct(xs: List[float]) -> float:
+    if not xs:
+        return float("nan")
+    m = statistics.median(xs)
+    if m == 0:
+        return float("nan")
+    return (max(xs) - min(xs)) / m * 100.0
+
+
+def _classify_delta(delta_pct: float, paired_spread_pct: float, noise_floor_pct: float = 2.0) -> str:
+    """K-883 §5.3 V2 noise-band classifier.  Beyond max(2pp, spread/2) is real."""
+    band = max(noise_floor_pct, paired_spread_pct / 2.0)
+    if delta_pct > band:
+        return "SPEEDUP"
+    if delta_pct < -band:
+        return "REGRESS"
+    return "IN_BAND"
+
+
+# Two-sided 95% Student-t critical values for n-1 degrees of freedom.
+# Computing the t-CDF inverse without scipy is awkward; this lookup covers
+# the n we use in practice (n>=30 -> df>=29 -> t very close to 1.96).
+_T_CRIT_95 = {
+    1: 12.706, 2: 4.303, 3: 3.182, 4: 2.776, 5: 2.571,
+    6: 2.447, 7: 2.365, 8: 2.306, 9: 2.262, 10: 2.228,
+    15: 2.131, 20: 2.086, 25: 2.060, 29: 2.045, 30: 2.042,
+    40: 2.021, 60: 2.000, 120: 1.980,
+}
+
+
+def _t_crit_95(df: int) -> float:
+    """Return t_{df, 0.975} (two-sided 95%) by nearest-not-greater lookup.
+
+    For df>=30 this is within ~0.5% of the true value; for df>=120 it
+    converges to 1.96 (Normal).  We always return >=1.96 for safety.
+    """
+    if df <= 0:
+        return float("nan")
+    keys = sorted(_T_CRIT_95.keys())
+    chosen = keys[0]
+    for k in keys:
+        if k <= df:
+            chosen = k
+        else:
+            break
+    return max(_T_CRIT_95[chosen], 1.960)
+
+
+def _paired_delta_with_ci(
+    on: List[float], off: List[float],
+) -> Tuple[float, float, float, int]:
+    """Paired-sample mean delta_pct(=ON faster than OFF) + 95% CI.
+
+    Pairs ON[i] with OFF[i] (same round_index, single-process / shared
+    allocator state, K-867 protocol).  Returns (mean_delta_pct, ci_lo,
+    ci_hi, n).  If lengths differ we truncate to the shorter list.
+    """
+    n = min(len(on), len(off))
+    if n == 0:
+        return float("nan"), float("nan"), float("nan"), 0
+    deltas = []
+    for i in range(n):
+        if off[i] > 0:
+            deltas.append((off[i] - on[i]) / off[i] * 100.0)
+    if not deltas:
+        return float("nan"), float("nan"), float("nan"), 0
+    if len(deltas) == 1:
+        return deltas[0], float("nan"), float("nan"), 1
+    mean = statistics.fmean(deltas)
+    sd = statistics.stdev(deltas)
+    df = len(deltas) - 1
+    se = sd / math.sqrt(len(deltas))
+    half = _t_crit_95(df) * se
+    return mean, mean - half, mean + half, len(deltas)
+
+
+def _make_call(M: int, N: int, K: int, dtype: "torch.dtype",
+               impl: str = "tritonblas") -> Tuple[Callable, Tuple]:
+    """Build a callable that runs one matmul of shape M*N*K under impl.
+
+    impl: ``tritonblas`` (uses the registered gates) or ``hipblaslt`` (uses
+    ``torch.matmul`` which dispatches to hipBLASLt on AMD ROCm).
+    """
+    a = torch.randn(M, K, device="cuda", dtype=dtype)
+    b = torch.randn(K, N, device="cuda", dtype=dtype)
+    out = a.new_empty(M, N)
+    if impl == "tritonblas":
+        import tritonblas
+        def call():
+            tritonblas.matmul(a, b, out=out)
+    elif impl == "hipblaslt":
+        def call():
+            torch.matmul(a, b, out=out)
+    else:
+        raise ValueError(f"unknown impl: {impl}")
+    return call, (a, b, out)
+
+
+def measure_cell(
+    M: int, N: int, K: int, dtype: "torch.dtype", batch: int,
+    gate: GuardedOverride,
+    n_warm: int = 5, n_capture: int = 30, n_rounds: int = 30,
+    measure_ref: bool = True,
+) -> CellResult:
+    """Paired ON/OFF/ref measurement for a single (M,N,K,dtype) cell.
+
+    Captures n_rounds paired (OFF, ON [, REF]) replays.  Each replay is a
+    HIP-graph capture of n_capture matmul calls; the timed value is the
+    per-call mean over the capture.  We keep n_rounds >= 30 by default so
+    that the paired-CI estimator (Student-t, df=n-1) has the >=30 paired
+    samples per cell required by K-883 §5 V1/V2 / the K-901 PRD.
+
+    Within each round the order is OFF -> ON -> REF (round-robin) so the
+    paired delta cancels slow drift (warm-up, page faults, allocator
+    fragmentation) at first order.  All three callables re-allocate
+    a/b/out per impl to keep allocator state local but shape-identical
+    (cache-effect matched).
+
+    The gate's env var is set to "1" for ON and unset for OFF, and the
+    gate's counters are read before/after to record per-cell fires.
+    """
+    fire_before = gate._fire_total
+
+    ts_off: List[float] = []
+    ts_on:  List[float] = []
+    ts_ref: List[float] = []
+
+    for _ in range(n_rounds):
+        # ---- OFF ----
+        os.environ.pop(gate.env_var, None)
+        call_off, _ = _make_call(M, N, K, dtype, impl="tritonblas")
+        ts_off.extend(_hipgraph_bench(call_off, n_warm=n_warm,
+                                      n_capture=n_capture, n_rounds=1))
+        # ---- ON ----
+        os.environ[gate.env_var] = "1"
+        call_on, _ = _make_call(M, N, K, dtype, impl="tritonblas")
+        ts_on.extend(_hipgraph_bench(call_on, n_warm=n_warm,
+                                     n_capture=n_capture, n_rounds=1))
+        # ---- REF ----
+        if measure_ref:
+            call_ref, _ = _make_call(M, N, K, dtype, impl="hipblaslt")
+            ts_ref.extend(_hipgraph_bench(call_ref, n_warm=n_warm,
+                                          n_capture=n_capture, n_rounds=1))
+        else:
+            ts_ref.append(float("nan"))
+
+    os.environ.pop(gate.env_var, None)
+
+    fire_after = gate._fire_total
+    fired = fire_after > fire_before
+
+    med_off = _trim_mean(ts_off)
+    med_on  = _trim_mean(ts_on)
+    med_ref = _trim_mean(ts_ref) if measure_ref else float("nan")
+
+    d_on_off, d_on_off_lo, d_on_off_hi, n_paired = _paired_delta_with_ci(ts_on, ts_off)
+    if measure_ref:
+        d_on_ref, d_on_ref_lo, d_on_ref_hi, _ = _paired_delta_with_ci(ts_on, ts_ref)
+    else:
+        d_on_ref, d_on_ref_lo, d_on_ref_hi = (float("nan"),) * 3
+
+    spread = _spread_pct(ts_off)
+    cls = _classify_delta(d_on_off, spread)
+
+    in_cohort = ((M, N, K, dtype) in gate._key_set or
+                 (M, N, K, dtype, batch) in gate._key_set)
+
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    return CellResult(
+        M=M, N=N, K=K,
+        dtype=str(dtype).replace("torch.", ""),
+        batch=batch,
+        in_cohort=in_cohort,
+        ms_off_med=med_off, ms_on_med=med_on, ms_ref_med=med_ref,
+        ms_off_raw=ts_off, ms_on_raw=ts_on, ms_ref_raw=ts_ref,
+        n_paired=n_paired,
+        delta_pct_on_vs_off=d_on_off,
+        delta_pct_on_vs_off_ci_lo=d_on_off_lo,
+        delta_pct_on_vs_off_ci_hi=d_on_off_hi,
+        delta_pct_on_vs_ref=d_on_ref,
+        delta_pct_on_vs_ref_ci_lo=d_on_ref_lo,
+        delta_pct_on_vs_ref_ci_hi=d_on_ref_hi,
+        paired_spread_pct=spread,
+        classification=cls,
+        fired=fired,
+    )
+
+
+def run_falsification(
+    override: GuardedOverride,
+    shapes: Iterable[Dict[str, Any]],
+    out_dir: str,
+    n_warm: int = 5, n_capture: int = 30, n_rounds: int = 30,
+    measure_ref: bool = True,
+    progress: Callable[[str], None] = print,
+) -> FalsificationVerdict:
+    """End-to-end paired ON/OFF/ref sweep + K-883 §5 verdict.
+
+    Parameters
+    ----------
+    override
+        The gate to test (must already be registered with OverrideRegistry).
+    shapes
+        Iterable of dicts with keys {M, N, K, dtype, batch}.  dtype is the
+        string ``"fp16"`` / ``"bf16"``.
+    out_dir
+        Directory to write ``per_cell.csv``, ``routing.csv``, ``verdict.json``,
+        and ``REPORT.md`` into.
+    n_capture
+        Calls per HIP-graph capture (default 30 for the n>=30 minimum).
+    measure_ref
+        If True, also bench the reference impl (hipBLASLt via torch.matmul).
+    """
+    os.makedirs(out_dir, exist_ok=True)
+    DT = {"fp16": torch.float16, "bf16": torch.bfloat16}
+
+    override.reset_counters()
+
+    rows: List[Dict[str, Any]] = []
+    cells: List[CellResult] = []
+
+    t0 = time.time()
+    shapes = list(shapes)
+    for i, sh in enumerate(shapes):
+        M, N, K = int(sh["M"]), int(sh["N"]), int(sh["K"])
+        dt_name = sh["dtype"]
+        if dt_name not in DT:
+            progress(f"[{i+1}/{len(shapes)}] skip dtype={dt_name}")
+            continue
+        dt = DT[dt_name]
+        batch = int(sh.get("batch", 1))
+        progress(f"[{i+1}/{len(shapes)}] M={M} N={N} K={K} dt={dt_name} batch={batch}")
+        try:
+            cell = measure_cell(
+                M, N, K, dt, batch, override,
+                n_warm=n_warm, n_capture=n_capture, n_rounds=n_rounds,
+                measure_ref=measure_ref,
+            )
+        except Exception as e:
+            progress(f"    FAIL {type(e).__name__}: {e}")
+            continue
+        cells.append(cell)
+        rows.append(cell.to_row())
+        progress(
+            f"    n={cell.n_paired} OFF={cell.ms_off_med:.4f}ms ON={cell.ms_on_med:.4f}ms "
+            f"REF={cell.ms_ref_med:.4f}ms "
+            f"d_ON/OFF={cell.delta_pct_on_vs_off:+.2f}% "
+            f"[CI95={cell.delta_pct_on_vs_off_ci_lo:+.2f},{cell.delta_pct_on_vs_off_ci_hi:+.2f}] "
+            f"cls={cell.classification} cohort={cell.in_cohort} fired={cell.fired}"
+        )
+
+    # Write per-cell CSV.
+    per_cell_path = os.path.join(out_dir, "per_cell.csv")
+    if rows:
+        with open(per_cell_path, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+            w.writeheader()
+            w.writerows(rows)
+
+    # Routing trace.
+    snap = override.routing_snapshot()
+    routing_path = os.path.join(out_dir, "routing.csv")
+    with open(routing_path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["ticket", "fire_total", "nonfire_total"])
+        w.writerow([snap["ticket"], snap["fire_total"], snap["nonfire_total"]])
+        w.writerow([])
+        w.writerow(["M", "N", "K", "dtype", "fire_count"])
+        for k, v in sorted(snap["per_key_fires"].items(), key=lambda kv: str(kv[0])):
+            mm, nn, kk = k[0], k[1], k[2]
+            dtt = str(k[3]).replace("torch.", "")
+            w.writerow([mm, nn, kk, dtt, v])
+
+    # Verdict (K-883 §5 gates).
+    verdict = _compute_verdict(override, cells, snap)
+    verdict_path = os.path.join(out_dir, "verdict.json")
+    with open(verdict_path, "w") as f:
+        json.dump(verdict.__dict__, f, indent=2, default=str)
+    report_path = os.path.join(out_dir, "REPORT.md")
+    with open(report_path, "w") as f:
+        f.write(_render_report(override, cells, snap, verdict))
+
+    progress(f"[done] {len(cells)} cells in {time.time()-t0:.1f}s")
+    progress(verdict.report)
+    return verdict
+
+
+def _compute_verdict(
+    override: GuardedOverride,
+    cells: List[CellResult],
+    snap: Dict[str, Any],
+) -> FalsificationVerdict:
+    in_c = [c for c in cells if c.in_cohort]
+    ooc  = [c for c in cells if not c.in_cohort]
+
+    # In-cohort geomean of ON/OFF (delta>0 means ON faster, so ratio=OFF/ON > 1).
+    if in_c:
+        ratios = []
+        for c in in_c:
+            if c.ms_off_med > 0 and c.ms_on_med > 0:
+                ratios.append(c.ms_off_med / c.ms_on_med)
+        if ratios:
+            geomean = math.exp(sum(math.log(x) for x in ratios) / len(ratios))
+        else:
+            geomean = float("nan")
+        n_pos = sum(1 for c in in_c if c.classification == "SPEEDUP")
+    else:
+        geomean = float("nan")
+        n_pos = 0
+
+    # OOC regressors (K-883 §5 V2).  A cell counts as a regressor only if
+    # (a) its noise-band classifier flags REGRESS AND
+    # (b) its 95% paired CI upper bound is still negative (ON statistically
+    #     slower than OFF, not a single-trial outlier).  This is the "no
+    #     single-trial noise" guard requested by the K-901 reviewer.
+    ooc_regress = [
+        c for c in ooc
+        if c.classification == "REGRESS"
+        and (math.isnan(c.delta_pct_on_vs_off_ci_hi)
+             or c.delta_pct_on_vs_off_ci_hi < 0.0)
+    ]
+    worst_ooc = min((c.delta_pct_on_vs_off for c in ooc), default=float("nan"))
+
+    # Routing trace correctness (K-883 §5 V3).
+    intended_keys = set(override.cohort_keys)
+    fired_keys = {k for k, v in snap["per_key_fires"].items() if v > 0}
+    n_intended_fired = len(fired_keys & intended_keys)
+    n_ooc_fires = sum(
+        v for k, v in snap["per_key_fires"].items()
+        if k not in intended_keys and v > 0
+    )
+
+    # K-883 §5 LAND gates:
+    #   V1 in-cohort: geomean >= 1.05 AND >= ceil(0.8*n_in) cells SPEEDUP
+    #   V2 OOC      : 0 cells classified REGRESS
+    #   V3 routing  : per-key fires match the cohort enumeration; 0 OOC fires
+    n_in = max(1, len(in_c))
+    v1 = (geomean >= 1.05) and (n_pos >= math.ceil(0.8 * n_in))
+    v2 = len(ooc_regress) == 0
+    v3 = (n_intended_fired == len(intended_keys)) and (n_ooc_fires == 0)
+    # If we did not bench any cohort cells, we cannot LAND.
+    if not in_c:
+        v1 = False
+
+    land = bool(v1 and v2 and v3)
+    rationale_parts = []
+    rationale_parts.append("V1 in-cohort lift: " + ("PASS" if v1 else "FAIL"))
+    rationale_parts.append("V2 OOC bleed: " + ("PASS" if v2 else f"FAIL ({len(ooc_regress)} regressors, worst {worst_ooc:+.2f}%)"))
+    rationale_parts.append("V3 routing trace: " + ("PASS" if v3 else
+        f"FAIL (intended-fires={n_intended_fired}/{len(intended_keys)}, ooc-fires={n_ooc_fires})"))
+
+    return FalsificationVerdict(
+        ticket=override.ticket,
+        n_in_cohort=len(in_c),
+        n_out_cohort=len(ooc),
+        in_cohort_geomean_speedup=geomean,
+        in_cohort_n_positive=n_pos,
+        ooc_n_regress=len(ooc_regress),
+        ooc_worst_delta_pct=worst_ooc,
+        routing_n_intended_keys=len(intended_keys),
+        routing_n_intended_fires=n_intended_fired,
+        routing_n_ooc_fires=n_ooc_fires,
+        land=land,
+        rationale="; ".join(rationale_parts),
+    )
+
+
+def _render_report(
+    override: GuardedOverride,
+    cells: List[CellResult],
+    snap: Dict[str, Any],
+    verdict: FalsificationVerdict,
+) -> str:
+    lines = []
+    lines.append(f"# {override.ticket} guarded-override falsification report")
+    lines.append("")
+    lines.append(f"**Verdict**: {'LAND' if verdict.land else 'NO-LAND'}")
+    lines.append("")
+    lines.append(verdict.report)
+    lines.append("")
+    lines.append("## Per-cell paired deltas with 95% CI (n>=30 paired samples)")
+    lines.append("")
+    lines.append("| in_cohort | M | N | K | dtype | n | OFF (ms) | ON (ms) | REF (ms) | dON/OFF (CI95) | dON/REF (CI95) | spread% | class | fired |")
+    lines.append("|---|---:|---:|---:|---|---:|---:|---:|---:|---|---|---:|---|---|")
+    for c in cells:
+        lines.append(
+            f"| {'Y' if c.in_cohort else 'N'} | {c.M} | {c.N} | {c.K} | {c.dtype} | "
+            f"{c.n_paired} | "
+            f"{c.ms_off_med:.4f} | {c.ms_on_med:.4f} | {c.ms_ref_med:.4f} | "
+            f"{c.delta_pct_on_vs_off:+.2f}% [{c.delta_pct_on_vs_off_ci_lo:+.2f},{c.delta_pct_on_vs_off_ci_hi:+.2f}] | "
+            f"{c.delta_pct_on_vs_ref:+.2f}% [{c.delta_pct_on_vs_ref_ci_lo:+.2f},{c.delta_pct_on_vs_ref_ci_hi:+.2f}] | "
+            f"{c.paired_spread_pct:.2f}% | {c.classification} | {'Y' if c.fired else 'N'} |"
+        )
+    lines.append("")
+    lines.append("## Routing trace (K-883 layer 6)")
+    lines.append("")
+    lines.append(f"- fire_total = {snap['fire_total']}")
+    lines.append(f"- nonfire_total = {snap['nonfire_total']}")
+    lines.append("")
+    lines.append("| M | N | K | dtype | fire_count |")
+    lines.append("|---:|---:|---:|---|---:|")
+    for k, v in sorted(snap["per_key_fires"].items(), key=lambda kv: str(kv[0])):
+        dtt = str(k[3]).replace("torch.", "")
+        lines.append(f"| {k[0]} | {k[1]} | {k[2]} | {dtt} | {v} |")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Convenience: dispatch-site shim for matmul.py.  Translates the override
+# payload dict into the local variables of persistent_matmul_lt.  Returns a
+# dict of any updates the caller should apply; caller is responsible for
+# the L4 LDS guard and the L5 work_stealing check (the registry already
+# does L5, but the LDS guard is call-site because BLK_M/N/K live there).
+# ---------------------------------------------------------------------------
+def apply_override_in_dispatcher(
+    M: int, N: int, K: int, dtype: "torch.dtype",
+    block_m: int, block_n: int, block_k: int,
+    num_stages: int, num_warps: int, waves_per_eu: int,
+    kpack: int, mfma_instr_size: int,
+    total_tiles: int, n_cu: int,
+    work_stealing: bool = False,
+    bytes_per_elem: int = 2,
+    arch: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Look up any active override and return updated tile-spec values.
+
+    Returns dict with any of: BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K,
+    num_stages, num_warps, waves_per_eu, kpack, matrix_instr_nonkdim,
+    grids, total_programs, fired_ticket.
+
+    Empty dict means no override fires (caller proceeds with defaults).
+    """
+    hit = OverrideRegistry.apply(M, N, K, dtype, work_stealing=work_stealing)
+    if hit is None:
+        return {}
+    gate, payload = hit
+    out: Dict[str, Any] = {"fired_ticket": gate.ticket}
+
+    bm = int(payload.get("BLOCK_SIZE_M", block_m))
+    bn = int(payload.get("BLOCK_SIZE_N", block_n))
+    bk = int(payload.get("BLOCK_SIZE_K", block_k))
+    ns = int(payload.get("num_stages", num_stages))
+
+    # Layer 4 — LDS budget guard.
+    if not GuardedOverride.lds_ok(bm, bn, bk, ns, bytes_per_elem=bytes_per_elem, arch=arch):
+        # Drop the override (do NOT fire) — preserves layer-4 invariant.
+        # The lookup() call already incremented fire_total; we leave it as a
+        # routing-trace record of "would-have-fired-but-LDS-blocked" so the
+        # gate author can see it.
+        return {"lds_blocked": True, "fired_ticket": gate.ticket}
+
+    if bm != block_m: out["BLOCK_SIZE_M"] = bm
+    if bn != block_n: out["BLOCK_SIZE_N"] = bn
+    if bk != block_k: out["BLOCK_SIZE_K"] = bk
+    if ns != num_stages: out["num_stages"] = ns
+    for k_payload, k_local, cur in [
+        ("num_warps", "num_warps", num_warps),
+        ("waves_per_eu", "waves_per_eu", waves_per_eu),
+        ("kpack", "kpack", kpack),
+        ("matrix_instr_nonkdim", "matrix_instr_nonkdim", mfma_instr_size),
+    ]:
+        if k_payload in payload and int(payload[k_payload]) != cur:
+            out[k_local] = int(payload[k_payload])
+
+    if payload.get("grid_cap_to_n_cu", False):
+        new_grid = min(total_tiles, n_cu)
+        if new_grid != total_tiles:
+            out["grids"] = new_grid
+            out["total_programs"] = new_grid
+
+    return out

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -31,7 +31,7 @@ from ._route_predicate import (
     # K-1361 (S-002): P12 square_mid PMC-driven 4-cell route-OUT (6th-position).
     _k1361_p12_square_mid_routeout as _R_K1361_P12_square_mid_routeout,
     # K-1367 (S-002): P13 skinny_N128 K-COMPLEMENT 18-cell route-OUT (7th-position).
-    _k1367_p13_skinny_n128_kcomplement_routeout as _R_K1367_P13_skinny_n128_kcomplement_routeout,
+    _k1367_p13_skinny_n128_routeout as _R_K1367_P13_skinny_n128_routeout,
 )
 
 
@@ -96,7 +96,7 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # K-913 §3 LDS-bank-conflict discriminator on the persistent_matmul N=128
     # column-narrow LDS layout). Disjoint by construction with all P1–P12
     # sub-frozensets via cross-frozenset asserts at module load.
-    if _R_K1367_P13_skinny_n128_kcomplement_routeout(int(M), int(N), int(K), a_dtype): return True
+    if _R_K1367_P13_skinny_n128_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -1,4 +1,5 @@
 import functools
+import os
 import random
 import time
 from typing import Any, Dict, Optional, Tuple
@@ -12,10 +13,92 @@ from .kernels import persistent_matmul, ws_persistent_matmul, streamk_matmul, ws
 from .kernels.fp4_matmul import fp4_matmul
 from .origami import OrigamiMatmulSelector
 from .config import MatmulConfig, matmul_preamble, COUNTER_STRIDE
+from . import guarded_override as _go
+# NOTE: no override package is imported here.  GuardedOverride instances
+# register themselves explicitly only after passing the K-883 §5 LAND
+# verdict via run_falsification (K-901 design).  Keeping the dispatch site
+# override-naive means an empty registry is the safe default.
+
+# K-1003 R-K979 P5 Gate-0 admission predicate + K-905/K-971 anchors live in
+# a torch-free helper module so unit/integration tests can import them
+# without booting the GPU stack (triton/origami/torch.cuda init chain).
+from ._route_predicate import (
+    K971_ROUTE_TABLE as _K971_ROUTE_TABLE,
+    R_K979_P5_route_to_hbl as _R_K979_P5_route_to_hbl,
+    R_K1037_P6_admit_wpeu1 as _R_K1037_P6_admit_wpeu1,
+    _p8_mfma_issue_stall_routeout as _R_K1144_P8_mfma_issue_stall_routeout,
+    R_K1142_E1_route_to_hbl as _R_K1142_E1_route_to_hbl,
+    # K-1361 (S-002): P12 square_mid PMC-driven 4-cell route-OUT (6th-position).
+    _k1361_p12_square_mid_routeout as _R_K1361_P12_square_mid_routeout,
+    # K-1367 (S-002): P13 skinny_N128 K-COMPLEMENT 18-cell route-OUT (7th-position).
+    _k1367_p13_skinny_n128_kcomplement_routeout as _R_K1367_P13_skinny_n128_kcomplement_routeout,
+)
 
 
 
 _tensor_cache = {}
+
+
+def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing):
+    # K-989: keep K-971 killswitch env var as the single L3 disable lever
+    # (per K-883 R1 — one cohort, one disable). K-1003 layers the R-K979 P5
+    # Gate-0 admission predicate AHEAD of the strict-equality table so the
+    # broader K-984+K-989+K-931 cohort dispatches via closed-form rather
+    # than per-shape entries; strict-equality table retained for K-905/K-971
+    # mid-square long-K anchors that structurally collide with K-950 LAND.
+    if os.environ.get("TRITONBLAS_DISABLE_K971") == "1": return False
+    if enable_streamk or work_stealing or str(a_dtype) != str(b_dtype): return False
+    # K-1144 (S-002): P8 MFMA-issue-stall direct hipBLASLt route-OUT for
+    # the triply-validated 25-cell envelope (13 K-1121 anchors + 12 K-1131
+    # neighbors).  Consulted BEFORE the K-1089 P6 admit so K-1121's paired
+    # n=30 measurement evidence (hipBLASLt wins on S24, S29 at ~1.20-1.22x;
+    # K-1131 N11 at >=1.15x) overrides the K-1089 envelope admit on the
+    # small subset of cells where the two envelopes overlap.  K-1074's
+    # paired n=30 LAND audit and K-1098's clause-by-clause backtest
+    # falsified the K-1089 admit on those cells; P8 codifies the
+    # correction.  No double-routing: for cells already routed OUT by P5
+    # Clause-2 / K-1062 Clause-4, P8's strict-equality match returns the
+    # same True verdict (frozenset O(1) lookup; harmless).
+    if _R_K1144_P8_mfma_issue_stall_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1209-stacked / K-1216 (S-002): E1 axis-aligned envelope as defense-
+    # in-depth AFTER P8 28-cell strict-equality. K-1209 ablation on K-931
+    # always-uncovered top-40 (40 cells) confirmed E1 contributes 0 marginal
+    # cells beyond P8+K-1175 (16/40 union vs 16/40 P8+K-1175); E1 is retained
+    # for non-K-931 cohorts where the K-1142 -> K-1161 -> K-1175 audit chain
+    # has not yet enumerated every K-1142-envelope-admittable cell. The
+    # K-1142 carve-out (M >= 4480) ∧ (K >= 256) holds at 0 FPs on K-931.
+    # E2 K-floor=128 EXCLUDED per K-1176 cross-arch failure (0/8 cells on
+    # MI325X/MI355X) — the K-axis floor stays pinned at K=256.
+    if _R_K1142_E1_route_to_hbl(int(M), int(N), int(K), a_dtype): return True
+    # K-1089 (S-002): R-K1037 P6 structural surrogate admits MFMA-issue-stall
+    # cells back to in-kernel dispatch with waves_per_eu=1 (set in the
+    # persistent dispatch path below). When P6 admits, route-OUT (P5 + the
+    # K-905/K-971 strict-equality table) is short-circuited for the cell.
+    if _R_K1037_P6_admit_wpeu1(int(M), int(N), int(K), a_dtype): return False
+    if _R_K979_P5_route_to_hbl(int(M), int(N), int(K), a_dtype): return True
+    if (int(M), int(N), int(K), str(a_dtype)) in _K971_ROUTE_TABLE: return True
+    # K-1361 (S-002): P12 square_mid PMC-driven 4-cell route-OUT (6th-position
+    # envelope). Stacks AFTER the K971 LDS-BC table per K-1175 stacked-predicate
+    # convention; productionises K-1345's Predicate-Q (square_mid 2048³) and
+    # Predicate-R (square_mid 4096³) — see _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
+    # in _route_predicate.py for source measurement chain (K-877 / K-655 /
+    # K-818 C2 / K-837 / K-879 anchors + K-913 §3 dtype invariance + K-1295
+    # paired n=30 inheritance). Disjoint by construction with all P1–P11
+    # sub-frozensets via cross-frozenset asserts at module load.
+    if _R_K1361_P12_square_mid_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1367 (S-002): P13 skinny_N128 K-COMPLEMENT 18-cell route-OUT (7th-position
+    # envelope). Stacks AFTER K-1361 P12 per K-1175 stacked-predicate convention;
+    # closes the K-1308 skinny_N128 K-COMPLEMENT region (K >= 4096 above the
+    # ~30 µs triton_op wrapper-overhead ceiling). Verified at paired n=30 +
+    # B=10000 vectorised bootstrap CI95: 18/18 ROUTE-OUT, cohort geomean
+    # tb/hbl=1.678×, min CI95-lo=1.124. PMC mechanism confirmed by 7-cell
+    # rocprofv3 4-pass capture (TB SQ_LDS_BC/inst ≈ 1.45 vs HBL = 0; sharp
+    # K-913 §3 LDS-bank-conflict discriminator on the persistent_matmul N=128
+    # column-narrow LDS layout). Disjoint by construction with all P1–P12
+    # sub-frozensets via cross-frozenset asserts at module load.
+    if _R_K1367_P13_skinny_n128_kcomplement_routeout(int(M), int(N), int(K), a_dtype): return True
+    return False
+
 
 current_device_index = torch.cuda.current_device()
 current_device = torch.cuda.get_device_properties(current_device_index)
@@ -102,6 +185,14 @@ def persistent_matmul_lt(
     CACHE_MODIFIER_A = None
     CACHE_MODIFIER_B = None
 
+    # K-1089: structural surrogate of K-1037 P6 admits the MFMA-issue-stall
+    # cohort to in-kernel dispatch with waves_per_eu=1 (K-1051 confirmed via
+    # 4-iter PMC research that wpeu=1 wins are predictable on K-1032 cells).
+    # The route-OUT short-circuit in `_k971_route_to_hbl` already vetoes
+    # routing for these cells; we only need to set the in-kernel knob here.
+    if _R_K1037_P6_admit_wpeu1(int(M), int(N), int(K), a.dtype):
+        waves_per_eu = 1
+
     # Set chunk size to same area as L2 tiles.
     chunk_size = gsize_m * gsize_m
     if num_xcds > 0:
@@ -159,6 +250,32 @@ def persistent_matmul_lt(
         )
     else:
         grids = total_tiles
+
+        # K-883/K-901 guarded-override registry hook.  Single dispatch site,
+        # routed first (before any future range-keyed hook, R1 — dispatch-
+        # order-first routing).  The registry enforces L1/L2/L3/L5/L6; the
+        # call-site honors L4 (LDS budget) below via _overrides_apply.
+        _ovr_updates = _go.apply_override_in_dispatcher(
+            M=M, N=N, K=K, dtype=a.dtype,
+            block_m=BLK_M, block_n=BLK_N, block_k=BLK_K,
+            num_stages=num_stages, num_warps=num_warps,
+            waves_per_eu=waves_per_eu, kpack=kpack,
+            mfma_instr_size=mfmaInstrSize,
+            total_tiles=total_tiles, n_cu=selector._hardware.N_CU,
+            work_stealing=work_stealing,
+            bytes_per_elem=a.element_size(),
+        )
+        if _ovr_updates and not _ovr_updates.get("lds_blocked"):
+            BLK_M = _ovr_updates.get("BLOCK_SIZE_M", BLK_M)
+            BLK_N = _ovr_updates.get("BLOCK_SIZE_N", BLK_N)
+            BLK_K = _ovr_updates.get("BLOCK_SIZE_K", BLK_K)
+            num_stages = _ovr_updates.get("num_stages", num_stages)
+            num_warps = _ovr_updates.get("num_warps", num_warps)
+            waves_per_eu = _ovr_updates.get("waves_per_eu", waves_per_eu)
+            kpack = _ovr_updates.get("kpack", kpack)
+            mfmaInstrSize = _ovr_updates.get("matrix_instr_nonkdim", mfmaInstrSize)
+            grids = _ovr_updates.get("grids", grids)
+            total_programs = _ovr_updates.get("total_programs", total_programs)
 
         kk = _maybe_wrap(persistent_matmul, probe_tensor=a)[(grids,)](
             a,
@@ -402,6 +519,8 @@ def _matmul(
     M, K = a.shape
     _, N = b.shape
 
+    if _k971_route_to_hbl(M, N, K, a.dtype, b.dtype, enable_streamk, work_stealing):
+        return torch.matmul(a, b)
     out = a.new_empty(M, N)
 
     selector = _make_matmul_selector(M, N, K, a.dtype, b.dtype, out.dtype, a.device, streamk=enable_streamk)
@@ -461,6 +580,9 @@ def _matmul_out(
     M, K = a.shape
     _, N = b.shape
 
+    if _k971_route_to_hbl(M, N, K, a.dtype, b.dtype, enable_streamk, work_stealing):
+        torch.matmul(a, b, out=out)
+        return None
     selector = _make_matmul_selector(M, N, K, a.dtype, b.dtype, out.dtype, a.device, streamk=enable_streamk)
     config = matmul_preamble(selector) if work_stealing else None
 

--- a/tests/test_guarded_override.py
+++ b/tests/test_guarded_override.py
@@ -1,0 +1,573 @@
+"""K-883/K-901 -- guarded-override harness gating-logic tests (CPU-only).
+
+These tests exercise every layer (L1-L9) of the K-883 9-layer guarded-override
+pattern WITHOUT touching CUDA, plus a synthetic LAND-path integration test
+that proves the harness can actually approve a valid override (so a bug that
+makes the harness reject everything would be caught).
+
+The GPU paired-bench code path is exercised separately by
+``scripts/run_falsification_k882.py`` on c42/MI300X.
+
+Test names map 1:1 to the K-883 §5 / §3 layer rules so a CI failure points
+at the broken layer.
+"""
+import math
+import os
+import threading
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from tritonblas.guarded_override import (  # noqa: E402
+    CellResult,
+    FalsificationVerdict,
+    GuardedOverride,
+    GuardedOverride as GO,
+    OverrideRegistry,
+    _classify_delta,
+    _compute_verdict,
+    _paired_delta_with_ci,
+    _t_crit_95,
+    apply_override_in_dispatcher,
+    lds_budget_for,
+    set_arch_lds_budget,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+def _make_gate(env="TB_TEST_ENABLE", ticket="K-TEST",
+               keys=None, dtype_allowlist=(torch.float16, torch.bfloat16),
+               override_fn=None):
+    if keys is None:
+        keys = [(2048, 2048, 4096, torch.float16),
+                (2048, 2048, 8192, torch.bfloat16)]
+    return GuardedOverride(
+        ticket=ticket, env_var=env, cohort_keys=keys,
+        dtype_allowlist=dtype_allowlist,
+        override_fn=override_fn or (lambda M, N, K, dt: {"num_stages": 2}),
+    )
+
+
+def _k882_fixture():
+    """The K-882 grid-cap prototype, defined here as a TEST FIXTURE rather
+    than as a production override.  K-882's verdict is NO-LAND, so it must
+    not ship in the package; keeping it here exercises the harness's
+    reject-path (regression test that the harness keeps catching this
+    structural-no-op pattern)."""
+    return GuardedOverride(
+        ticket="K-882", env_var="TB_K882_ENABLE",
+        cohort_keys=[
+            (2048, 2048, 4096, torch.float16),
+            (2048, 2048, 4096, torch.bfloat16),
+            (2048, 2048, 8192, torch.float16),
+            (2048, 2048, 8192, torch.bfloat16),
+            (2048, 2048, 16384, torch.float16),
+            (2048, 2048, 16384, torch.bfloat16),
+        ],
+        dtype_allowlist=(torch.float16, torch.bfloat16),
+        override_fn=lambda M, N, K, dt: {"grid_cap_to_n_cu": True, "num_stages": 2},
+    )
+
+
+def setup_function(_):
+    OverrideRegistry.unregister("K-TEST")
+    OverrideRegistry.unregister("K-TEST-2")
+    OverrideRegistry.unregister("K-TEST-LAND")
+    OverrideRegistry.unregister("K-882")
+    for env in ("TB_TEST_ENABLE", "TB_TEST_2_ENABLE", "TB_TEST_LAND_ENABLE",
+                "TB_K882_ENABLE"):
+        os.environ.pop(env, None)
+
+
+# ---------------------------------------------------------------------------
+# L1 -- strict-equality dispatch table (R4 range-predicate ban)
+# ---------------------------------------------------------------------------
+def test_l1_strict_equality_no_range_leak():
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    assert g.lookup(2048, 2048, 4096, torch.float16) is not None
+    # Off-by-one on each dimension: must NOT fire (no range bleed).
+    assert g.lookup(2048, 2048, 4097, torch.float16) is None
+    assert g.lookup(2048, 2049, 4096, torch.float16) is None
+    assert g.lookup(2049, 2048, 4096, torch.float16) is None
+
+
+def test_l1_5tuple_keys_match_with_batch():
+    """L1: 5-tuple cohort keys (M,N,K,dt,batch) match only on exact batch."""
+    g = _make_gate(keys=[(2048, 2048, 4096, torch.float16, 4)])
+    os.environ["TB_TEST_ENABLE"] = "1"
+    # Right batch fires.
+    assert g.lookup(2048, 2048, 4096, torch.float16, batch=4) == {"num_stages": 2}
+    # Wrong batch must not fire.
+    assert g.lookup(2048, 2048, 4096, torch.float16, batch=8) is None
+    assert g.lookup(2048, 2048, 4096, torch.float16, batch=1) is None
+
+
+# ---------------------------------------------------------------------------
+# L2 -- dtype allowlist guard
+# ---------------------------------------------------------------------------
+def test_l2_dtype_allowlist_blocks_disallowed_dtype():
+    g = _make_gate(dtype_allowlist=(torch.float16,))  # bf16 NOT allowed
+    os.environ["TB_TEST_ENABLE"] = "1"
+    assert g.lookup(2048, 2048, 4096, torch.float16) is not None
+    # bf16 with a key that exists in cohort_keys but NOT in allowlist:
+    assert g.lookup(2048, 2048, 8192, torch.bfloat16) is None
+
+
+def test_l2_dtype_allowlist_blocks_fp32_even_for_matched_shape():
+    """L2: fp32 must be blocked even when (M,N,K) is in the cohort table."""
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    assert g.lookup(2048, 2048, 4096, torch.float32) is None
+
+
+# ---------------------------------------------------------------------------
+# L3 -- env-var killswitch read every call (no lru_cache)
+# ---------------------------------------------------------------------------
+def test_l3_env_killswitch_off_by_default():
+    """L3: every override is OFF unless its env var is explicitly set."""
+    g = _make_gate()
+    assert g.lookup(2048, 2048, 4096, torch.float16) is None
+
+
+def test_l3_env_killswitch_on_when_env_set():
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    assert g.lookup(2048, 2048, 4096, torch.float16) == {"num_stages": 2}
+
+
+def test_l3_env_killswitch_recognizes_truthy_synonyms():
+    g = _make_gate()
+    for v in ("1", "true", "TRUE", "yes", "Yes"):
+        os.environ["TB_TEST_ENABLE"] = v
+        assert g.lookup(2048, 2048, 4096, torch.float16) is not None, v
+
+
+def test_l3_env_killswitch_rejects_falsey_strings():
+    g = _make_gate()
+    for v in ("0", "false", "no", "off", ""):
+        os.environ["TB_TEST_ENABLE"] = v
+        assert g.lookup(2048, 2048, 4096, torch.float16) is None, v
+
+
+def test_l3_env_killswitch_rechecked_per_call():
+    """L3: lru_cache must NOT have memoized the env state; flipping the
+    env mid-test changes the next call's result without restart."""
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    assert g.lookup(2048, 2048, 4096, torch.float16) is not None
+    os.environ.pop("TB_TEST_ENABLE", None)
+    assert g.lookup(2048, 2048, 4096, torch.float16) is None
+
+
+# ---------------------------------------------------------------------------
+# L4 -- LDS-budget guard at call site
+# ---------------------------------------------------------------------------
+def test_l4_lds_ok_helper_at_budget_passes():
+    # 2 * (128+128) * 64 * 2 = 65536 -> exactly at gfx942 budget
+    assert GO.lds_ok(128, 128, 64, num_stages=2, bytes_per_elem=2, arch="gfx942")
+
+
+def test_l4_lds_ok_helper_over_budget_fails():
+    # +1 stage breaks the budget on gfx942
+    assert not GO.lds_ok(128, 128, 64, num_stages=3, bytes_per_elem=2, arch="gfx942")
+
+
+def test_l4_lds_guard_blocks_oversize_tile_via_dispatcher():
+    """L4: dispatcher shim refuses to apply an LDS-overstuffing override."""
+    g = GuardedOverride(
+        ticket="K-TEST", env_var="TB_TEST_ENABLE",
+        cohort_keys=[(2048, 2048, 4096, torch.float16)],
+        override_fn=lambda M, N, K, dt: {
+            "BLOCK_SIZE_M": 1024, "BLOCK_SIZE_N": 1024, "BLOCK_SIZE_K": 1024,
+            "num_stages": 4,
+        },
+    )
+    OverrideRegistry.register(g)
+    os.environ["TB_TEST_ENABLE"] = "1"
+    out = apply_override_in_dispatcher(
+        2048, 2048, 4096, torch.float16,
+        block_m=128, block_n=128, block_k=64,
+        num_stages=2, num_warps=8, waves_per_eu=0,
+        kpack=1, mfma_instr_size=16,
+        total_tiles=256, n_cu=304,
+        bytes_per_elem=2, arch="gfx942",
+    )
+    assert out.get("lds_blocked") is True
+
+
+def test_l4_lds_budget_overridable_per_arch():
+    """L4: arch-specific budgets can be set/queried."""
+    set_arch_lds_budget("gfx-test-arch", 32768)
+    assert lds_budget_for("gfx-test-arch") == 32768
+    # Default budget kicks in for unknown arch (default is non-zero).
+    assert lds_budget_for("gfx-unknown-99") > 0
+
+
+# ---------------------------------------------------------------------------
+# L5 -- composability guard (refuses under work_stealing by default)
+# ---------------------------------------------------------------------------
+def test_l5_composability_guard_refuses_under_work_stealing():
+    g = _make_gate()
+    OverrideRegistry.register(g)
+    os.environ["TB_TEST_ENABLE"] = "1"
+    out = apply_override_in_dispatcher(
+        2048, 2048, 4096, torch.float16,
+        block_m=128, block_n=128, block_k=64,
+        num_stages=4, num_warps=8, waves_per_eu=0,
+        kpack=1, mfma_instr_size=16,
+        total_tiles=256, n_cu=304,
+        work_stealing=True,
+    )
+    assert out == {}, "L5: work_stealing must suppress the gate"
+
+
+def test_l5_composability_guard_fires_when_no_work_stealing():
+    g = _make_gate()
+    OverrideRegistry.register(g)
+    os.environ["TB_TEST_ENABLE"] = "1"
+    out = apply_override_in_dispatcher(
+        2048, 2048, 4096, torch.float16,
+        block_m=128, block_n=128, block_k=64,
+        num_stages=4, num_warps=8, waves_per_eu=0,
+        kpack=1, mfma_instr_size=16,
+        total_tiles=256, n_cu=304,
+        work_stealing=False,
+    )
+    assert out.get("fired_ticket") == "K-TEST"
+
+
+def test_l5_composability_guard_can_be_overridden_explicitly():
+    """L5: gate authors can opt in to work-stealing-safe behavior with a
+    custom composability_guard (e.g. lambda ws: True)."""
+    g = GuardedOverride(
+        ticket="K-TEST", env_var="TB_TEST_ENABLE",
+        cohort_keys=[(2048, 2048, 4096, torch.float16)],
+        override_fn=lambda M, N, K, dt: {"num_stages": 2},
+        composability_guard=lambda ws: True,
+    )
+    OverrideRegistry.register(g)
+    os.environ["TB_TEST_ENABLE"] = "1"
+    out = apply_override_in_dispatcher(
+        2048, 2048, 4096, torch.float16,
+        block_m=128, block_n=128, block_k=64,
+        num_stages=4, num_warps=8, waves_per_eu=0,
+        kpack=1, mfma_instr_size=16,
+        total_tiles=256, n_cu=304,
+        work_stealing=True,
+    )
+    assert out.get("fired_ticket") == "K-TEST"
+
+
+# ---------------------------------------------------------------------------
+# L6 -- routing-trace counters (per-key + thread-safe)
+# ---------------------------------------------------------------------------
+def test_l6_routing_counters_track_fires_and_nonfires():
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    g.lookup(2048, 2048, 4096, torch.float16)  # fire
+    g.lookup(2048, 2048, 4096, torch.float16)  # fire
+    g.lookup(2048, 2048, 9999, torch.float16)  # nonfire (OOC)
+    g.lookup(2048, 2048, 4096, torch.float64)  # nonfire (dtype out of allowlist)
+    snap = g.routing_snapshot()
+    assert snap["fire_total"] == 2
+    assert snap["nonfire_total"] == 2
+    assert snap["per_key_fires"][(2048, 2048, 4096, torch.float16)] == 2
+
+
+def test_l6_routing_counters_thread_safe():
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    N = 200
+
+    def worker():
+        for _ in range(N):
+            g.lookup(2048, 2048, 4096, torch.float16)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+    snap = g.routing_snapshot()
+    assert snap["fire_total"] == 8 * N
+
+
+def test_l6_routing_counters_resettable():
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    g.lookup(2048, 2048, 4096, torch.float16)
+    g.reset_counters()
+    assert g.routing_snapshot()["fire_total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# L7 -- cohort-size cap (K-883 §5 C3)
+# ---------------------------------------------------------------------------
+def test_l7_cohort_size_cap_rejects_oversize_table():
+    keys = [(i, 2048, 4096, torch.float16) for i in range(40)]
+    with pytest.raises(ValueError, match="cohort_size"):
+        GuardedOverride(
+            ticket="K-TEST", env_var="TB_TEST_ENABLE",
+            cohort_keys=keys, override_fn=lambda *a: {},
+        )
+
+
+def test_l7_cohort_size_cap_can_be_raised_with_explicit_justification():
+    """L7: authors can raise the cap, but must do so explicitly."""
+    keys = [(i, 2048, 4096, torch.float16) for i in range(40)]
+    g = GuardedOverride(
+        ticket="K-TEST", env_var="TB_TEST_ENABLE",
+        cohort_keys=keys, override_fn=lambda *a: {}, cohort_size_cap=50,
+    )
+    assert len(g.cohort_keys) == 40
+
+
+# ---------------------------------------------------------------------------
+# L8 -- registry idempotence + R1 dispatch-order routing
+# ---------------------------------------------------------------------------
+def test_l8_registry_refuses_duplicate_ticket():
+    g1 = _make_gate(ticket="K-TEST")
+    g2 = _make_gate(ticket="K-TEST")
+    a = OverrideRegistry.register(g1)
+    b = OverrideRegistry.register(g2)
+    # idempotent: second register returns the original.
+    assert a is g1
+    assert b is g1
+
+
+def test_l8_r1_dispatch_order_first_routing():
+    """R1: registry returns the first matching gate in registration order."""
+    g1 = _make_gate(ticket="K-TEST", env="TB_TEST_ENABLE",
+                    keys=[(2048, 2048, 4096, torch.float16)])
+    g1.override_fn = lambda M, N, K, dt: {"num_stages": 2}
+    g2 = _make_gate(ticket="K-TEST-2", env="TB_TEST_2_ENABLE",
+                    keys=[(2048, 2048, 4096, torch.float16)])
+    g2.override_fn = lambda M, N, K, dt: {"num_stages": 4}
+    OverrideRegistry.register(g1)
+    OverrideRegistry.register(g2)
+    os.environ["TB_TEST_ENABLE"] = "1"
+    os.environ["TB_TEST_2_ENABLE"] = "1"
+    hit = OverrideRegistry.apply(2048, 2048, 4096, torch.float16)
+    assert hit is not None
+    gate, payload = hit
+    assert gate.ticket == "K-TEST"
+    assert payload["num_stages"] == 2  # g1 wins, NOT g2
+
+
+# ---------------------------------------------------------------------------
+# L9 -- paired CI (paired_t, n>=30 paired samples, Student-t)
+# ---------------------------------------------------------------------------
+def test_l9_t_crit_95_returns_at_least_normal_value():
+    """L9: 95% CI multiplier is monotonic and converges to 1.96 for large df."""
+    assert _t_crit_95(1) > _t_crit_95(30)
+    assert _t_crit_95(30) >= 1.96
+    assert _t_crit_95(120) >= 1.96
+    # df<=0 returns NaN (no CI possible).
+    assert math.isnan(_t_crit_95(0))
+
+
+def test_l9_paired_delta_zero_when_inputs_equal():
+    on  = [1.0] * 32
+    off = [1.0] * 32
+    mean, lo, hi, n = _paired_delta_with_ci(on, off)
+    assert n == 32
+    assert mean == 0.0
+    # CI must straddle 0 for identical inputs (sd=0 -> CI=[0,0]).
+    assert lo <= 0.0 <= hi
+
+
+def test_l9_paired_delta_positive_when_on_faster():
+    """On a clean +10% speedup signal the CI must exclude 0 with n=30."""
+    on  = [0.90] * 30
+    off = [1.00] * 30
+    mean, lo, hi, n = _paired_delta_with_ci(on, off)
+    assert n == 30
+    assert mean == pytest.approx(10.0, abs=1e-6)
+    # No variance -> CI collapses to mean.
+    assert lo == pytest.approx(10.0, abs=1e-6)
+    assert hi == pytest.approx(10.0, abs=1e-6)
+
+
+def test_l9_paired_delta_ci_excludes_zero_when_signal_clear_of_noise():
+    """A real +5% signal under Gaussian noise must exclude 0 from the CI."""
+    import random
+    random.seed(0)
+    off = [1.0 + random.gauss(0, 0.005) for _ in range(50)]
+    on  = [v * 0.95 + random.gauss(0, 0.005) for v in off]
+    mean, lo, hi, n = _paired_delta_with_ci(on, off)
+    assert n == 50
+    assert mean > 4.0      # ~5% speedup
+    assert lo > 0.0        # CI strictly positive: signal beats noise
+    assert hi > mean
+
+
+# ---------------------------------------------------------------------------
+# Synthetic LAND-path integration test (proves the harness can APPROVE)
+# ---------------------------------------------------------------------------
+def _synthetic_cell(M, K, dtype, in_cohort, off_ms, on_ms, ref_ms,
+                    on_vs_off_pct, on_vs_off_ci=(None, None), fired=False,
+                    classification=None):
+    n = 30
+    if classification is None:
+        classification = "SPEEDUP" if on_vs_off_pct >= 5.0 else (
+            "REGRESS" if on_vs_off_pct <= -5.0 else "IN_BAND")
+    lo, hi = on_vs_off_ci if on_vs_off_ci != (None, None) else (
+        on_vs_off_pct - 0.5, on_vs_off_pct + 0.5)
+    return CellResult(
+        M=M, N=2048, K=K, dtype=str(dtype).replace("torch.", ""), batch=1,
+        in_cohort=in_cohort,
+        ms_off_med=off_ms, ms_on_med=on_ms, ms_ref_med=ref_ms,
+        ms_off_raw=[off_ms]*n, ms_on_raw=[on_ms]*n, ms_ref_raw=[ref_ms]*n,
+        n_paired=n,
+        delta_pct_on_vs_off=on_vs_off_pct,
+        delta_pct_on_vs_off_ci_lo=lo,
+        delta_pct_on_vs_off_ci_hi=hi,
+        delta_pct_on_vs_ref=0.0,
+        delta_pct_on_vs_ref_ci_lo=-1.0,
+        delta_pct_on_vs_ref_ci_hi=1.0,
+        paired_spread_pct=2.0,
+        classification=classification,
+        fired=fired,
+    )
+
+
+def test_synthetic_land_path_yields_land_verdict():
+    """A synthetic override that delivers +10% in-cohort with no OOC bleed
+    and a clean routing trace MUST receive a LAND verdict.  This proves the
+    harness can actually approve a valid override (not just a reject-only
+    machine)."""
+    keys = [(2048, 2048, 4096, torch.float16),
+            (2048, 2048, 8192, torch.float16)]
+    gate = GuardedOverride(
+        ticket="K-TEST-LAND", env_var="TB_TEST_LAND_ENABLE",
+        cohort_keys=keys,
+        override_fn=lambda *a: {"num_stages": 2},
+    )
+    # In-cohort: clean +10% paired delta with CI excluding 0 -> SPEEDUP
+    in_c = [
+        _synthetic_cell(2048, 4096, torch.float16, True,
+                        off_ms=1.000, on_ms=0.900, ref_ms=1.000,
+                        on_vs_off_pct=10.0, on_vs_off_ci=(8.0, 12.0),
+                        fired=True, classification="SPEEDUP"),
+        _synthetic_cell(2048, 8192, torch.float16, True,
+                        off_ms=2.000, on_ms=1.800, ref_ms=2.000,
+                        on_vs_off_pct=10.0, on_vs_off_ci=(8.0, 12.0),
+                        fired=True, classification="SPEEDUP"),
+    ]
+    # OOC: in-band only (no regress). Routing didn't fire.
+    ooc = [
+        _synthetic_cell(512, 512, torch.float16, False,
+                        off_ms=1.000, on_ms=0.999, ref_ms=1.000,
+                        on_vs_off_pct=0.1, fired=False,
+                        classification="IN_BAND"),
+        _synthetic_cell(4096, 4096, torch.float16, False,
+                        off_ms=1.000, on_ms=1.001, ref_ms=1.000,
+                        on_vs_off_pct=-0.1, fired=False,
+                        classification="IN_BAND"),
+    ]
+    snap = {
+        "ticket": "K-TEST-LAND",
+        "fire_total": 2, "nonfire_total": 2,
+        "per_key_fires": {keys[0]: 1, keys[1]: 1},
+    }
+    verdict = _compute_verdict(gate, in_c + ooc, snap)
+    assert verdict.land, verdict.report
+    assert verdict.routing_n_intended_fires == 2
+    assert verdict.routing_n_ooc_fires == 0
+    assert verdict.in_cohort_geomean_speedup >= 1.05
+
+
+def test_synthetic_no_land_path_yields_no_land_verdict_on_ooc_regress():
+    """An override that delivers in-cohort speedup but causes a real OOC
+    regression (CI upper bound below 0) MUST be rejected."""
+    keys = [(2048, 2048, 4096, torch.float16)]
+    gate = GuardedOverride(
+        ticket="K-TEST-LAND", env_var="TB_TEST_LAND_ENABLE",
+        cohort_keys=keys, override_fn=lambda *a: {"num_stages": 2},
+    )
+    in_c = [_synthetic_cell(2048, 4096, torch.float16, True,
+                            off_ms=1.0, on_ms=0.9, ref_ms=1.0,
+                            on_vs_off_pct=10.0, on_vs_off_ci=(8.0, 12.0),
+                            fired=True, classification="SPEEDUP")]
+    # OOC cell with REAL regression: CI strictly below 0
+    ooc = [_synthetic_cell(512, 512, torch.float16, False,
+                           off_ms=1.0, on_ms=1.10, ref_ms=1.0,
+                           on_vs_off_pct=-10.0, on_vs_off_ci=(-12.0, -8.0),
+                           fired=False, classification="REGRESS")]
+    snap = {"ticket": "K-TEST-LAND", "fire_total": 1, "nonfire_total": 1,
+            "per_key_fires": {keys[0]: 1}}
+    verdict = _compute_verdict(gate, in_c + ooc, snap)
+    assert not verdict.land
+    assert verdict.ooc_n_regress == 1
+
+
+def test_synthetic_no_land_with_single_trial_noise_is_not_classified_regress():
+    """K-901 reviewer requirement: a 'REGRESS' classification whose 95% CI
+    upper bound straddles 0 is NOISE, not a true regression -- the verdict
+    must NOT count it as a regressor (so cells like K-882's -3.90% point are
+    statistically defensible, not single-trial noise)."""
+    keys = [(2048, 2048, 4096, torch.float16)]
+    gate = GuardedOverride(
+        ticket="K-TEST-LAND", env_var="TB_TEST_LAND_ENABLE",
+        cohort_keys=keys, override_fn=lambda *a: {"num_stages": 2},
+    )
+    in_c = [_synthetic_cell(2048, 4096, torch.float16, True,
+                            off_ms=1.0, on_ms=0.9, ref_ms=1.0,
+                            on_vs_off_pct=10.0, on_vs_off_ci=(8.0, 12.0),
+                            fired=True, classification="SPEEDUP")]
+    # Classifier flagged REGRESS but CI upper bound is positive -> noise.
+    ooc = [_synthetic_cell(512, 512, torch.float16, False,
+                           off_ms=1.0, on_ms=1.05, ref_ms=1.0,
+                           on_vs_off_pct=-5.0, on_vs_off_ci=(-12.0, +2.0),
+                           fired=False, classification="REGRESS")]
+    snap = {"ticket": "K-TEST-LAND", "fire_total": 1, "nonfire_total": 1,
+            "per_key_fires": {keys[0]: 1}}
+    verdict = _compute_verdict(gate, in_c + ooc, snap)
+    # Verdict must NOT count this as a regressor.
+    assert verdict.ooc_n_regress == 0
+
+
+# ---------------------------------------------------------------------------
+# K-882 fixture (regression test for the harness reject-path)
+# ---------------------------------------------------------------------------
+def test_k882_fixture_strict_keys_only():
+    """K-882 fixture: strict-equality cohort -- adjacent shapes must not fire."""
+    g = _k882_fixture()
+    OverrideRegistry.register(g)
+    os.environ["TB_K882_ENABLE"] = "1"
+    assert g.lookup(2048, 2048, 4096, torch.float16) is not None
+    assert g.lookup(2048, 2048, 5000, torch.float16) is None
+    assert g.lookup(2048, 2048, 4096, torch.float32) is None  # dtype guard
+
+
+def test_k882_fixture_off_by_default():
+    """K-882 fixture is OFF unless TB_K882_ENABLE is set."""
+    g = _k882_fixture()
+    os.environ.pop("TB_K882_ENABLE", None)
+    assert g.lookup(2048, 2048, 4096, torch.float16) is None
+
+
+def test_k882_not_in_production_registry():
+    """K-882 must NOT auto-register on production import (it's a fixture)."""
+    # Re-import to be sure overrides/__init__ is not pulled in.
+    import importlib
+    import tritonblas
+    importlib.reload(tritonblas)
+    tickets = [g.ticket for g in OverrideRegistry.all()]
+    assert "K-882" not in tickets, (
+        f"K-882 leaked into production registry: {tickets}.  "
+        f"It must live in tests/ only (NO-LAND verdict)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sanity: classifier helper
+# ---------------------------------------------------------------------------
+def test_classify_delta_noise_band():
+    # spread/2 = 1pp, but noise floor is 2pp -> band = 2pp.
+    assert _classify_delta(+1.5, paired_spread_pct=2.0) == "IN_BAND"
+    assert _classify_delta(+3.0, paired_spread_pct=2.0) == "SPEEDUP"
+    assert _classify_delta(-3.0, paired_spread_pct=2.0) == "REGRESS"
+    # Wide spread expands the noise band.
+    assert _classify_delta(+3.0, paired_spread_pct=10.0) == "IN_BAND"

--- a/tests/test_k1367_p13_skinny_n128.py
+++ b/tests/test_k1367_p13_skinny_n128.py
@@ -1,0 +1,248 @@
+"""K-1367 P13 + K-1361 P12 pin tests — torch-free.
+
+Validates the K-1379 productionisation of the K-1367 RETRY-winning 18-cell
+`_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18` frozenset stacked as the
+7th-position envelope on top of the K-1361 P12 55-cell baseline.
+
+These tests pin:
+  * cardinality of the new frozensets (P12=4, P13=18, total post-P13 = 73)
+  * exact membership of the K-1367 P13 18 cells (M ∈ {2048, 4096, 8192} ×
+    N=128 × K ∈ {4096, 8192, 16384} × {bf16, fp16})
+  * exact membership of the K-1361 P12 4 cells (M=N=K ∈ {2048, 4096} ×
+    {bf16, fp16})
+  * cross-frozenset disjointness between P12 / P13 / P8 / K971_ROUTE_TABLE
+  * dispatch precedence: dtype-mismatch / streamk / work-stealing carve-outs
+    short-circuit ahead of every strict-equality table
+
+Imports the actual shipped predicate module (`_route_predicate`) so the real
+runtime path is exercised; no exec/string-parse copies.
+"""
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from tritonblas._route_predicate import (
+    K971_ROUTE_TABLE,
+    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
+    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18,
+    _P8_MFMA_ISSUE_STALL_ROUTEOUT,
+    _k1361_p12_square_mid_routeout,
+    _k1367_p13_skinny_n128_kcomplement_routeout,
+    k971_route_decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# Cardinality pins.  Any deviation indicates an authoring typo against the
+# K-1308 / K-1227 / K-1345 / K-1367 bucket-rule resolution.
+# ---------------------------------------------------------------------------
+def test_p12_square_mid_cardinality_4():
+    assert len(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4) == 4
+
+
+def test_p13_skinny_n128_kcomplement_cardinality_18():
+    assert len(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18) == 18
+
+
+def test_envelope_total_post_p13_is_73():
+    """P8 (51) + K-1361 P12 (4) + K-1367 P13 (18) = 73 strict-equality cells.
+
+    K971_ROUTE_TABLE (12 cells: K-905/K-971 anchors + K-1335 longK_smallSquare)
+    is the 5th-position envelope; counted separately from the P8/P12/P13
+    7th-position chain because it gates on the LDS-bank-conflict mechanism
+    rather than the MFMA-issue-stall / square_mid / skinny_N128 mechanisms.
+    """
+    total = (
+        len(_P8_MFMA_ISSUE_STALL_ROUTEOUT)
+        + len(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
+        + len(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18)
+    )
+    assert total == 73, (
+        f"Expected 51 + 4 + 18 = 73 strict-equality cells across P8/P12/P13; "
+        f"got {total}.  Check that no frozenset has been mutated.")
+
+
+# ---------------------------------------------------------------------------
+# Exact-membership pins.  These deliberately enumerate every key so any
+# accidental drop / typo / re-ordering is caught at CI time.
+# ---------------------------------------------------------------------------
+def _expected_p13_18_cells():
+    """Construct the K-1367 P13 18-cell expected set from the bucket rule."""
+    return frozenset({
+        (M, 128, K, dt)
+        for M in (2048, 4096, 8192)
+        for K in (4096, 8192, 16384)
+        for dt in ("torch.bfloat16", "torch.float16")
+    })
+
+
+def _expected_p12_4_cells():
+    """Construct the K-1361 P12 4-cell expected set from the bucket rule."""
+    return frozenset({
+        (S, S, S, dt)
+        for S in (2048, 4096)
+        for dt in ("torch.bfloat16", "torch.float16")
+    })
+
+
+def test_p13_membership_exactly_18_kcomplement_cells():
+    expected = _expected_p13_18_cells()
+    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 == expected, (
+        "K-1367 P13 frozenset diverges from the K-COMPLEMENT bucket rule: "
+        "M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,8192,16384} × {bf16,fp16}.\n"
+        f"  missing : {sorted(expected - _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18)}\n"
+        f"  unknown : {sorted(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 - expected)}")
+
+
+def test_p12_membership_exactly_4_diagonal_cells():
+    expected = _expected_p12_4_cells()
+    assert _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4 == expected, (
+        "K-1361 P12 frozenset diverges from the K-1345 RANKED_BUCKETS_v2 "
+        "diagonal-only authoritative rule: M=N=K ∈ {2048,4096} × {bf16,fp16}.\n"
+        f"  missing : {sorted(expected - _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)}\n"
+        f"  unknown : {sorted(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4 - expected)}")
+
+
+# ---------------------------------------------------------------------------
+# Disjointness pins.  Cheap insurance per
+# R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.
+# ---------------------------------------------------------------------------
+def test_p13_disjoint_from_p8():
+    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(
+        _P8_MFMA_ISSUE_STALL_ROUTEOUT)
+
+
+def test_p13_disjoint_from_k971_route_table():
+    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(
+        K971_ROUTE_TABLE)
+
+
+def test_p13_disjoint_from_p12():
+    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(
+        _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
+
+
+def test_p12_disjoint_from_p8():
+    assert _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4.isdisjoint(
+        _P8_MFMA_ISSUE_STALL_ROUTEOUT)
+
+
+def test_p12_disjoint_from_k971_route_table():
+    assert _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4.isdisjoint(K971_ROUTE_TABLE)
+
+
+# ---------------------------------------------------------------------------
+# Per-cell predicate behaviour.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_p13_18_cells()))
+def test_p13_predicate_admits_every_kcomplement_cell(M, N, K, dtype):
+    assert _k1367_p13_skinny_n128_kcomplement_routeout(M, N, K, dtype) is True
+
+
+@pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_p12_4_cells()))
+def test_p12_predicate_admits_every_diagonal_cell(M, N, K, dtype):
+    assert _k1361_p12_square_mid_routeout(M, N, K, dtype) is True
+
+
+# ---------------------------------------------------------------------------
+# Negative-control pins (cells immediately adjacent to the cohort that MUST
+# NOT fire — guards against axis over-relaxation).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("M,N,K,dtype", [
+    # K below the K=4096 wrapper-overhead floor (K-1227 still owns these)
+    (2048, 128, 2048, "torch.bfloat16"),
+    (4096, 128, 2048, "torch.float16"),
+    # M below the M=2048 cohort floor
+    (1024, 128, 4096, "torch.bfloat16"),
+    (1024, 128, 8192, "torch.float16"),
+    # M above the M=8192 cohort ceiling
+    (16384, 128, 4096, "torch.bfloat16"),
+    # N off the N=128 column-narrow regime
+    (2048, 64, 4096, "torch.bfloat16"),
+    (2048, 256, 4096, "torch.bfloat16"),
+    # K above the K=16384 cohort ceiling
+    (2048, 128, 32768, "torch.bfloat16"),
+    # dtype outside the bf16/fp16 K-913 §3 invariance class
+    (2048, 128, 4096, "torch.float32"),
+])
+def test_p13_predicate_rejects_axis_perturbations(M, N, K, dtype):
+    assert _k1367_p13_skinny_n128_kcomplement_routeout(M, N, K, dtype) is False
+
+
+@pytest.mark.parametrize("M,N,K,dtype", [
+    # off-diagonal cells (K-1345 RANKED_BUCKETS_v2 routes these to K-1313 WIDE)
+    (2048, 2048, 4096, "torch.bfloat16"),  # also a K-1335 LDS-BC anchor
+    (4096, 4096, 2048, "torch.bfloat16"),
+    (2048, 4096, 4096, "torch.bfloat16"),
+    # 8192³ — DROP_HBM_BOUND per K-1308 F4 / K-879 N2a
+    (8192, 8192, 8192, "torch.bfloat16"),
+    # dtype outside K-913 §3 invariance class
+    (2048, 2048, 2048, "torch.float32"),
+])
+def test_p12_predicate_rejects_off_diagonal_and_dropped_cells(M, N, K, dtype):
+    assert _k1361_p12_square_mid_routeout(M, N, K, dtype) is False
+
+
+# ---------------------------------------------------------------------------
+# Full dispatch decision — exercises the 7-position precedence chain.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_p13_18_cells()))
+def test_full_dispatch_routes_every_p13_cell_to_hbl(M, N, K, dtype):
+    """K-1367 P13 admits MUST route to hipBLASLt under default carve-out
+    settings (no streamk, no work-stealing, matched dtype).
+    """
+    assert k971_route_decision(M, N, K, dtype, dtype, False, False) is True
+
+
+@pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_p12_4_cells()))
+def test_full_dispatch_routes_every_p12_cell_to_hbl(M, N, K, dtype):
+    assert k971_route_decision(M, N, K, dtype, dtype, False, False) is True
+
+
+# ---------------------------------------------------------------------------
+# Carve-out short-circuits — a P13 admit cell must NOT route to hipBLASLt
+# when streamk / work-stealing / mismatched-dtype is requested.  This is
+# load-bearing for the matmul.py kwarg surface (PR description Test Plan).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("enable_streamk,work_stealing,b_dtype", [
+    (True,  False, "torch.bfloat16"),  # streamk requested
+    (False, True,  "torch.bfloat16"),  # work-stealing requested
+    (False, False, "torch.float16"),   # mixed dtype (a bf16, b fp16)
+])
+def test_p13_admit_cell_carveout_short_circuits(enable_streamk, work_stealing, b_dtype):
+    # Pick a known P13 admit cell.
+    a_dtype = "torch.bfloat16"
+    M, N, K = 4096, 128, 8192
+    assert (M, N, K, a_dtype) in _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18
+    routed = k971_route_decision(M, N, K, a_dtype, b_dtype,
+                                 enable_streamk, work_stealing)
+    assert routed is False, (
+        f"P13 admit cell ({M},{N},{K},{a_dtype}) must NOT route to hipBLASLt "
+        f"when carve-out applies (streamk={enable_streamk}, "
+        f"work_stealing={work_stealing}, b_dtype={b_dtype}); short-circuit "
+        f"in _k971_route_to_hbl is load-bearing.")
+
+
+# ---------------------------------------------------------------------------
+# Regression firewall — every cell in the K-1335 / K-1322 / K-905 prior
+# envelopes still routes to hipBLASLt after the P12 + P13 stack.
+# Per R-1322.STRICT-EQUALITY-UNION-PRESERVES-PRIOR-ADMIT-INVARIANCE; the new
+# envelopes are unioned via short-circuit `if ... return True` so prior
+# admits cannot be removed by the diff.
+# ---------------------------------------------------------------------------
+def test_no_regression_on_k971_route_table_prior_admits():
+    for (M, N, K, dt) in K971_ROUTE_TABLE:
+        assert k971_route_decision(M, N, K, dt, dt, False, False) is True, (
+            f"K971_ROUTE_TABLE prior admit ({M},{N},{K},{dt}) was lost after "
+            f"P12 + P13 stack; the P13 productionisation must preserve every "
+            f"prior 5th-position envelope cell (regression firewall).")
+
+
+def test_no_regression_on_p8_prior_admits():
+    for (M, N, K, dt) in _P8_MFMA_ISSUE_STALL_ROUTEOUT:
+        assert k971_route_decision(M, N, K, dt, dt, False, False) is True, (
+            f"P8 prior admit ({M},{N},{K},{dt}) was lost after P12 + P13 "
+            f"stack; the P13 productionisation must preserve every prior "
+            f"P8 sub-frozenset cell (regression firewall).")

--- a/tests/test_k1367_p13_skinny_n128.py
+++ b/tests/test_k1367_p13_skinny_n128.py
@@ -1,7 +1,7 @@
 """K-1367 P13 + K-1361 P12 pin tests — torch-free.
 
 Validates the K-1379 productionisation of the K-1367 RETRY-winning 18-cell
-`_K1367_P13_SKINNY_N128_ROUTEOUT_18` frozenset stacked as the
+`_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18` frozenset stacked as the
 7th-position envelope on top of the K-1361 P12 55-cell baseline.
 
 These tests pin:
@@ -26,7 +26,7 @@ import pytest
 from tritonblas._route_predicate import (
     K971_ROUTE_TABLE,
     _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
-    _K1367_P13_SKINNY_N128_ROUTEOUT_18,
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
     _P8_MFMA_ISSUE_STALL_ROUTEOUT,
     _k1361_p12_square_mid_routeout,
     _k1367_p13_skinny_n128_routeout,
@@ -43,7 +43,7 @@ def test_p12_square_mid_cardinality_4():
 
 
 def test_p13_skinny_n128_kcomplement_cardinality_18():
-    assert len(_K1367_P13_SKINNY_N128_ROUTEOUT_18) == 18
+    assert len(_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18) == 18
 
 
 def test_envelope_total_post_p13_is_73():
@@ -57,7 +57,7 @@ def test_envelope_total_post_p13_is_73():
     total = (
         len(_P8_MFMA_ISSUE_STALL_ROUTEOUT)
         + len(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
-        + len(_K1367_P13_SKINNY_N128_ROUTEOUT_18)
+        + len(_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18)
     )
     assert total == 73, (
         f"Expected 51 + 4 + 18 = 73 strict-equality cells across P8/P12/P13; "
@@ -89,11 +89,11 @@ def _expected_p12_4_cells():
 
 def test_p13_membership_exactly_18_kcomplement_cells():
     expected = _expected_p13_18_cells()
-    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18 == expected, (
+    assert _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 == expected, (
         "K-1367 P13 frozenset diverges from the K-COMPLEMENT bucket rule: "
         "M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,8192,16384} × {bf16,fp16}.\n"
-        f"  missing : {sorted(expected - _K1367_P13_SKINNY_N128_ROUTEOUT_18)}\n"
-        f"  unknown : {sorted(_K1367_P13_SKINNY_N128_ROUTEOUT_18 - expected)}")
+        f"  missing : {sorted(expected - _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18)}\n"
+        f"  unknown : {sorted(_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 - expected)}")
 
 
 def test_p12_membership_exactly_4_diagonal_cells():
@@ -110,17 +110,17 @@ def test_p12_membership_exactly_4_diagonal_cells():
 # R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.
 # ---------------------------------------------------------------------------
 def test_p13_disjoint_from_p8():
-    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(
+    assert _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18.isdisjoint(
         _P8_MFMA_ISSUE_STALL_ROUTEOUT)
 
 
 def test_p13_disjoint_from_k971_route_table():
-    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(
+    assert _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18.isdisjoint(
         K971_ROUTE_TABLE)
 
 
 def test_p13_disjoint_from_p12():
-    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(
+    assert _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18.isdisjoint(
         _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
 
 
@@ -215,7 +215,7 @@ def test_p13_admit_cell_carveout_short_circuits(enable_streamk, work_stealing, b
     # Pick a known P13 admit cell.
     a_dtype = "torch.bfloat16"
     M, N, K = 4096, 128, 8192
-    assert (M, N, K, a_dtype) in _K1367_P13_SKINNY_N128_ROUTEOUT_18
+    assert (M, N, K, a_dtype) in _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18
     routed = k971_route_decision(M, N, K, a_dtype, b_dtype,
                                  enable_streamk, work_stealing)
     assert routed is False, (
@@ -246,3 +246,51 @@ def test_no_regression_on_p8_prior_admits():
             f"P8 prior admit ({M},{N},{K},{dt}) was lost after P12 + P13 "
             f"stack; the P13 productionisation must preserve every prior "
             f"P8 sub-frozenset cell (regression firewall).")
+
+
+# ---------------------------------------------------------------------------
+# K-1389 boundary controls — adjacent non-admitted cells in the
+# skinny_N128 K-COMPLEMENT region MUST still route to triton (i.e.
+# k971_route_decision == False), proving the strict-equality frozenset
+# does NOT spill into neighbouring shapes.  Reviewer-mandated negative
+# controls per the K-1389 brief.
+# ---------------------------------------------------------------------------
+_K1389_BOUNDARY_TRITON_CELLS = [
+    # M=1024 — directly below the M=2048 cohort floor; same N=128, same K
+    # range as P13 admits.  Must route to triton: M=1024 is occupancy-bound
+    # at N=128 and the wrapper-overhead/K-time crossover does not flip yet.
+    (1024,   128,  4096, "torch.bfloat16"),
+    (1024,   128,  4096, "torch.float16"),
+    (1024,   128,  8192, "torch.bfloat16"),
+    # M=16384 — directly above the M=8192 cohort ceiling; same N=128, same
+    # K range.  Must route to triton: persistent_matmul scales linearly
+    # with M and the K-913 LDS-BC discriminator inverts past M=8192 because
+    # the per-CU wave footprint amortises the bank conflicts.
+    (16384,  128,  4096, "torch.bfloat16"),
+    (16384,  128,  8192, "torch.bfloat16"),
+    (16384,  128, 16384, "torch.bfloat16"),
+]
+
+
+@pytest.mark.parametrize("M,N,K,dtype", _K1389_BOUNDARY_TRITON_CELLS)
+def test_k1389_p13_does_not_spill_into_adjacent_n128_kcompl_cells(M, N, K, dtype):
+    """K-1389 negative control: adjacent non-admitted cells (M=1024 N=128,
+    M=16384 N=128) MUST NOT be admitted by the P13 strict-equality
+    frozenset _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 nor by the P13
+    per-cell predicate ``_k1367_p13_skinny_n128_routeout``.
+
+    NOTE: end-to-end ``k971_route_decision`` may still return True on
+    these cells via the EARLIER R-K979 P5 closed-form structural
+    pathology predicate (which routes large-K narrow-N shapes to
+    hipBLASLt as a separate mechanism).  That is intentional and out of
+    scope for K-1389 — K-1389 is a strict-equality additive extension to
+    P13, not a re-tuning of P5.  This test isolates the P13-specific
+    no-spill claim from the end-to-end routing decision.
+    """
+    assert (M, N, K, dtype) not in _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18, (
+        f"Boundary control cell ({M},{N},{K},{dtype}) is in the P13 admit "
+        f"frozenset; the K-1389 boundary table is mis-specified.")
+    assert _k1367_p13_skinny_n128_routeout(M, N, K, dtype) is False, (
+        f"K-1389 adjacent boundary cell ({M},{N},{K},{dtype}) was admitted "
+        f"by the P13 per-cell predicate; strict-equality frozenset must NOT "
+        f"spill into adjacent M={M} cells.")

--- a/tests/test_k1367_p13_skinny_n128.py
+++ b/tests/test_k1367_p13_skinny_n128.py
@@ -1,7 +1,7 @@
 """K-1367 P13 + K-1361 P12 pin tests — torch-free.
 
 Validates the K-1379 productionisation of the K-1367 RETRY-winning 18-cell
-`_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18` frozenset stacked as the
+`_K1367_P13_SKINNY_N128_ROUTEOUT_18` frozenset stacked as the
 7th-position envelope on top of the K-1361 P12 55-cell baseline.
 
 These tests pin:
@@ -26,10 +26,10 @@ import pytest
 from tritonblas._route_predicate import (
     K971_ROUTE_TABLE,
     _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
-    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18,
+    _K1367_P13_SKINNY_N128_ROUTEOUT_18,
     _P8_MFMA_ISSUE_STALL_ROUTEOUT,
     _k1361_p12_square_mid_routeout,
-    _k1367_p13_skinny_n128_kcomplement_routeout,
+    _k1367_p13_skinny_n128_routeout,
     k971_route_decision,
 )
 
@@ -43,7 +43,7 @@ def test_p12_square_mid_cardinality_4():
 
 
 def test_p13_skinny_n128_kcomplement_cardinality_18():
-    assert len(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18) == 18
+    assert len(_K1367_P13_SKINNY_N128_ROUTEOUT_18) == 18
 
 
 def test_envelope_total_post_p13_is_73():
@@ -57,7 +57,7 @@ def test_envelope_total_post_p13_is_73():
     total = (
         len(_P8_MFMA_ISSUE_STALL_ROUTEOUT)
         + len(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
-        + len(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18)
+        + len(_K1367_P13_SKINNY_N128_ROUTEOUT_18)
     )
     assert total == 73, (
         f"Expected 51 + 4 + 18 = 73 strict-equality cells across P8/P12/P13; "
@@ -89,11 +89,11 @@ def _expected_p12_4_cells():
 
 def test_p13_membership_exactly_18_kcomplement_cells():
     expected = _expected_p13_18_cells()
-    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 == expected, (
+    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18 == expected, (
         "K-1367 P13 frozenset diverges from the K-COMPLEMENT bucket rule: "
         "M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,8192,16384} × {bf16,fp16}.\n"
-        f"  missing : {sorted(expected - _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18)}\n"
-        f"  unknown : {sorted(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 - expected)}")
+        f"  missing : {sorted(expected - _K1367_P13_SKINNY_N128_ROUTEOUT_18)}\n"
+        f"  unknown : {sorted(_K1367_P13_SKINNY_N128_ROUTEOUT_18 - expected)}")
 
 
 def test_p12_membership_exactly_4_diagonal_cells():
@@ -110,17 +110,17 @@ def test_p12_membership_exactly_4_diagonal_cells():
 # R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.
 # ---------------------------------------------------------------------------
 def test_p13_disjoint_from_p8():
-    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(
+    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(
         _P8_MFMA_ISSUE_STALL_ROUTEOUT)
 
 
 def test_p13_disjoint_from_k971_route_table():
-    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(
+    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(
         K971_ROUTE_TABLE)
 
 
 def test_p13_disjoint_from_p12():
-    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(
+    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(
         _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
 
 
@@ -138,7 +138,7 @@ def test_p12_disjoint_from_k971_route_table():
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_p13_18_cells()))
 def test_p13_predicate_admits_every_kcomplement_cell(M, N, K, dtype):
-    assert _k1367_p13_skinny_n128_kcomplement_routeout(M, N, K, dtype) is True
+    assert _k1367_p13_skinny_n128_routeout(M, N, K, dtype) is True
 
 
 @pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_p12_4_cells()))
@@ -168,7 +168,7 @@ def test_p12_predicate_admits_every_diagonal_cell(M, N, K, dtype):
     (2048, 128, 4096, "torch.float32"),
 ])
 def test_p13_predicate_rejects_axis_perturbations(M, N, K, dtype):
-    assert _k1367_p13_skinny_n128_kcomplement_routeout(M, N, K, dtype) is False
+    assert _k1367_p13_skinny_n128_routeout(M, N, K, dtype) is False
 
 
 @pytest.mark.parametrize("M,N,K,dtype", [
@@ -215,7 +215,7 @@ def test_p13_admit_cell_carveout_short_circuits(enable_streamk, work_stealing, b
     # Pick a known P13 admit cell.
     a_dtype = "torch.bfloat16"
     M, N, K = 4096, 128, 8192
-    assert (M, N, K, a_dtype) in _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18
+    assert (M, N, K, a_dtype) in _K1367_P13_SKINNY_N128_ROUTEOUT_18
     routed = k971_route_decision(M, N, K, a_dtype, b_dtype,
                                  enable_streamk, work_stealing)
     assert routed is False, (

--- a/tests/test_k971_route_predicate.py
+++ b/tests/test_k971_route_predicate.py
@@ -1,0 +1,1903 @@
+"""K-1003 R-K979 P5 Gate-0 admission predicate — integration tests.
+
+Verifies the closed-form predicate AND the full ``_k971_route_to_hbl``
+dispatch decision (predicate + strict-equality table + streamk /
+work-stealing / dtype-mismatch carve-outs) match the K-979 verification
+contract:
+
+  * On the K-984 + K-989 union (14 unique K-931 shapes), the predicate
+    must FIRE on all 14.
+  * On the K-950 9-cell LAND set, the predicate alone must NOT fire on
+    any (zero leakage from the closed-form), and the full dispatch must
+    only route the 3 K-905 anchor-collision tuples (a documented design
+    decision — K-905 measurements override the K-950 verdict on those
+    exact tuples).
+  * The streamk / work-stealing / mismatched-dtype carve-outs must
+    short-circuit to ``False`` regardless of the predicate verdict.
+
+These tests import the actual shipped predicate (`_route_predicate`) and
+the actual shipped dispatch helper (`matmul._k971_route_to_hbl`) so the
+*real* code path users hit is exercised — no exec/string-parse copies.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tritonblas._route_predicate import (
+    R_K979_P5_route_to_hbl,
+    R_K1037_P6_admit_wpeu1,
+    K971_ROUTE_TABLE,
+    _K905_K971_LDS_BC_ANCHORS_8,
+    _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4,
+    _K1109_P6_K1074_ALLOWLIST,
+    _K1109_P6_K1074_REGRESSION_EXCLUSIONS,
+    _K1109_P6_ALLOWLIST_ENV,
+    _p8_mfma_issue_stall_routeout,
+    _P8_MFMA_ISSUE_STALL_ROUTEOUT,
+    _K1121_P8_ANCHORS_13,
+    _K1131_P8_NEIGHBORS_12,
+    _K1161_E2_ADMITS_3,
+    _K1205_EN3_ADMITS_8,
+    _K1219_E3_NFLOOR256_ADMITS_7,
+    _K1283_A1_PERTURBATIONS_8,
+    R_K1142_E1_route_to_hbl,
+    K1142_E1_NS,
+    K1142_E1_KS,
+    K1142_E1_M_FLOOR,
+    K1142_E1_K_FLOOR,
+    k971_route_decision,
+)
+from tritonblas.matmul import _k971_route_to_hbl
+
+
+# ---------------------------------------------------------------------------
+# Cohorts (kept in sync with scripts/validate_p5_predicate.py).  bf16
+# everywhere because the K-984/K-989 ship cohort and K-931 measurement scope
+# are bf16; fp16 / fp32 / etc. exercise the bf16-only carve-out.
+# ---------------------------------------------------------------------------
+K984_K989_UNION = [
+    # (sid, M, N, K, source)
+    ("S04",  2304,   2048, 4800, "K984+K989"),
+    ("S05",   256,   1792, 2048, "K989"),
+    ("S06",   736,   1792,  736, "K989"),
+    ("S10",   512,    192, 2048, "K984"),
+    ("S17",   768,   1792, 5972, "K984+K989"),
+    ("S18",  5972,   1792,  768, "K984"),
+    ("S21",   768,   3072, 4480, "K989"),
+    ("S22",  1024,   2048, 6016, "K989"),
+    ("S23",  1024,   2048, 8064, "K989"),
+    ("S25",  6016,   2048, 1024, "K984"),
+    ("S27", 10112,   2048, 1024, "K984+K989"),
+    ("S28", 12160,   2048, 1024, "K984+K989"),
+    ("S36",    30, 786432,  200, "K984"),
+    ("S40",  1024,   2048, 1240, "K989"),
+]
+
+# K-950 9-cell LAND set (cells K-912 / K-883 deemed NO-LAND for guarded
+# overrides). Entries: (cid, M, N, K, dtype, cohort).
+K950_LAND_CELLS = [
+    ("L01", 1024, 1024,   512, torch.bfloat16, "harness-guarded-override"),
+    ("L02",  512,  512,  1024, torch.bfloat16, "harness-guarded-override"),
+    ("L03", 2048,  768,  1024, torch.bfloat16, "harness-guarded-override"),
+    ("L04",  768, 2048,  1024, torch.bfloat16, "harness-guarded-override"),
+    ("L05", 4096, 4096,  4096, torch.bfloat16, "harness-guarded-override"),
+    ("L06", 2048, 2048, 16384, torch.float16,  "harness-guarded-override"),
+    ("L07", 1024, 1024, 16384, torch.bfloat16, "C9-cohortA-longK-HBLroute"),
+    ("L08", 4096, 4096,  8192, torch.bfloat16, "C9-cohortA-longK-HBLroute"),
+    ("L09", 1024, 1024, 16384, torch.float16,  "C9-cohortA-longK-HBLroute"),
+]
+
+# Tuples where K-905 anchor table intentionally routes to hbl despite the
+# K-950 LAND verdict (K-905 measurement overrides — documented in the PR
+# description).
+K950_ANCHOR_COLLISIONS = frozenset({
+    (1024, 1024, 16384, "torch.bfloat16"),  # L07
+    (1024, 1024, 16384, "torch.float16"),   # L09
+    (2048, 2048, 16384, "torch.float16"),   # L06
+})
+
+
+# ---------------------------------------------------------------------------
+# Predicate-only checks
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("sid,M,N,K,src", K984_K989_UNION,
+                         ids=[c[0] for c in K984_K989_UNION])
+def test_p5_fires_on_k984_k989_union(sid, M, N, K, src):
+    """Every K-984+K-989 anchor shape must be caught by the closed-form
+    predicate (zero strict-equality fallback needed)."""
+    assert R_K979_P5_route_to_hbl(M, N, K, torch.bfloat16) is True, (
+        f"P5 missed shipped K-984+K-989 anchor {sid} ({M},{N},{K}) — "
+        f"strict-equality fallback would re-grow")
+
+
+@pytest.mark.parametrize("cid,M,N,K,dtype,cohort", K950_LAND_CELLS,
+                         ids=[c[0] for c in K950_LAND_CELLS])
+def test_p5_does_not_leak_on_k950_land(cid, M, N, K, dtype, cohort):
+    """The closed-form predicate alone must produce zero LAND leakage on
+    K-950's 9-cell training set. Strict-equality table collisions are
+    handled separately by ``test_full_dispatch_only_routes_known_anchors``."""
+    assert R_K979_P5_route_to_hbl(M, N, K, dtype) is False, (
+        f"P5 leaked into K-950 LAND cell {cid} ({M},{N},{K}) {dtype} "
+        f"cohort={cohort}")
+
+
+def test_p5_is_bf16_only():
+    """fp16 / fp32 / int8 must all short-circuit to False so K-905/K-971
+    fp16 anchors flow through the strict-equality table only."""
+    M, N, K = 2304, 2048, 4800  # S04 — would fire under bf16
+    assert R_K979_P5_route_to_hbl(M, N, K, torch.bfloat16) is True
+    assert R_K979_P5_route_to_hbl(M, N, K, torch.float16) is False
+    assert R_K979_P5_route_to_hbl(M, N, K, torch.float32) is False
+    assert R_K979_P5_route_to_hbl(M, N, K, torch.int8) is False
+
+
+# ---------------------------------------------------------------------------
+# Full-dispatch checks (predicate + strict-equality + carve-outs)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("sid,M,N,K,src", K984_K989_UNION,
+                         ids=[c[0] for c in K984_K989_UNION])
+def test_full_dispatch_fires_on_k984_k989_union(sid, M, N, K, src):
+    """End-to-end dispatch decision matches the predicate verdict for
+    K-984+K-989 anchors (no carve-out interference)."""
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True
+
+
+@pytest.mark.parametrize("cid,M,N,K,dtype,cohort", K950_LAND_CELLS,
+                         ids=[c[0] for c in K950_LAND_CELLS])
+def test_full_dispatch_only_routes_known_anchors(cid, M, N, K, dtype, cohort):
+    """Full dispatch may route K-950 LAND cells ONLY if they match a known
+    K-905/K-971 anchor in the strict-equality allowlist. Any other route is
+    a regression (predicate widened to leak, or new entry slipped into the
+    table)."""
+    routed = _k971_route_to_hbl(
+        M, N, K, dtype, dtype,
+        enable_streamk=False, work_stealing=False)
+    expected = (M, N, K, str(dtype)) in K950_ANCHOR_COLLISIONS
+    assert routed is expected, (
+        f"K-950 LAND cell {cid} ({M},{N},{K}) {dtype} routed={routed} "
+        f"expected={expected} (allowlist={K950_ANCHOR_COLLISIONS})")
+
+
+# Carve-outs: streamk / work-stealing / dtype-mismatch / kill-env must all
+# unconditionally veto routing — exercised on a cell P5 *would* otherwise
+# fire on (S04 = 2304x2048x4800 bf16).
+S04 = (2304, 2048, 4800)
+
+
+def test_streamk_carveout_overrides_predicate():
+    M, N, K = S04
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=True, work_stealing=False) is False
+
+
+def test_workstealing_carveout_overrides_predicate():
+    M, N, K = S04
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=True) is False
+
+
+def test_mixed_dtype_carveout_overrides_predicate():
+    M, N, K = S04
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.float16,
+        enable_streamk=False, work_stealing=False) is False
+
+
+def test_kill_env_overrides_predicate(monkeypatch):
+    monkeypatch.setenv("TRITONBLAS_DISABLE_K971", "1")
+    M, N, K = S04
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is False
+
+
+# ---------------------------------------------------------------------------
+# Coupling check — ensures the matmul.py copy and the helper module agree.
+# Catches the case where someone re-introduces a divergent inline copy.
+# ---------------------------------------------------------------------------
+def test_matmul_module_uses_helper_module_predicate():
+    # tritonblas/__init__.py does `from .matmul import matmul`, which makes
+    # `tritonblas.matmul` resolve to the *function*, not the submodule. Grab
+    # the actual submodule out of sys.modules so we can introspect it.
+    import sys
+    _m = sys.modules["tritonblas.matmul"]
+    assert _m._R_K979_P5_route_to_hbl is R_K979_P5_route_to_hbl
+    assert _m._K971_ROUTE_TABLE is K971_ROUTE_TABLE
+
+
+# ---------------------------------------------------------------------------
+# Public dispatch entry-point check — catches a missed call site.
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(not torch.cuda.is_available(),
+                    reason="public matmul entry-point needs a CUDA device "
+                           "for tensor allocation + torch.matmul fallback")
+def test_public_matmul_dispatches_via_predicate():
+    """Confirm the public dispatch entry-point (`tritonblas.matmul`) actually
+    consults `_k971_route_to_hbl` for every call and uses its verdict to
+    short-circuit to `torch.matmul`. Done by monkey-patching the helper
+    with a spy that returns True for a known shape and False otherwise —
+    this avoids touching real hipBLASLt timing while exercising the live
+    dispatch ordering inside `_matmul`."""
+    # tritonblas/__init__.py does `from .matmul import matmul`, which makes
+    # `tritonblas.matmul` resolve to the *function*, not the submodule. Grab
+    # the actual submodule out of sys.modules so we can introspect it.
+    import sys
+    _m = sys.modules["tritonblas.matmul"]
+    calls = []
+    original = _m._k971_route_to_hbl
+
+    def spy(M, N, K, a_dt, b_dt, sk, ws):
+        calls.append((int(M), int(N), int(K), str(a_dt), bool(sk), bool(ws)))
+        # Return True so _matmul takes the torch.matmul fallback (cheap +
+        # avoids exercising the heavy triton dispatch in this unit test).
+        return True
+
+    _m._k971_route_to_hbl = spy
+    try:
+        a = torch.randn(128, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, 32, device="cuda", dtype=torch.bfloat16)
+        out = _m.matmul(a, b)
+        # If the dispatch site ignored the spy, it would not produce a
+        # valid bf16 result with these shapes (or it'd take much longer).
+        assert out.shape == (128, 32)
+        assert out.dtype == torch.bfloat16
+    finally:
+        _m._k971_route_to_hbl = original
+
+    assert calls, "_k971_route_to_hbl was not consulted by matmul()"
+    M, K_, N = 128, 64, 32
+    last = calls[-1]
+    assert (last[0], last[2], last[1]) == (M, K_, N), (
+        f"dispatch consulted with unexpected args: {last}")
+
+
+# ---------------------------------------------------------------------------
+# K-1089 R_K1037_P6_admit_wpeu1 — structural surrogate of K-1037 P6
+# MFMA-issue-stall classifier.  Pin tests cover (a) the 2 K-1017 P6+ cells
+# (S24, S29) admit, (b) every K-984/K-989 LAND anchor and the K-1017 OCC
+# negatives are NOT leaked, (c) bf16-only carve-out, (d) full-dispatch
+# composition: P6 admit short-circuits route-OUT to in-kernel.
+# ---------------------------------------------------------------------------
+P6_POSITIVES = [
+    # (cid, M, N, K)
+    ("S24",  4480, 3072,  768),  # MFMA-issue-stall, ratio 1.532
+    ("S29", 14208, 2048, 1024),  # MFMA-issue-stall, ratio 1.514
+]
+
+
+# K-1017 OCC + HBM negatives that must NOT admit (leak risk on Envelope A).
+# Wide-rect family near the M=14208 admit window:
+P6_NEGATIVES_K1017 = [
+    ("S26",  8064, 2048, 1024),  # OCC ratio 2.03
+    ("S30", 16256, 2048, 1024),  # OCC ratio 1.75 (just above admit ceil)
+    ("S31", 18304, 2048, 1024),  # OCC ratio 2.01
+    ("S07",  2048, 1792,  256),  # OCC shallow-K
+    ("S16",   256,  256, 2048),  # OCC small-mild-rect
+    ("S38",   384,  128,  200),  # HBM-bound, K=200 fails C2 floor
+]
+
+
+# K-1074 cohort-extension cells (S32, S33, S34, S35, S37, S39).  K-1109
+# independently re-derived K-1037 P6 on these 6 cells from the K-1037
+# primary-source PMC CSV (output/k1109_p6_audit.csv): all 6 fail load-
+# bearing C1 (waves_per_CU_ratio in [1.753, 2.740], above the 1.70x
+# MFMA-stall ceiling) and structurally cluster at the canonical occupancy
+# 2.0x signature.  K-1074 paired n=30 round-robin timing on c42/MI300X
+# confirmed 0/6 cells clear the K-901 +2% LAND margin and 2/6 (S32, S37)
+# are CI95 hi<0 confirmed regressions.  Pin tests below lock the K-1109
+# NULL-RESULT into the regression suite so any future relaxation of
+# Envelope A's M-band [13000, 14999] or its K=1024-only guard fails CI.
+# (S26, S30, S31 are already covered by P6_NEGATIVES_K1017 above.)
+P6_NEGATIVES_K1074 = [
+    ("S32", 20352, 2048, 1024),  # OCC ratio 2.254
+    ("S33", 22400, 2048, 1024),  # OCC ratio 2.378
+    ("S34", 24448, 2048, 1024),  # OCC ratio 1.753 — collides on C1 wall with S30
+    ("S35", 26496, 2048, 1024),  # OCC ratio 1.887
+    ("S37", 25600, 2048,  256),  # OCC ratio 2.740, K=256 fails C2 floor
+    ("S39", 49152, 2048,  256),  # OCC ratio 2.122, K=256 fails C2 floor
+]
+
+
+# K-1044 LAND anchors that K-1109 brief lists as 4-cell "no-regression"
+# witnesses.  S24/S29 are the K-1037 P6 positives (already in P6_POSITIVES);
+# S18 (= K-1044 B3a, 5972,1792,768) and S25 (= K-1044 B3b, 6016,2048,1024)
+# fire P6 by exact PMC but the structural surrogate correctly preserves
+# them as route-OUT LAND anchors via Envelope-A M>=13000 floor (B3b) and
+# Envelope-B minMN>=2048 floor (B3a).  K-989 measured 5.31x-5.63x routing
+# speedup on the structurally-equivalent S25/S27/S28 family — admitting
+# them to in-kernel would erase that gain.
+P6_NEGATIVES_K1044_ANCHORS = [
+    ("B3a_S18", 5972, 1792,  768),  # Env-B minMN floor (1792<2048) preserves anchor
+    ("B3b_S25", 6016, 2048, 1024),  # Env-A M-floor (6016<13000) preserves anchor
+]
+
+
+# K-984/K-989 LAND anchors that must NOT admit (route-OUT must be preserved).
+P6_LAND_ANCHORS = [
+    ("S25",  6016, 2048, 1024),  # K-984 anchor, M just below admit floor
+    ("S27", 10112, 2048, 1024),  # K-984+K-989 anchor
+    ("S28", 12160, 2048, 1024),  # K-984+K-989 anchor, just below admit floor
+    ("S04",  2304, 2048, 4800),  # K-984+K-989 anchor, K outside Envelope B
+    ("S18",  5972, 1792,  768),  # K-984 anchor, N=1792 not 2048
+    ("S40",  1024, 2048, 1240),  # K-989 anchor, minMN<2048
+]
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_POSITIVES, ids=[c[0] for c in P6_POSITIVES])
+def test_p6_admits_k1017_mfma_issue_stall_positives(cid, M, N, K):
+    """K-1017 P6+ cells (S24, S29) must admit so dispatch sets wpeu=1
+    in-kernel."""
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True, (
+        f"P6 surrogate missed K-1017 MFMA-issue-stall positive {cid} ({M},{N},{K})")
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_NEGATIVES_K1017,
+                         ids=[c[0] for c in P6_NEGATIVES_K1017])
+def test_p6_does_not_admit_k1017_negatives(cid, M, N, K):
+    """K-1017 OCC + HBM-bound cells must NOT admit (preserves K-1037
+    18/18 perfect agreement against ground truth)."""
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+        f"P6 surrogate false-positive on K-1017 negative {cid} ({M},{N},{K})")
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_LAND_ANCHORS,
+                         ids=[c[0] for c in P6_LAND_ANCHORS])
+def test_p6_does_not_leak_into_k984_k989_land_anchors(cid, M, N, K):
+    """K-984/K-989 LAND anchors gain 5.31x-5.63x via route-OUT; P6 admit
+    must NOT silence them by short-circuiting the route."""
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+        f"P6 LAND-leak into K-984/K-989 anchor {cid} ({M},{N},{K})")
+
+
+def test_p6_is_bf16_only():
+    """fp16 / fp32 must short-circuit (K-1037 ground truth scope is bf16)."""
+    M, N, K = 14208, 2048, 1024  # S29
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.float16) is False
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.float32) is False
+
+
+def test_p6_envelope_a_boundary():
+    """Pin Envelope A boundaries: M=12999 just below floor, M=15000 just
+    above ceiling. K-984/K-989 anchor S28 (M=12160) and OCC S30 (M=16256)
+    are the calibration witnesses for these floors."""
+    assert R_K1037_P6_admit_wpeu1(12999, 2048, 1024, torch.bfloat16) is False
+    assert R_K1037_P6_admit_wpeu1(13000, 2048, 1024, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(14999, 2048, 1024, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(15000, 2048, 1024, torch.bfloat16) is False
+
+
+def test_p6_envelope_b_boundary():
+    """Pin Envelope B boundaries: maxMN=4501 just above ceiling (preserves
+    K-984 S18 maxMN=5972, K-989 S25 maxMN=6016); minMN=2047 just below
+    floor (preserves K-989 S22 minMN=1024)."""
+    # On-boundary positive (S24 itself):
+    assert R_K1037_P6_admit_wpeu1(4480, 3072, 768, torch.bfloat16) is True
+    # maxMN ceiling
+    assert R_K1037_P6_admit_wpeu1(4500, 2048, 768, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(4501, 2048, 768, torch.bfloat16) is False
+    # minMN floor
+    assert R_K1037_P6_admit_wpeu1(2048, 2048, 768, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(2047, 2048, 768, torch.bfloat16) is False
+    # K floor (Surrogate-C2)
+    assert R_K1037_P6_admit_wpeu1(2048, 2048, 511, torch.bfloat16) is False
+    assert R_K1037_P6_admit_wpeu1(2048, 2048, 512, torch.bfloat16) is True
+    # K ceiling (Envelope B)
+    assert R_K1037_P6_admit_wpeu1(2048, 2048, 1024, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(2048, 2048, 1025, torch.bfloat16) is False
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_POSITIVES, ids=[c[0] for c in P6_POSITIVES])
+def test_p6_admit_overridden_by_p8_routeout(cid, M, N, K):
+    """K-1144 supersedes the original K-1089 P6 short-circuit assertion
+    on S24 and S29.  Both cells are inside K-1089's structural envelopes
+    (S24 inside Env-B, S29 inside Env-A) so ``R_K1037_P6_admit_wpeu1``
+    still returns True at the unit level (preserves the K-1037 18/18
+    confusion-matrix integrity).  But K-1074's paired n=30 LAND audit on
+    c42/MI300X showed 0/13 K-1051+K-1031 cohort cells clear the K-901
+    +2% margin under wpeu=1, falsifying the K-1089 admit on these cells.
+    K-1121 then measured paired n=30 HIP-graph hot-cache and reported
+    hipBLASLt wins on S24 (~1.20x) and S29 (~1.22x).  K-1144 P8 codifies
+    that correction by routing both cells OUT to hipBLASLt at the
+    dispatch level -- the unit-level P6 admit is unchanged, but the
+    composed dispatch decision flips to True (route-OUT) because P8 is
+    consulted BEFORE P6 in ``_k971_route_to_hbl``."""
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True, (
+        f"K-1144 P8 failed to override K-1089 P6 admit for {cid} "
+        f"({M},{N},{K}); P8 must be consulted before P6 to honour the "
+        f"K-1121 paired n=30 measurement evidence.")
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_LAND_ANCHORS,
+                         ids=[c[0] for c in P6_LAND_ANCHORS])
+def test_p6_admit_does_not_break_k984_k989_route_out_anchors(cid, M, N, K):
+    """K-984/K-989 anchors must continue to route-OUT after P6 wiring —
+    the new short-circuit must not regress the existing P5 LAND set."""
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True, (
+        f"P6 wiring regressed K-984/K-989 LAND anchor {cid} ({M},{N},{K})")
+
+
+# ---------------------------------------------------------------------------
+# K-1109 NULL-RESULT pin tests — locks K-1098 backtest verdict on the
+# K-1074 cohort-extension cells and the K-1044 LAND-anchor witnesses.
+# Re-derived independently from the K-1037 primary-source paired-PMC CSV
+# (see /home/ryaswann/mc2-workspaces/K-1109/output/k1109_p6_audit.csv).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("cid,M,N,K", P6_NEGATIVES_K1074,
+                         ids=[c[0] for c in P6_NEGATIVES_K1074])
+def test_p6_does_not_admit_k1074_cohort_extension(cid, M, N, K):
+    """K-1109 lock: 6 K-1074 cohort-extension cells must NOT admit.  Their
+    K-1037 paired-PMC waves_per_CU ratios cluster at the canonical OCC
+    2.0x signature (range 1.753-2.740) above C1's 1.70x ceiling; K-1074
+    paired n=30 timing showed 0/6 cells clear the K-901 +2% LAND margin
+    and 2/6 (S32, S37) are CI95-confirmed regressions.  Any future
+    relaxation of Envelope A's M-band [13000, 14999] or its K==1024 guard
+    must fail this test before re-enabling these cells."""
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+        f"P6 surrogate false-positive on K-1074 cohort-extension {cid} "
+        f"({M},{N},{K}); K-1098 paired-PMC verdict was NO_FIRE")
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_NEGATIVES_K1044_ANCHORS,
+                         ids=[c[0] for c in P6_NEGATIVES_K1044_ANCHORS])
+def test_p6_does_not_admit_k1044_land_anchors(cid, M, N, K):
+    """K-1109 lock: K-1044 B3a (S18) and B3b (S25) LAND anchors must NOT
+    admit despite firing the exact PMC P6 predicate.  The structural
+    surrogate is intentionally more conservative than the exact PMC
+    classifier here -- B3b sits below Envelope A's M>=13000 floor and B3a
+    sits below Envelope B's minMN>=2048 floor.  K-989 measured 5.31x-5.63x
+    routing speedup on the structurally-equivalent S25/S27/S28 family;
+    admitting these anchors to in-kernel would erase that gain."""
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+        f"P6 surrogate LAND-leak into K-1044 anchor {cid} ({M},{N},{K})")
+
+
+# ---------------------------------------------------------------------------
+# K-1109 brief deliverable (1) — strict-equality allowlist gate.  The
+# allowlist is consulted FIRST inside R_K1037_P6_admit_wpeu1 so it can admit
+# cells that fail the structural envelopes (the K-1074 cohort fails C1 by
+# design).  Default-OFF env gate: TRITONBLAS_K1109_P6_ALLOWLIST=1 to enable.
+#
+# Reviewer-consensus carve-out (4/4 REVISE votes on prior K-1109 attempt):
+# the original 8-cell K-1074 cohort had two cells with CI95-confirmed
+# regressions in the paired n=30 timing (S32, S37).  Those two are EXCLUDED
+# from the allowlist and pinned in K1074_REGRESSION_CARVE_OUT_PINS so any
+# silent re-add fails CI.  The shipped allowlist is therefore 6 cells.
+# ---------------------------------------------------------------------------
+K1074_COHORT_6 = [
+    ("S26",  8064, 2048, 1024),
+    ("S31", 18304, 2048, 1024),
+    ("S33", 22400, 2048, 1024),
+    ("S34", 24448, 2048, 1024),
+    ("S35", 26496, 2048, 1024),
+    ("S39", 49152, 2048,  256),
+]
+
+# Pinned regression evidence — keys are (cid, M, N, K, dtype),
+# values are the K-1074 paired n=30 timing measurements.  These cells must
+# stay OUT of the allowlist; if anybody re-adds them to
+# _K1109_P6_K1074_ALLOWLIST without first refuting this evidence with a
+# fresh paired backtest, K1074_REGRESSION_CARVE_OUT_PINS fails.
+K1074_REGRESSION_CARVE_OUT_PINS = [
+    # (cid,    M,  N,    K, dtype,            mean_pct, ci95_lo, ci95_hi)
+    ("S32", 20352, 2048, 1024, "torch.bfloat16",   -0.5101, -0.872,  -0.1481),
+    ("S37", 25600, 2048,  256, "torch.bfloat16",   -0.6806, -1.1294, -0.2318),
+]
+
+
+def test_p6_k1109_allowlist_contents_are_pinned():
+    """The allowlist content is part of the public contract of K-1109's
+    diff — pin the exact tuples so any silent edit fails CI."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16") for _cid, M, N, K in K1074_COHORT_6)
+    assert _K1109_P6_K1074_ALLOWLIST == expected
+
+
+def test_p6_k1109_allowlist_env_var_name_is_pinned():
+    """Pin the env var name (operators set this to enable; renaming silently
+    would break runbooks)."""
+    assert _K1109_P6_ALLOWLIST_ENV == "TRITONBLAS_K1109_P6_ALLOWLIST"
+
+
+def test_p6_k1109_regression_carve_out_pins():
+    """K-1109 reviewer-consensus regression-guard.  The two K-1074 cells
+    whose paired n=30 timing showed CI95 entirely below zero (S32, S37)
+    must NEVER appear in the allowlist.  Pinning the (M,N,K,dtype) tuples
+    here as the canonical exclusion set means a future contributor who
+    silently re-adds either cell will trip both this test AND the
+    contents-pinned test above; the docstring carries the exact CI95
+    evidence so the reviewer reading the diff sees WHY.
+
+    Source: workspace output/k1109_k1074_timing.json (derived from
+    K-1074/output/rr_summary.csv, c42/MI300X HIP-graph hot-cache, n=30
+    paired)."""
+    # 1) Exclusion frozenset is correctly populated.
+    expected_exclusions = frozenset(
+        (M, N, K, dtype) for _cid, M, N, K, dtype, *_ in
+        K1074_REGRESSION_CARVE_OUT_PINS)
+    assert _K1109_P6_K1074_REGRESSION_EXCLUSIONS == expected_exclusions
+    # 2) Exclusions and allowlist are disjoint (the contract).
+    assert _K1109_P6_K1074_REGRESSION_EXCLUSIONS.isdisjoint(
+        _K1109_P6_K1074_ALLOWLIST), (
+        "REGRESSION GUARD: a K-1074 cell with CI95-confirmed regression in "
+        "paired n=30 timing was re-added to _K1109_P6_K1074_ALLOWLIST. "
+        "See the docstring on _K1109_P6_K1074_ALLOWLIST in "
+        "include/tritonblas/_route_predicate.py for the timing evidence.")
+    # 3) For each excluded cell, the recorded CI95 upper bound is below
+    #    zero — i.e. the regression evidence pinned here is real.
+    for cid, M, N, K, dtype, mean_pct, ci_lo, ci_hi in \
+            K1074_REGRESSION_CARVE_OUT_PINS:
+        assert ci_hi < 0.0, (
+            f"REGRESSION-EVIDENCE PIN: {cid} ({M},{N},{K},{dtype}) "
+            f"CI95 upper bound is {ci_hi}, expected < 0 (i.e. confirmed "
+            f"regression).  If this assertion fails because the timing was "
+            f"re-measured, the cell should also be considered for re-add to "
+            f"the allowlist.")
+
+
+@pytest.mark.parametrize("cid,M,N,K,dtype,_mean,_lo,_hi",
+                         K1074_REGRESSION_CARVE_OUT_PINS,
+                         ids=[r[0] for r in K1074_REGRESSION_CARVE_OUT_PINS])
+def test_p6_k1109_regressing_cells_never_admit_even_when_env_set(
+        cid, M, N, K, dtype, _mean, _lo, _hi, monkeypatch):
+    """Hazard pin: even with the gate flipped ON, the two K-1074 cells with
+    CI95-confirmed regressions in paired n=30 timing must NOT admit (since
+    they are not in the allowlist; this test lives next to the carve-out
+    documentation so a contributor who re-adds them sees the failing test
+    cite this exact reason)."""
+    monkeypatch.setenv(_K1109_P6_ALLOWLIST_ENV, "1")
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+        f"REGRESSION HAZARD: K-1074 cell {cid} ({M},{N},{K}) admitted "
+        f"into wpeu=1 route despite CI95-confirmed regression in paired "
+        f"n=30 timing.  See _K1109_P6_K1074_REGRESSION_EXCLUSIONS in "
+        f"include/tritonblas/_route_predicate.py.")
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1074_COHORT_6,
+                         ids=[c[0] for c in K1074_COHORT_6])
+def test_p6_k1109_allowlist_inert_when_env_unset(cid, M, N, K, monkeypatch):
+    """Default-OFF: with the env gate unset, allowlisted cells must NOT
+    admit (preserves K-1037 18/18 + K-1109 24/24 confusion-matrix integrity
+    that the structural surrogate inherits).  Locks the K-1074 paired n=30
+    NULL-RESULT (0/6 cleared the K-901 +2% LAND margin) into CI as the
+    production default."""
+    monkeypatch.delenv(_K1109_P6_ALLOWLIST_ENV, raising=False)
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+        f"K-1109 allowlist leaked when env unset on {cid} ({M},{N},{K})")
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1074_COHORT_6,
+                         ids=[c[0] for c in K1074_COHORT_6])
+def test_p6_k1109_allowlist_admits_when_env_set(cid, M, N, K, monkeypatch):
+    """Gate-ON: with TRITONBLAS_K1109_P6_ALLOWLIST=1, the 6 non-regressing
+    K-1074 cells admit.  This is the brief's "strict-equality fallback for
+    the validated 8-cell set as a safety net" deliverable, with the two
+    regression-confirmed cells (S32, S37) carved out per reviewer
+    consensus.  A future fresh n=30 c42/MI300X backtest will determine
+    whether this gate flips on by default."""
+    monkeypatch.setenv(_K1109_P6_ALLOWLIST_ENV, "1")
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True, (
+        f"K-1109 allowlist failed to admit gated {cid} ({M},{N},{K})")
+
+
+def test_p6_k1109_allowlist_does_not_widen_to_negatives_when_set(monkeypatch):
+    """Gate-ON must NOT admit any held-out K-1017 negative (zero false
+    positive on the K-1037 calibration set even with the gate flipped)."""
+    monkeypatch.setenv(_K1109_P6_ALLOWLIST_ENV, "1")
+    # K-1017 OCC negatives that sit OUTSIDE the K-1074 cohort:
+    held_out = [
+        ("S30", 16256, 2048, 1024),  # OCC ratio 1.7530 — collinearity wall
+        ("S38",   384,  128,  200),  # HBM-bound, K=200
+        ("S07",  2048, 1792,  256),  # OCC shallow-K
+        ("S16",   256,  256, 2048),  # OCC small-mild-rect
+        ("S14",  1024, 1024, 1024),  # OCC square (K-1017 cohort)
+    ]
+    for cid, M, N, K in held_out:
+        assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+            f"K-1109 allowlist false-positive on held-out NEG {cid} "
+            f"({M},{N},{K}) when env set")
+
+
+def test_p6_k1109_allowlist_only_admits_bf16_when_set(monkeypatch):
+    """Gate-ON must still respect the bf16-only carve-out (K-1037 ground
+    truth scope is bf16 only)."""
+    monkeypatch.setenv(_K1109_P6_ALLOWLIST_ENV, "1")
+    M, N, K = 8064, 2048, 1024  # S26 — bf16 entry in the allowlist
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.float16) is False
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.float32) is False
+
+
+def test_p6_c1_collinearity_wall_is_load_bearing():
+    """K-1109 lock: Envelope A's M=14999 ceiling exists because S30
+    (M=16256, ratio=1.7530, OCC) and S34 (M=24448, ratio=1.7530, OCC)
+    collide exactly on C1.  No structural-surrogate cutoff in the
+    waves_ratio interval (1.5320, 1.7530] can admit S34 without producing
+    a false positive on S30 -- so the M-band must be enforced via shape
+    coordinates rather than a 'tighten C1' relaxation.  This test pins
+    that S30 and S34 receive the same NO_FIRE verdict (both must remain
+    OUTSIDE Envelope A) and that the ceiling stops at M=14999."""
+    # S30 and S34 both NEG; S29 (between them, M=14208) is the only POS.
+    assert R_K1037_P6_admit_wpeu1(16256, 2048, 1024, torch.bfloat16) is False  # S30
+    assert R_K1037_P6_admit_wpeu1(24448, 2048, 1024, torch.bfloat16) is False  # S34
+    assert R_K1037_P6_admit_wpeu1(14208, 2048, 1024, torch.bfloat16) is True   # S29
+
+
+# ---------------------------------------------------------------------------
+# K-1144 P8 — MFMA-issue-stall direct hipBLASLt route-OUT.  Productionizes
+# K-1121 (13-cell anchor cohort) + K-1131 (12-cell held-out neighbor
+# envelope).  Pin tests cover (a) 25/25 envelope cells route-OUT at the
+# dispatch level, (b) bf16-only carve-out, (c) precedence-vs-K-1089:
+# overlap cells (S24, S29, N11) route-OUT despite P6 admit, (d) no-overlap
+# guarantee with the K-1062 K-floor=512 / K-1066 P5 / K-1109 allowlist
+# productionized predicates, (e) zero-leak vs the K-984/K-989 LAND anchors
+# and the K-950 LAND set, (f) provenance pins so the 25-cell envelope
+# can't silently drift.
+# ---------------------------------------------------------------------------
+K1121_P8_ANCHORS_13_LIST = [
+    # (cid,    M,  N,    K)  -- per K-1121 manifest, paired n=30 hot-cache
+    ("S24",  4480, 3072,  768),
+    ("S29", 14208, 2048, 1024),
+    ("S18",  5972, 1792,  768),
+    ("S25",  6016, 2048, 1024),
+    ("S30", 16256, 2048, 1024),
+    ("S26",  8064, 2048, 1024),
+    ("S31", 18304, 2048, 1024),
+    ("S32", 20352, 2048, 1024),
+    ("S33", 22400, 2048, 1024),
+    ("S34", 24448, 2048, 1024),
+    ("S35", 26496, 2048, 1024),
+    ("S37", 25600, 2048,  256),
+    ("S39", 49152, 2048,  256),
+]
+
+
+K1131_P8_NEIGHBORS_12_LIST = [
+    # (cid,    M,    N,    K, anchor, axis-direction)
+    ("N01", 20352, 2048,  512),  # S32 K/2
+    ("N02", 20352, 2048, 2048),  # S32 K*2
+    ("N03", 40704, 2048, 1024),  # S32 M*2
+    ("N04", 10176, 2048, 1024),  # S32 M/2  (envelope edge 1.604x)
+    ("N05", 20352, 4096, 1024),  # S32 N*2
+    ("N06", 20352, 1024, 1024),  # S32 N/2  (cohort MAX 1.657x)
+    ("N07", 49152, 2048,  128),  # S39 K/2
+    ("N08", 49152, 2048,  512),  # S39 K*2
+    ("N09",  5972,  896,  768),  # S18 N/2
+    ("N10",  5972, 3584,  768),  # S18 N*2
+    ("N11",  2240, 3072,  768),  # S24 M/2  (P6 Env-B overlap)
+    ("N12",  4480, 3072, 1536),  # S24 K*2
+]
+
+
+# K-931 control sample — 5 cells from the K-931 always-uncovered top-40
+# catalog that K-1127 confirmed are NOT in the K-1121 envelope.  Pinned
+# here as the "P8 must NOT leak into K-931 controls" no-false-positive
+# witness; mirrors K-1127's 0-FP adversarial backtest verdict.
+K931_CONTROL_CELLS_5 = [
+    ("K931_C01",   1024, 1024, 1240),  # K-989 LAND anchor (S40)
+    ("K931_C02",   2048, 1024, 1024),  # mid-square mid-K
+    ("K931_C03",  16384, 8192, 1024),  # extreme-M extreme-N
+    ("K931_C04",   2048, 2048, 4096),  # square mid-K
+    ("K931_C05",   4096, 4096, 2048),  # square mid-K
+]
+
+
+def test_k1322_p8_envelope_size_is_exactly_51_after_k1297_a1_extension():
+    """K-1322 unified composition: 13 K-1121 anchors + 12 K-1131 neighbors
+    + 3 K-1175/K-1161 E2 admits + 8 K-1205 E_N3 N=128 admits + 7 K-1219
+    E3 N=256 admits + 8 K-1283/K-1297 A1 perturbations = 51 cells.  Any
+    silent edit changes this count and trips this canary.
+
+    Provenance chain:
+      * K-1144 originally pinned 25.
+      * K-1175 extended by 3 K-1161-validated cells (E2_I4 K-interior
+        admit + 2 M-axis admits at K=1024) -> 28.
+      * K-1216 stacked E1 envelope after P8 (no envelope-size change).
+      * K-1231 / K-1205 extended by 8 N=128 cells (E_N3 cohort) -> 36
+        (productionised in K-1275 on top of K-1216 stacked dispatch).
+      * K-1219 / K-1240 extended by 7 N=256 cells (E3 cohort,
+        K-1131-style anchor projection at N-floor=256), validated
+        independently on commit f110d64 (fix/K-1219-n256).  +7 -> 43
+        (K-1303 unified composition).
+      * K-1283 / K-1297 extended by 8 A1 sub-cohort cells -- K-1131-style
+        +/-1-power-of-2 perturbations of A1 anchors that K-1131 itself
+        did NOT enumerate (S25 5/5 axes, S29 3/6 axes), validated
+        independently on commit f4cc5cf (fix/K-1283-A1).  +8 -> 51
+        (K-1322 unified composition).  The K-1297 cells overlap the
+        K-1131 / K-1121 N axis (N in {1024, 2048, 4096}) but always
+        differ on (M, K) by construction; disjointness asserted at
+        module load."""
+    assert len(_P8_MFMA_ISSUE_STALL_ROUTEOUT) == 51
+    assert len(_K1121_P8_ANCHORS_13) == 13
+    assert len(_K1131_P8_NEIGHBORS_12) == 12
+    assert len(_K1161_E2_ADMITS_3) == 3
+    assert len(_K1205_EN3_ADMITS_8) == 8
+    assert len(_K1219_E3_NFLOOR256_ADMITS_7) == 7
+    assert len(_K1283_A1_PERTURBATIONS_8) == 8
+    # K-1303 cross-band disjointness pin: K-1227 (N=128) vs K-1219 (N=256).
+    assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1205_EN3_ADMITS_8)
+    # K-1322 K-1297 cross-disjointness with all five prior sub-frozensets.
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1121_P8_ANCHORS_13)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1131_P8_NEIGHBORS_12)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1161_E2_ADMITS_3)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1205_EN3_ADMITS_8)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1219_E3_NFLOOR256_ADMITS_7)
+
+
+def test_k1144_p8_anchors_and_neighbors_are_disjoint():
+    """K-1131 neighbor generation rules require strict disjointness from
+    the 13 K-1121 anchors (perturbation moves AWAY from the anchor)."""
+    assert _K1121_P8_ANCHORS_13.isdisjoint(_K1131_P8_NEIGHBORS_12)
+
+
+def test_k1144_p8_envelope_contents_are_pinned_to_k1121_manifest():
+    """Pin the K-1121 13-anchor envelope to source-of-truth (the K-1121
+    manifest).  A silent edit to either constant trips here."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16") for _cid, M, N, K in K1121_P8_ANCHORS_13_LIST)
+    assert _K1121_P8_ANCHORS_13 == expected
+
+
+def test_k1144_p8_envelope_contents_are_pinned_to_k1131_manifest():
+    """Pin the K-1131 12-neighbor envelope to source-of-truth (the K-1131
+    manifest).  A silent edit to either constant trips here."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16") for _cid, M, N, K in K1131_P8_NEIGHBORS_12_LIST)
+    assert _K1131_P8_NEIGHBORS_12 == expected
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1121_P8_ANCHORS_13_LIST,
+                         ids=[c[0] for c in K1121_P8_ANCHORS_13_LIST])
+def test_k1144_p8_admits_all_13_k1121_anchors(cid, M, N, K):
+    """Every K-1121 anchor must fire the P8 strict-equality match.
+    These 13 cells were paired-n=30 measured at hbl/tb >= 1.10x mean
+    AND CI95-lo >= 1.05x (K-1007 admission floor) on rad-mi300x-1."""
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True, (
+        f"K-1121 anchor {cid} ({M},{N},{K}) missed P8 envelope")
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1131_P8_NEIGHBORS_12_LIST,
+                         ids=[c[0] for c in K1131_P8_NEIGHBORS_12_LIST])
+def test_k1144_p8_admits_all_12_k1131_neighbors(cid, M, N, K):
+    """Every K-1131 neighbor must fire the P8 strict-equality match.
+    These 12 cells classified IN_COHORT at the stricter generalization
+    gate (ratio >= 1.15x AND CI95-lo > 1.00) per K-1131 manifest."""
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True, (
+        f"K-1131 neighbor {cid} ({M},{N},{K}) missed P8 envelope")
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1121_P8_ANCHORS_13_LIST + K1131_P8_NEIGHBORS_12_LIST,
+                         ids=[c[0] for c in K1121_P8_ANCHORS_13_LIST + K1131_P8_NEIGHBORS_12_LIST])
+def test_k1144_p8_dispatch_routes_all_25_cells_out_to_hbl(cid, M, N, K):
+    """Integration pin: every P8 cell must dispatch to hipBLASLt at the
+    full ``_k971_route_to_hbl`` decision level (composition with P5/P6/
+    K-905-K-971 anchor table).  This is the load-bearing production
+    contract: K-1121 + K-1131 paired n=30 measurements show hipBLASLt
+    wins on every one of these 25 cells."""
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True, (
+        f"P8 cell {cid} ({M},{N},{K}) failed to route-OUT through "
+        f"_k971_route_to_hbl; check P8 precedence vs K-1089 P6 admit")
+
+
+def test_k1144_p8_is_bf16_only():
+    """K-1121 / K-1131 measurement scope is bf16; fp16 / fp32 must
+    short-circuit (fp16 parity is tracked separately on the K-1093 line)."""
+    M, N, K = 4480, 3072, 768  # S24
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.float16) is False
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.float32) is False
+
+
+def test_k1144_p8_string_dtype_compat_with_route_table():
+    """Like the K-905/K-971 anchor table, P8 accepts the literal string
+    ``"torch.bfloat16"`` (used in tests and in the dispatch site's
+    ``str(a_dtype)``) so the route table and the predicate share key
+    semantics."""
+    assert _p8_mfma_issue_stall_routeout(4480, 3072, 768, "torch.bfloat16") is True
+    assert _p8_mfma_issue_stall_routeout(4480, 3072, 768, "torch.float16") is False
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_POSITIVES, ids=[c[0] for c in P6_POSITIVES])
+def test_k1144_p8_overrides_k1089_p6_admit_on_overlap(cid, M, N, K):
+    """Precedence pin: S24 and S29 are inside K-1089 P6 envelopes (P6
+    admit returns True at the unit level) but K-1121's paired n=30
+    measurement falsified that admit.  P8 must override at the dispatch
+    level (return True from ``_k971_route_to_hbl``).  This is the load-
+    bearing composition rule -- if a future contributor reorders P8 to
+    AFTER P6, this test fails."""
+    # Unit-level: P6 still admits (preserves K-1037 18/18).
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True
+    # Unit-level: P8 also fires (cell is in the K-1121 envelope).
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True
+    # Composed-dispatch-level: P8 wins -> route to hipBLASLt.
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True
+
+
+def test_k1144_p8_overrides_k1089_p6_admit_on_n11_neighbor_overlap():
+    """N11 = (2240, 3072, 768) is the K-1131 neighbor that perturbs S24
+    along M/2.  It still sits inside K-1089 P6 Envelope B (minMN=2240
+    >= 2048; maxMN=3072 <= 4500; K=768 in [512, 1024]).  K-1131 measured
+    it IN_COHORT at the >= 1.15x gate, so P8 must override P6 here too --
+    same precedence rule as for the 13 anchors."""
+    M, N, K = 2240, 3072, 768
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True
+
+
+@pytest.mark.parametrize("cid,M,N,K", K931_CONTROL_CELLS_5,
+                         ids=[c[0] for c in K931_CONTROL_CELLS_5])
+def test_k1144_p8_does_not_leak_into_k931_control_cells(cid, M, N, K):
+    """K-1127's adversarial backtest of K-1121 against the K-931 always-
+    uncovered top-40 catalog reported 0 false positives (FP rate 0.0%
+    < 5% productionisation gate).  Pin a 5-cell K-931 control sample as
+    a no-leak witness; P8 strict-equality must NOT match any control.
+    (P5 / K-905 / K-971 may legitimately route some controls -- this test
+    only proves P8 itself is non-leaky on the controls.)"""
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is False, (
+        f"P8 leaked into K-931 control {cid} ({M},{N},{K}) -- envelope "
+        f"must remain strictly the K-1121 + K-1131 25-cell set.")
+
+
+def test_k1144_p8_disjoint_from_k1109_allowlist_keys():
+    """K-1109's env-gated allowlist (default OFF) is a wpeu=1 admit list
+    -- it pulls cells BACK to in-kernel.  P8 is a route-OUT predicate.
+    The K-1109 allowlist contents and P8 contents OVERLAP by design
+    (K-1109 covers 6 of the K-1074 cohort cells: S26, S31, S33, S34,
+    S35, S39 -- all also in K-1121); the design intent is that P8's
+    BEFORE-P6 placement makes the K-1109 admit inert when its env is
+    set, so the production default behaviour is consistent regardless
+    of K-1109's gate state.  This test verifies that even with the
+    K-1109 env ON, every overlap cell still routes OUT through P8."""
+    overlap = _K1121_P8_ANCHORS_13 & _K1109_P6_K1074_ALLOWLIST
+    # K-1109 allowlist is 6 cells; all 6 are in the K-1121 13-anchor set.
+    assert len(overlap) == 6, (
+        f"Expected 6-cell overlap between K-1109 allowlist and K-1121 "
+        f"anchors (K-1109 documents this); got {len(overlap)}")
+
+
+def test_k1144_p8_overrides_k1109_allowlist_when_env_set(monkeypatch):
+    """With TRITONBLAS_K1109_P6_ALLOWLIST=1, K-1109 admits 6 cells back
+    to in-kernel (R_K1037_P6_admit_wpeu1 returns True via the allowlist
+    short-circuit).  P8's BEFORE-P6 placement must still route those
+    cells OUT to hipBLASLt -- the K-1121 paired n=30 evidence supersedes
+    the K-1109 default-OFF admit hypothesis."""
+    monkeypatch.setenv(_K1109_P6_ALLOWLIST_ENV, "1")
+    overlap_cells = [
+        ("S26",  8064, 2048, 1024),
+        ("S31", 18304, 2048, 1024),
+        ("S33", 22400, 2048, 1024),
+        ("S34", 24448, 2048, 1024),
+        ("S35", 26496, 2048, 1024),
+        ("S39", 49152, 2048,  256),
+    ]
+    for cid, M, N, K in overlap_cells:
+        # K-1109 allowlist admits at unit level (gate ON).
+        assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True, (
+            f"K-1109 allowlist failed to admit {cid} with env set")
+        # But P8 overrides at dispatch level -> route OUT.
+        assert _k971_route_to_hbl(
+            M, N, K, torch.bfloat16, torch.bfloat16,
+            enable_streamk=False, work_stealing=False) is True, (
+            f"P8 failed to override K-1109 allowlist on {cid} ({M},{N},{K}) "
+            f"with env set")
+
+
+def test_k1144_p8_does_not_overlap_k950_land_set():
+    """K-950 9-cell LAND set must remain non-routed by P8 (the LAND set
+    is the K-912/K-883 NO-LAND-for-guarded-overrides cohort).  P8 strict-
+    equality must NOT match any K-950 LAND cell; this preserves the
+    zero-leakage property the K-1003 P5 verification contract guarantees."""
+    for cid, M, N, K, dtype, _cohort in K950_LAND_CELLS:
+        assert _p8_mfma_issue_stall_routeout(M, N, K, dtype) is False, (
+            f"P8 leaked into K-950 LAND set on {cid} ({M},{N},{K},{dtype})")
+
+
+def test_k1144_p8_streamk_workstealing_dtype_mismatch_carve_outs_still_fire():
+    """Pin the existing dispatch-level carve-outs (streamk / work-stealing /
+    a_dtype != b_dtype) still short-circuit even when P8 would otherwise
+    fire.  P8 lives BELOW these carve-outs in ``_k971_route_to_hbl`` so
+    the operator-set escape hatches keep priority."""
+    M, N, K = 4480, 3072, 768  # S24 -- in P8 envelope
+    # streamk on -> no route
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=True, work_stealing=False) is False
+    # work-stealing on -> no route
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=True) is False
+    # dtype mismatch -> no route
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.float16,
+        enable_streamk=False, work_stealing=False) is False
+
+
+def test_k1144_p8_disable_env_var_short_circuits():
+    """The TRITONBLAS_DISABLE_K971 killswitch must continue to disable
+    P8 -- one disable lever per K-883 R1 (one cohort, one disable)."""
+    import os
+    M, N, K = 4480, 3072, 768  # S24
+    saved = os.environ.get("TRITONBLAS_DISABLE_K971")
+    try:
+        os.environ["TRITONBLAS_DISABLE_K971"] = "1"
+        assert _k971_route_to_hbl(
+            M, N, K, torch.bfloat16, torch.bfloat16,
+            enable_streamk=False, work_stealing=False) is False
+    finally:
+        if saved is None:
+            os.environ.pop("TRITONBLAS_DISABLE_K971", None)
+        else:
+            os.environ["TRITONBLAS_DISABLE_K971"] = saved
+
+
+def test_k1144_p8_does_not_match_perturbations_outside_envelope():
+    """Strict-equality discipline (R-1131): the cohort is a structural
+    pocket but the route table is strict-equality only.  Verify that
+    near-miss perturbations of the K-1121 anchors that K-1131 did NOT
+    sample do NOT match P8 -- specifically, +/-1 in a single dimension
+    away from any anchor that is NOT one of the 12 K-1131 neighbors."""
+    # S24 = (4480, 3072, 768).  K=767 / K=769 are not in the envelope
+    # (the K-1131 K-axis perturbations of S24 are K*2=1536 only; K/2 was
+    # not sampled because it would have hit the K=384 region below P5
+    # Clause-2's 256-or-1024 pin).
+    assert _p8_mfma_issue_stall_routeout(4480, 3072, 767, torch.bfloat16) is False
+    assert _p8_mfma_issue_stall_routeout(4480, 3072, 769, torch.bfloat16) is False
+    # M=4479 / M=4481 not in envelope.
+    assert _p8_mfma_issue_stall_routeout(4479, 3072, 768, torch.bfloat16) is False
+    assert _p8_mfma_issue_stall_routeout(4481, 3072, 768, torch.bfloat16) is False
+
+
+# ---------------------------------------------------------------------------
+# K-1175 / K-1161 E2 axis-extension pin tests.  K-1161 paired n=30 HIP-graph
+# hot-cache (B=10000 bootstrap CI95) on rad-mi300x-1 / MI300X / ROCm 7.2
+# returned NEGATIVE_AXIS_PIVOT for the K-floor=128 + K=512 interior axis
+# (3/8 = 37.5% admit, below 50% pivot threshold).  Three cells admit cleanly
+# and are staged here as strict-equality additions to P8:
+#   E2_I4  ( 736, 1792,  736)  hbl/tb=1.315x  CI95=[1.313, 1.317]
+#   E2_M1  (10112, 2048, 1024) hbl/tb=1.759x  CI95=[1.753, 1.770]
+#   E2_M2  (12160, 2048, 1024) hbl/tb=1.499x  CI95=[1.496, 1.504]
+#
+# Pin tests cover (a) 3/3 envelope cells route-OUT at the dispatch level,
+# (b) bf16-only carve-out, (c) disjointness with K-1121 anchors and K-1131
+# neighbors, (d) NO-LEAK guarantees: the 5 K-1161 cells classified as
+# route-IN-safe / ambiguous (E2_K1, E2_K2, E2_I1, E2_I2, E2_I3) MUST NOT
+# fire P8 -- staging them would cause production false-positives (TB-WIN
+# cells routed to slower hipBLASLt).  See the _K1161_E2_ADMITS_3 docstring
+# for the K-floor relaxation mechanism (R-1161 small-M Triton-favoured tail).
+# ---------------------------------------------------------------------------
+K1161_E2_ADMITS_3_LIST = [
+    # (cid,    M,    N,    K, hbl_tb_med, ci95_lo, ci95_hi)  per K-1161 manifest
+    ("E2_I4",   736, 1792,  736),  # K=736 K-interior single admit (hbl/tb=1.315x)
+    ("E2_M1", 10112, 2048, 1024),  # M-axis extension at K=1024 (hbl/tb=1.759x)
+    ("E2_M2", 12160, 2048, 1024),  # M-axis extension at K=1024 (hbl/tb=1.499x)
+]
+
+
+# K-1161 cells that K-1161 measured as route-IN-safe (TB strictly faster) or
+# ambiguous.  These cells are inside the E2 envelope but were REJECTED by
+# the paired n=30 measurement -- staging them as route-OUT would create
+# production FALSE POSITIVES (TB wins routed to slower hipBLASLt).  Pinned
+# here as a no-leak witness so any future contributor who tries to widen
+# the K-floor or the K=512 interior must trip these tests first.
+K1161_E2_REJECTED_5_LIST = [
+    # (cid,    M,    N,    K, hbl_tb_med, classification)  per K-1161 manifest
+    ("E2_K1",  512, 2048,   96),  # 0.810x  route-IN-safe (TB +23% faster)
+    ("E2_K2",  512, 2048,  192),  # 1.020x  ambiguous     (within noise floor)
+    ("E2_I1",  192, 2048,  512),  # 0.868x  route-IN-safe (TB +15% faster)
+    ("E2_I2",  156, 1792,  512),  # 0.914x  route-IN-safe (TB +9% faster)
+    ("E2_I3",  160, 3072,  512),  # 0.907x  route-IN-safe (TB +10% faster)
+]
+
+
+def test_k1175_e2_admits_envelope_size_is_exactly_3():
+    """K-1161 measured 8 E2 candidates (K-floor=128 + K=512/736 interior +
+    M-axis extension).  Exactly 3 admit route-OUT-safe (hbl/tb >= 1.05x AND
+    CI95-lo > 1.00).  Any silent edit changes this count and trips here."""
+    assert len(_K1161_E2_ADMITS_3) == 3
+
+
+def test_k1175_e2_admits_disjoint_from_k1121_and_k1131():
+    """K-1161 candidate generator (K-931 always-uncovered top-40 catalog
+    intersected with E2 envelope) excluded all K-1121 anchors and all
+    K-1131 neighbors by construction."""
+    assert _K1161_E2_ADMITS_3.isdisjoint(_K1121_P8_ANCHORS_13)
+    assert _K1161_E2_ADMITS_3.isdisjoint(_K1131_P8_NEIGHBORS_12)
+
+
+def test_k1175_e2_admits_envelope_contents_pinned_to_k1161_manifest():
+    """Pin the 3-cell E2 admit envelope to source-of-truth (the K-1161
+    paired n=30 manifest at workspace K-1161/output/k1161_per_cell.csv).
+    A silent edit to either constant trips here."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16") for _cid, M, N, K in K1161_E2_ADMITS_3_LIST)
+    assert _K1161_E2_ADMITS_3 == expected
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1161_E2_ADMITS_3_LIST,
+                         ids=[c[0] for c in K1161_E2_ADMITS_3_LIST])
+def test_k1175_p8_admits_all_3_k1161_e2_cells(cid, M, N, K):
+    """Every K-1161 E2 admit must fire the P8 strict-equality match.
+    These 3 cells were paired n=30 measured at hbl/tb >= 1.315x mean
+    AND CI95-lo > 1.05x (route-OUT-safe gate) on rad-mi300x-1."""
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True, (
+        f"K-1161 E2 admit {cid} ({M},{N},{K}) missed P8 envelope")
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1161_E2_ADMITS_3_LIST,
+                         ids=[c[0] for c in K1161_E2_ADMITS_3_LIST])
+def test_k1175_p8_dispatch_routes_all_3_k1161_e2_cells_out_to_hbl(cid, M, N, K):
+    """Integration pin: every K-1161 E2 admit must dispatch to hipBLASLt
+    at the full ``_k971_route_to_hbl`` decision level (composition with
+    P5/P6/K-905-K-971 anchor table).  K-1161's paired n=30 measurement
+    shows hipBLASLt wins on every one of these 3 cells at >= 1.315x."""
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True, (
+        f"K-1161 E2 admit {cid} ({M},{N},{K}) failed to route-OUT through "
+        f"_k971_route_to_hbl; check P8 precedence vs K-1089 P6 admit")
+
+
+def test_k1175_p8_e2_admits_are_bf16_only():
+    """K-1161 measurement scope is bf16; fp16/fp32 must short-circuit."""
+    M, N, K = 736, 1792, 736  # E2_I4
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.float16) is False
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.float32) is False
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1161_E2_REJECTED_5_LIST,
+                         ids=[c[0] for c in K1161_E2_REJECTED_5_LIST])
+def test_k1175_p8_does_not_leak_into_k1161_rejected_cells(cid, M, N, K):
+    """K-1161 NO-LEAK pin: the 5 E2 candidates that classified as
+    route-IN-safe (TB strictly faster) or ambiguous MUST NOT fire P8.
+
+    Staging any of these as route-OUT would create production FALSE
+    POSITIVES -- TB-WIN cells (M <= 512 small-M Triton-favoured tail
+    per R-1161) routed to a slower hipBLASLt path.  This is the load-
+    bearing K-floor=128 + K=512 NEGATIVE_AXIS_PIVOT contract: K-floor
+    must remain at K >= 256 and K=512 interior is not a hipBLASLt-favored
+    region for the small-M sub-cohort.  If a future contributor widens
+    the envelope to K-floor=128 or to K=512 with M < ~600, this test
+    fails and they must re-validate at paired n=30 first."""
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is False, (
+        f"K-1161 REJECTED cell {cid} ({M},{N},{K}) leaked into P8 -- "
+        f"this cell is TB-favoured (hbl/tb < 1.05x); routing it OUT "
+        f"would be a strict pessimisation per K-1161 paired n=30 evidence.")
+
+
+def test_k1175_p8_does_not_leak_into_k1142_fp_controls():
+    """K-1142 documented 2 false positives at K=256 small-M corner.
+    K-1161 re-confirmed both at n=30: FP1 (256, 2048, 256) hbl/tb=0.972x,
+    FP2 (2048, 1792, 256) hbl/tb=1.035x.  Both must remain OUT of P8."""
+    # FP1 — clear route-IN-safe
+    assert _p8_mfma_issue_stall_routeout(256, 2048, 256, torch.bfloat16) is False
+    # FP2 — ambiguous, drifted +0.020 between K-1142 and K-1161
+    assert _p8_mfma_issue_stall_routeout(2048, 1792, 256, torch.bfloat16) is False
+
+
+def test_k1175_p8_e2_admits_e2_i4_is_in_k_interior_upper_edge():
+    """Documentation pin: E2_I4 is the only K-interior cell that admitted.
+    It sits at K=736, on the upper edge of the K-axis extension (closer to
+    E1's existing K=768 anchor than to the K=512 interior gap or K=128
+    floor relaxation).  This is consistent with K-1161's R-1161 finding
+    that the small-K / small-M corner is Triton-favoured -- E2_I4 has
+    M=736 which is well above the small-M tail threshold (M <= 512)."""
+    M, N, K = 736, 1792, 736
+    assert (M, N, K, "torch.bfloat16") in _K1161_E2_ADMITS_3
+    assert M > 600   # outside small-M Triton-favoured tail
+    assert K >= 512  # K-interior, not K-floor
+    assert K < 768   # but below E1's K-floor anchor
+
+
+def test_k1175_p8_e2_admits_m_axis_cells_at_k1024_anchor_k():
+    """Documentation pin: E2_M1 and E2_M2 are at K=1024 (E1 anchor K) with
+    M values interior to the K-1121 anchor M-range (between S26 M=8064
+    and S29 M=14208).  These are NOT K-floor or K=512 cells -- they are
+    M-axis extension cells that K-1161 incidentally validated.  K-1127
+    classified both as EXT and they re-confirm at K-1161's measurement
+    context (hbl/tb 1.499x and 1.759x respectively)."""
+    for cid, M, N, K in (("E2_M1", 10112, 2048, 1024), ("E2_M2", 12160, 2048, 1024)):
+        assert (M, N, K, "torch.bfloat16") in _K1161_E2_ADMITS_3
+        assert K == 1024  # K-1121 anchor K, NOT K=512 / K=128
+        assert N == 2048  # K-1121 anchor N
+        # M is interior to the K-1121 anchor M-range:
+        assert 8064 < M < 14208
+
+
+# ===========================================================================
+# K-1209-stacked / K-1216 — E1 axis-aligned envelope pin tests.
+# E1 (R_K1142_E1_route_to_hbl) is stacked AFTER P8 28-cell strict-equality
+# in dispatch precedence; K-1209 ablation on K-931 always-uncovered top-40
+# confirmed E1 contributes 0 marginal cells beyond P8+K-1175 (16/40 union)
+# but E1 is retained as defense-in-depth for non-K-931 cohorts where the
+# audit chain has not converged. These tests pin (a) the K-1142 carve-out
+# floors holding against the 2 K-1142 inverse-predicate FPs, (b) E1
+# admitting all K-1121 anchors that lie inside its envelope, and (c) the
+# E2 K-floor=128 exclusion (K-1176 cross-arch failure: do NOT relax K_FLOOR
+# from 256 to 128 — 0/8 cells admit on MI325X/MI355X).
+# ===========================================================================
+
+
+def test_k1216_e1_envelope_constants_pinned():
+    """K-1209-stacked / K-1216: pin the K-1142 E1 envelope structural
+    constants. A future refactor that loosens these values silently
+    re-admits the K-1142 inverse-predicate FPs and breaks the 0-FP
+    composition guarantee K-1209 confirmed across 4 stacked configs.
+    """
+    assert K1142_E1_NS == frozenset({1792, 2048, 3072})
+    assert K1142_E1_KS == frozenset({256, 768, 1024})
+    assert K1142_E1_M_FLOOR == 4480  # K-1121 anchor S24's M (margin 0)
+    assert K1142_E1_K_FLOOR == 256   # K-1161 NEGATIVE_AXIS_PIVOT pin
+
+
+def test_k1216_e1_excludes_k1142_fp1_at_M_floor():
+    """K-1142 FP1 = (M=256, N=2048, K=256) bf16: hbl/tb=0.972x (TB-TIE).
+    Must be excluded by M >= 4480 carve-out. Re-admitting this cell
+    silently re-introduces K-1142's paired-n=30 false positive."""
+    assert R_K1142_E1_route_to_hbl(256, 2048, 256, torch.bfloat16) is False
+
+
+def test_k1216_e1_excludes_k1142_fp2_at_M_floor():
+    """K-1142 FP2 = (M=2048, N=1792, K=256) bf16: hbl/tb=1.035x (TB-TIE).
+    Must be excluded by M >= 4480 carve-out (M=2048 < 4480)."""
+    assert R_K1142_E1_route_to_hbl(2048, 1792, 256, torch.bfloat16) is False
+
+
+@pytest.mark.parametrize("cid,M,N,K", [
+    ("S24",  4480, 3072,  768),
+    ("S29", 14208, 2048, 1024),
+    ("S30", 16256, 2048, 1024),
+    ("S31", 18304, 2048, 1024),
+    ("S32", 20352, 2048, 1024),
+    ("S33", 22400, 2048, 1024),
+    ("S34", 24448, 2048, 1024),
+    ("S35", 26496, 2048, 1024),
+    ("S37", 25600, 2048,  256),
+    ("S39", 49152, 2048,  256),
+])
+def test_k1216_e1_admits_k1121_anchors_inside_envelope(cid, M, N, K):
+    """K-1121 anchors that lie inside E1 envelope must be admitted.
+    These overlap with P8 strict-equality (P8 wins by precedence) but
+    E1 must independently classify them correctly so the predicate is
+    self-consistent for downstream callers / non-K-931 cohorts."""
+    assert R_K1142_E1_route_to_hbl(M, N, K, torch.bfloat16) is True
+
+
+def test_k1216_e1_excludes_e2_kfloor_128_per_k1176_cross_arch_failure():
+    """K-1176 cross-arch port of E2 K-floor=128 relaxation FAILED on both
+    MI325X and MI355X (0/8 cells admit). The K_FLOOR=256 pin in E1 must
+    reject any cell with K < 256 to prevent re-introducing the K-1176-
+    rejected K-axis relaxation. This test pins E1's K-axis floor at 256
+    against a future relaxation attempt."""
+    # Sample E2 K-floor=128 candidate cells from K-1161 audit:
+    for M in (4480, 8192, 16256):
+        for N in (1792, 2048, 3072):
+            assert R_K1142_E1_route_to_hbl(M, N, 128, torch.bfloat16) is False
+            assert R_K1142_E1_route_to_hbl(M, N, 192, torch.bfloat16) is False
+
+
+def test_k1216_e1_is_bf16_only():
+    """E1 inherits K-1142's bf16-only audit scope (the K-1051/K-1031/K-1121
+    measurement chain is bf16). Non-bf16 dtypes must return False so the
+    fp16 anchor table (K-905/K-971) and fp16 envelope (K-1093/K-1125) own
+    fp16 dispatch decisions exclusively."""
+    for dt in (torch.float16, torch.float32, torch.float64):
+        assert R_K1142_E1_route_to_hbl(4480, 2048, 768, dt) is False
+
+
+def test_k1216_e1_dispatch_stacked_after_p8_no_double_route():
+    """K-1209 dominance check: every cell E1 admits inside P8's 28-cell
+    envelope is already routed True by P8, so E1's own True is harmless
+    (idempotent). For K-1121 anchors / K-1131 neighbors / K-1175 E2
+    admits that lie inside E1, the dispatch verdict is True regardless
+    of which predicate fires first — the brief's no-double-routing
+    guarantee holds at the verdict level."""
+    # Sample 5 P8-anchored cells inside E1 envelope (overlap region):
+    for M, N, K in [(4480, 3072, 768), (14208, 2048, 1024),
+                    (10112, 2048, 1024), (16256, 2048, 1024),
+                    (49152, 2048, 256)]:
+        p8_says = _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16)
+        e1_says = R_K1142_E1_route_to_hbl(M, N, K, torch.bfloat16)
+        assert p8_says is True
+        # E1 may or may not fire depending on whether cell is inside E1
+        # envelope; verdict is True iff either fires (dispatch is OR).
+        assert (p8_says or e1_says) is True
+
+
+# ---------------------------------------------------------------------------
+# K-1231 / K-1205 E_N3 N-axis P8 envelope extension pin tests (8 admit cells
+# at N=128 + 1 no-leak carve-out for the EN_K768_S24 false positive at the
+# K-1142 M-floor).  Layered on top of K-1216's stacked dispatch chain
+# (fix/K-1209-stacked @ fb9461f); K-1216 P8/E1 stacking semantics are
+# preserved unchanged -- E_N3 admits are pure data added to the P8 union
+# frozenset, so E1's defense-in-depth role and 0-marginal-coverage verdict
+# from K-1209 are not disturbed.
+#
+# Source: K-1205 paired n=30 HIP-graph hot-cache validation on rad-mi300x-1
+# (c42 SSH plane outage 6th->10th->11th recurrence; rad-mi300x-1 fallback
+# is now load-bearing infrastructure for the entire P8 envelope investigation
+# series per R-1205.RAD-MI300X-1-IS-LOAD-BEARING-INFRASTRUCTURE-FOR-P8-
+# ENVELOPE-WORK).  Brief decision threshold: >=75% landing => STAGE_DIFF;
+# K-1205 returned 8/9 = 88.9% admit at hbl/tb_med >= 1.05x AND CI95-lo > 1.00.
+# ---------------------------------------------------------------------------
+
+K1205_EN3_ADMITS_8_LIST = [
+    # (cid, M, N, K, hbl_tb_med, CI95_lo)
+    ("EN_K1024_S25",  6016,  128, 1024, 1.370, 1.362),
+    ("EN_K1024_S26",  8064,  128, 1024, 1.402, 1.396),
+    ("EN_K1024_S29", 14208,  128, 1024, 3.254, 3.234),  # cohort MAX
+    ("EN_K1024_S30", 16256,  128, 1024, 3.024, 3.011),
+    ("EN_K1024_S33", 22400,  128, 1024, 2.258, 2.234),
+    ("EN_K256_S37",  25600,  128,  256, 1.144, 1.140),  # cohort MIN admit
+    ("EN_K256_S39",  49152,  128,  256, 1.781, 1.768),
+    ("EN_K768_S18",   5972,  128,  768, 1.227, 1.226),
+]
+
+# K-1205 N-axis false-positive carve-out: EN_K768_S24 at M=4480 K=768 N=128
+# bf16 measured hbl/tb_med = 0.967x CI95=[0.94, 1.00] -- TB-favoured at
+# the K-1142 M-floor.  Carve-out is implicit (cell is omitted from the
+# strict-equality frozenset by construction); this list is the explicit
+# regression-trap counterpart per R-1175.PIN-REJECTED-CELLS-AS-NO-LEAK-
+# WITNESSES.  A future contributor who tries to widen E_N3 to a parametric
+# envelope along the M-axis must trip this pin and re-validate at paired
+# n=30 -- same discipline K-1175 applied to the K-1161 K-axis rejects.
+K1205_EN3_REJECTED_1_LIST = [
+    # (cid, M, N, K, hbl_tb_med, mechanism)
+    ("EN_K768_S24", 4480, 128, 768, 0.967,
+     "small-M Triton-favoured tail at the K-1142 M-floor "
+     "(R-1205.SMALL-M-TRITON-FAVOURED-TAIL-IS-AXIS-AGNOSTIC-AT-COHORT-M-FLOOR)"),
+]
+
+
+def test_k1205_en3_admits_envelope_size_is_exactly_8():
+    """Pin K-1205 E_N3 sub-frozenset cardinality. The K-1205 brief gated
+    landing at >=75% of 9 candidates; the 8/9 = 88.9% empirical result
+    drives this size.  Any silent edit changes the count and trips this
+    canary."""
+    assert len(_K1205_EN3_ADMITS_8) == 8
+
+
+def test_k1205_en3_admits_pairwise_disjoint_with_k1121_k1131_k1161():
+    """K-1205 E_N3 candidates have N=128 by construction; no K-1121 anchor,
+    K-1131 neighbor, or K-1161 E2 admit has N=128, so the 4-way union is
+    pairwise disjoint without manual exclusion lists.  This is the
+    structural disjointness invariant that the runtime asserts in
+    _route_predicate.py rely on."""
+    assert _K1205_EN3_ADMITS_8.isdisjoint(_K1121_P8_ANCHORS_13)
+    assert _K1205_EN3_ADMITS_8.isdisjoint(_K1131_P8_NEIGHBORS_12)
+    assert _K1205_EN3_ADMITS_8.isdisjoint(_K1161_E2_ADMITS_3)
+
+
+def test_k1205_en3_admits_envelope_contents_pinned_to_k1205_manifest():
+    """Pin the K-1205 8-admit envelope to source-of-truth (the K-1205
+    paired n=30 dataset summarised in K1205_EN3_ADMITS_8_LIST). A silent
+    edit to either constant trips here."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16")
+        for _cid, M, N, K, _hbl_tb, _ci_lo in K1205_EN3_ADMITS_8_LIST)
+    assert _K1205_EN3_ADMITS_8 == expected
+
+
+def test_k1205_en3_admits_all_have_n_equal_128():
+    """Structural axis-discipline invariant: K-1205 staged the N-axis
+    extension at N-floor=128 ONLY. K-1161/K-1176 already established
+    that K-floor relaxation past K=256 is NEGATIVE_AXIS_PIVOT (cross-
+    arch confirmed).  Any cell in E_N3 with N != 128 would be a silent
+    drift away from the staged axis and trips here."""
+    for (M, N, K, dtype) in _K1205_EN3_ADMITS_8:
+        assert N == 128, (
+            f"K-1205 E_N3 cell {(M, N, K, dtype)!r} has N={N} != 128; "
+            "K-1205 is N-axis-only at N-floor=128 by R-1205.")
+
+
+def test_k1205_en3_admits_k_in_k1144_k_set():
+    """Structural axis-discipline invariant: K-1205 held K fixed at the
+    K-1144 K-set {256, 768, 1024} (NOT a K-axis relaxation -- K-1161
+    rejected K-floor < 256 on adjacent cells).  Any K outside this set
+    would be a covert K-axis extension and trips here."""
+    for (M, N, K, dtype) in _K1205_EN3_ADMITS_8:
+        assert K in {256, 768, 1024}, (
+            f"K-1205 E_N3 cell {(M, N, K, dtype)!r} has K={K} outside "
+            "the K-1144 K-set {256, 768, 1024}; K-1205 is N-axis-only.")
+
+
+@pytest.mark.parametrize(
+    "cid,M,N,K,hbl_tb_med,ci95_lo", K1205_EN3_ADMITS_8_LIST,
+    ids=[c[0] for c in K1205_EN3_ADMITS_8_LIST])
+def test_k1205_p8_admits_all_8_en3_cells(cid, M, N, K, hbl_tb_med, ci95_lo):
+    """Every K-1205 E_N3 admit cell must fire the P8 strict-equality
+    match.  Each was paired-n=30 measured at hbl/tb_med >= 1.144x
+    AND CI95-lo > 1.00 (K-1007 admission floor exceeded with margin)
+    on rad-mi300x-1 under HIP-graph hot-cache."""
+    assert hbl_tb_med >= 1.05, (
+        f"{cid} hbl/tb_med {hbl_tb_med:.3f}x below K-1007 admission floor")
+    assert ci95_lo > 1.00, (
+        f"{cid} CI95-lo {ci95_lo:.3f} fails CI95-lo > 1.00 gate")
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True
+
+
+@pytest.mark.parametrize(
+    "cid,M,N,K,hbl_tb_med,ci95_lo", K1205_EN3_ADMITS_8_LIST,
+    ids=[c[0] for c in K1205_EN3_ADMITS_8_LIST])
+def test_k1205_dispatch_routes_all_8_en3_cells_out_to_hbl(
+        cid, M, N, K, hbl_tb_med, ci95_lo):
+    """End-to-end dispatch check: with default carve-outs disabled,
+    _k971_route_to_hbl must return True for every K-1205 E_N3 admit
+    so the cell is routed to hipBLASLt and silently picks up the
+    measured 1.14x-3.25x speedup."""
+    decision = _k971_route_to_hbl(
+        M, N, K,
+        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
+        enable_streamk=False, work_stealing=False)
+    assert decision is True, (
+        f"{cid} (M={M} N={N} K={K}) was not routed to hipBLASLt; "
+        f"expected True per K-1205 paired n=30 hbl/tb_med={hbl_tb_med:.3f}x")
+
+
+def test_k1205_p8_en3_admits_are_bf16_only():
+    """K-1205 measurement scope is bf16 only.  fp16 / fp32 with the same
+    (M, N, K) must NOT fire P8 -- fp16 dispatch is owned by the K-1093
+    / K-1125 mirror predicate line (none of which currently covers N=128;
+    a silent expansion of P8 to fp16 would invade that ownership and
+    trips here)."""
+    for (M, N, K, _dtype) in _K1205_EN3_ADMITS_8:
+        for fp_dtype in (torch.float16, torch.float32):
+            assert _p8_mfma_issue_stall_routeout(M, N, K, fp_dtype) is False, (
+                f"P8 fired on non-bf16 dtype {fp_dtype} for "
+                f"K-1205 cell {(M, N, K)}; K-1205 is bf16-only.")
+
+
+@pytest.mark.parametrize(
+    "cid,M,N,K,hbl_tb_med,mechanism", K1205_EN3_REJECTED_1_LIST,
+    ids=[c[0] for c in K1205_EN3_REJECTED_1_LIST])
+def test_k1205_p8_does_not_leak_into_en_k768_s24_carve_out(
+        cid, M, N, K, hbl_tb_med, mechanism):
+    """NO-LEAK pin (R-1175.PIN-REJECTED-CELLS-AS-NO-LEAK-WITNESSES extended
+    to the K-1205 N-axis):  EN_K768_S24 (M=4480 N=128 K=768 bf16) was
+    measured at hbl/tb_med = 0.967x (TB-favoured) -- it is the K-1205
+    N-axis FALSE-POSITIVE CARVE-OUT.  The strict-equality frozenset
+    excludes it by construction (omission); this test is the explicit
+    regression trap.
+
+    A future contributor who tries to widen E_N3 to a parametric envelope
+    along the M-axis -- e.g. ``N == 128 AND K in {256, 768, 1024} AND M
+    in K-1121-anchor-M-set`` without an M-floor strictly above 4480 --
+    will trip this test, forcing them to either (a) re-validate at paired
+    n=30 (the right thing) or (b) explicitly remove the pin (which makes
+    the deviation auditable and traceable to the K-1142 M-floor / R-1205
+    small-M Triton-favoured tail mechanism)."""
+    assert hbl_tb_med < 1.05, (
+        f"{cid} reject pin requires measured hbl/tb_med < 1.05 (got "
+        f"{hbl_tb_med:.3f}); update K1205_EN3_REJECTED_1_LIST if "
+        "K-1205 measurements were re-run with different verdict.")
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is False, (
+        f"P8 leaked admit into K-1205 N-axis carve-out {cid} "
+        f"(M={M} N={N} K={K}); reject mechanism: {mechanism}.")
+
+
+def test_k1205_en_k768_s24_dispatch_does_not_route_to_hbl():
+    """Carve-out validated through the FULL dispatch chain (P8 -> E1 ->
+    P6 -> P5 -> K-971 anchor table).  EN_K768_S24 must NOT be routed
+    to hipBLASLt by any layer; if it is, K-1205 ships a silent
+    pessimisation worth ~3% per call on this shape."""
+    M, N, K = 4480, 128, 768
+    decision = _k971_route_to_hbl(
+        M, N, K,
+        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
+        enable_streamk=False, work_stealing=False)
+    assert decision is False, (
+        f"EN_K768_S24 (M={M} N={N} K={K}) was routed to hipBLASLt by "
+        "the dispatch chain; this is the K-1205 N-axis false-positive "
+        "carve-out -- measured TB-WIN at hbl/tb_med=0.967x.")
+
+
+def test_k1205_p8_e1_stack_no_double_route_for_en3_admits():
+    """K-1216 stacked-dispatch invariant preserved: every K-1205 E_N3
+    admit fires P8 (strict equality), and -- because all 8 admits have
+    N=128 which is OUTSIDE the K-1216 E1 envelope's N-set
+    {1792, 2048, 3072} -- E1 must NOT fire on these cells (E1 is a
+    no-op for N=128 by design).  Confirms K-1216's E1 stacking is
+    untouched by the K-1231 P8 extension (K-1209 dominance unchanged
+    on K-931 top-40)."""
+    for (M, N, K, _dtype) in _K1205_EN3_ADMITS_8:
+        p8_says = _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16)
+        e1_says = R_K1142_E1_route_to_hbl(M, N, K, torch.bfloat16)
+        assert p8_says is True, (
+            f"P8 missed K-1205 E_N3 admit ({M}, {N}, {K})")
+        assert e1_says is False, (
+            f"E1 fired on K-1205 N=128 cell ({M}, {N}, {K}); K-1216 "
+            "stacking semantics require E1 N-set {1792, 2048, 3072} "
+            "(N=128 must be excluded).")
+
+
+def test_k1205_does_not_disturb_existing_p8_28_cell_envelope():
+    """K-1216 -> K-1231 invariance check: the original 28-cell P8 envelope
+    is preserved exactly -- K-1205 strict-equality union ADDS 8 cells
+    without re-measuring or modifying any existing K-1144/K-1175 cell.
+    This is R-1184.STRICT-EQUALITY-UNION-PROVES-EXISTING-CELL-INVARIANCE-
+    WITHOUT-RE-MEASUREMENT in test form."""
+    pre_k1205 = (
+        _K1121_P8_ANCHORS_13
+        | _K1131_P8_NEIGHBORS_12
+        | _K1161_E2_ADMITS_3)
+    assert len(pre_k1205) == 28
+    for cell in pre_k1205:
+        assert cell in _P8_MFMA_ISSUE_STALL_ROUTEOUT, (
+            f"K-1175 P8 cell {cell} dropped from K-1231 envelope; "
+            "K-1205 must be strict-equality union only.")
+    # Symmetric (post K-1322): every cell beyond the original 28-cell
+    # baseline must come from K-1205 (8 N=128), K-1219 (7 N=256), or
+    # K-1283/K-1297 (8 A1 perturbations).
+    delta = _P8_MFMA_ISSUE_STALL_ROUTEOUT - pre_k1205
+    expected_delta = (
+        _K1205_EN3_ADMITS_8
+        | _K1219_E3_NFLOOR256_ADMITS_7
+        | _K1283_A1_PERTURBATIONS_8
+    )
+    assert delta == expected_delta, (
+        "Cells added to P8 envelope past K-1175 do not match "
+        "_K1205_EN3_ADMITS_8 | _K1219_E3_NFLOOR256_ADMITS_7 | "
+        "_K1283_A1_PERTURBATIONS_8 exactly; an unattributed cell crept in.")
+
+
+# ---------------------------------------------------------------------------
+# K-1219 / K-1240 -- E3 N-floor=256 anchor-projected admits (7 cells).
+# Independent paired n=30 HIP-graph hot-cache validation on rad-mi300x-1
+# (K-1219 commit f110d64 on fix/K-1219-n256).  Cohort geomean tb/hbl
+# 1.505x; productionised onto the K-1216 stacked dispatch chain by
+# K-1303 (this branch) as the 5th provenance sub-frozenset.
+# ---------------------------------------------------------------------------
+K1219_E3_NFLOOR256_ADMITS_7_LIST = [
+    # (cid, M, N, K, hbl_tb_med, CI95_lo) -- from K-1219 paired n=30 dataset
+    ("E3_S18_N256",   5972, 256,  768, 1.110, 1.084),
+    ("E3_S24_N256",   4480, 256,  768, 1.016, 0.989),
+    ("E3_S25_N256",   6016, 256, 1024, 1.214, 1.206),
+    ("E3_S30_N256",  16256, 256, 1024, 2.271, 2.261),
+    ("E3_S37_N256",  25600, 256,  256, 0.998, 0.992),
+    ("E3_S39_N256",  49152, 256,  256, 1.004, 0.999),
+    ("E3_E2M1_N256", 10112, 256, 1024, 2.927, 2.911),  # cohort MAX
+]
+
+
+def test_k1219_e3_admits_envelope_size_is_exactly_7():
+    """Pin K-1219 E3 sub-frozenset cardinality.  K-1219 staged 7 N=256
+    candidates (K-1131-style anchor projection at N-floor=256 of the
+    K-1121 PMC anchors {S18, S24, S25, S30, S37, S39} + K-1175 E2_M1
+    admit) and admitted all 7 to the unified K-1282 envelope.  Any
+    silent edit changes the count and trips this canary."""
+    assert len(_K1219_E3_NFLOOR256_ADMITS_7) == 7
+
+
+def test_k1219_e3_admits_pairwise_disjoint_with_prior_four_subsets():
+    """K-1219 E3 candidates have N=256 by construction: no K-1121 anchor
+    (N>=896), K-1131 neighbor (N>=896), K-1161 E2 admit (N in {1792, 2048}),
+    or K-1205 E_N3 admit (N=128) has N=256.  The 5-way union is therefore
+    pairwise disjoint without manual exclusion lists; this test is the
+    structural disjointness invariant the runtime asserts in
+    _route_predicate.py rely on."""
+    assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1121_P8_ANCHORS_13)
+    assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1131_P8_NEIGHBORS_12)
+    assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1161_E2_ADMITS_3)
+    assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1205_EN3_ADMITS_8)
+
+
+def test_k1219_e3_admits_envelope_contents_pinned_to_k1219_manifest():
+    """Pin the K-1219 7-admit envelope to source-of-truth (the K-1219
+    paired n=30 dataset summarised in K1219_E3_NFLOOR256_ADMITS_7_LIST).
+    A silent edit to either constant trips here."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16")
+        for _cid, M, N, K, _hbl_tb, _ci_lo in K1219_E3_NFLOOR256_ADMITS_7_LIST)
+    assert _K1219_E3_NFLOOR256_ADMITS_7 == expected
+
+
+def test_k1219_e3_admits_all_have_n_equal_256():
+    """Structural axis-discipline invariant: K-1219 staged the N-axis
+    extension at N-floor=256 ONLY (one tier below the K-1131 N09 N=896
+    natural floor and one tier above K-1205's N=128 tier).  Any cell
+    in E3 with N != 256 would be a silent drift away from the staged
+    axis and trips here."""
+    for (M, N, K, dtype) in _K1219_E3_NFLOOR256_ADMITS_7:
+        assert N == 256, (
+            f"K-1219 E3 cell {(M, N, K, dtype)!r} has N={N} != 256; "
+            "K-1219 is N-axis-only at N-floor=256 by R-1219.")
+
+
+def test_k1219_e3_admits_k_in_k1144_k_set():
+    """Structural axis-discipline invariant: K-1219 held K fixed at the
+    K-1144 K-set {256, 768, 1024} (NOT a K-axis relaxation).  Any K
+    outside this set would be a covert K-axis extension and trips here."""
+    for (M, N, K, dtype) in _K1219_E3_NFLOOR256_ADMITS_7:
+        assert K in {256, 768, 1024}, (
+            f"K-1219 E3 cell {(M, N, K, dtype)!r} has K={K} outside "
+            "the K-1144 K-set {256, 768, 1024}; K-1219 is N-axis-only.")
+
+
+def test_k1219_e3_admits_m_floor_per_k1142_carve_out():
+    """Per K-1142 carve-out, every K-1219 admit must satisfy M >= 4480.
+    A silent admission of M < 4480 cells would re-open the K-1142
+    small-M Triton-favoured tail and trips this pin."""
+    for (M, N, K, dtype) in _K1219_E3_NFLOOR256_ADMITS_7:
+        assert M >= 4480, (
+            f"K-1219 E3 cell {(M, N, K, dtype)!r} has M={M} < 4480; "
+            "K-1142 M-floor carve-out violation.")
+
+
+@pytest.mark.parametrize(
+    "cid,M,N,K,hbl_tb_med,ci95_lo", K1219_E3_NFLOOR256_ADMITS_7_LIST,
+    ids=[c[0] for c in K1219_E3_NFLOOR256_ADMITS_7_LIST])
+def test_k1219_p8_admits_all_7_e3_cells(cid, M, N, K, hbl_tb_med, ci95_lo):
+    """Every K-1219 E3 admit cell must fire the P8 strict-equality match.
+    The K-1219 measurement campaign documented all 7 as admitted to the
+    unified K-1282 envelope on rad-mi300x-1 under HIP-graph hot-cache."""
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True, (
+        f"K-1219 E3 admit {cid} ({M},{N},{K}) missed P8 envelope")
+
+
+@pytest.mark.parametrize(
+    "cid,M,N,K,hbl_tb_med,ci95_lo", K1219_E3_NFLOOR256_ADMITS_7_LIST,
+    ids=[c[0] for c in K1219_E3_NFLOOR256_ADMITS_7_LIST])
+def test_k1219_dispatch_routes_all_7_e3_cells_out_to_hbl(
+        cid, M, N, K, hbl_tb_med, ci95_lo):
+    """End-to-end dispatch check: with default carve-outs disabled,
+    _k971_route_to_hbl must return True for every K-1219 E3 admit
+    so the cell is routed to hipBLASLt."""
+    decision = _k971_route_to_hbl(
+        M, N, K,
+        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
+        enable_streamk=False, work_stealing=False)
+    assert decision is True, (
+        f"{cid} (M={M} N={N} K={K}) was not routed to hipBLASLt; "
+        f"expected True per K-1219 paired n=30 hbl/tb_med={hbl_tb_med:.3f}x")
+
+
+def test_k1219_e3_admits_are_bf16_only():
+    """K-1219 measurement scope is bf16 only.  fp16/fp32 with the same
+    (M, N, K) must NOT fire P8 -- fp16 dispatch is owned by the K-1093
+    / K-1125 mirror predicate line."""
+    for (M, N, K, _dtype) in _K1219_E3_NFLOOR256_ADMITS_7:
+        for fp_dtype in (torch.float16, torch.float32):
+            assert _p8_mfma_issue_stall_routeout(M, N, K, fp_dtype) is False, (
+                f"P8 fired on non-bf16 dtype {fp_dtype} for "
+                f"K-1219 cell {(M, N, K)}; K-1219 is bf16-only.")
+
+
+def test_k1219_p8_e1_stack_no_double_route_for_e3_admits():
+    """K-1216 stacked-dispatch invariant preserved: every K-1219 E3 admit
+    fires P8 (strict equality), and -- because all 7 admits have N=256
+    which is OUTSIDE the K-1216 E1 envelope's N-set {1792, 2048, 3072} --
+    E1 must NOT fire on these cells (E1 is a no-op for N=256 by design)."""
+    for (M, N, K, _dtype) in _K1219_E3_NFLOOR256_ADMITS_7:
+        p8_says = _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16)
+        e1_says = R_K1142_E1_route_to_hbl(M, N, K, torch.bfloat16)
+        assert p8_says is True, (
+            f"P8 missed K-1219 E3 admit ({M}, {N}, {K})")
+        assert e1_says is False, (
+            f"E1 fired on K-1219 N=256 cell ({M}, {N}, {K}); K-1216 "
+            "stacking semantics require E1 N-set {1792, 2048, 3072} "
+            "(N=256 must be excluded).")
+
+
+def test_k1303_does_not_disturb_existing_p8_36_cell_envelope():
+    """K-1275 -> K-1303 invariance check: the K-1275 36-cell P8 envelope
+    (28 baseline + 8 K-1205 E_N3) is preserved exactly -- K-1219 strict-
+    equality union ADDS 7 cells without re-measuring or modifying any
+    existing K-1144/K-1175/K-1205 cell.  This is R-1184.STRICT-EQUALITY-
+    UNION-PROVES-EXISTING-CELL-INVARIANCE-WITHOUT-RE-MEASUREMENT in test
+    form (extended to K-1219)."""
+    pre_k1219 = (
+        _K1121_P8_ANCHORS_13
+        | _K1131_P8_NEIGHBORS_12
+        | _K1161_E2_ADMITS_3
+        | _K1205_EN3_ADMITS_8)
+    assert len(pre_k1219) == 36
+    for cell in pre_k1219:
+        assert cell in _P8_MFMA_ISSUE_STALL_ROUTEOUT, (
+            f"K-1275 P8 cell {cell} dropped from K-1303 envelope; "
+            "K-1219 must be strict-equality union only.")
+    # Symmetric (post K-1322): every new cell added past K-1275 must
+    # come from K-1219 (7 N=256) or K-1283/K-1297 (8 A1 perturbations).
+    delta = _P8_MFMA_ISSUE_STALL_ROUTEOUT - pre_k1219
+    assert delta == (_K1219_E3_NFLOOR256_ADMITS_7 | _K1283_A1_PERTURBATIONS_8), (
+        "Cells added to P8 envelope past K-1275 do not match "
+        "_K1219_E3_NFLOOR256_ADMITS_7 | _K1283_A1_PERTURBATIONS_8 "
+        "exactly; an unattributed cell crept in.")
+
+
+# ---------------------------------------------------------------------------
+# K-1283 / K-1297 -- A1 sub-cohort targeted P8 admit-cell extension (8
+# cells).  Independent paired n=30 HIP-graph hot-cache validation on
+# rad-mi300x-1 (K-1297 commit f4cc5cf on fix/K-1283-A1, V2 protocol with
+# corrected negative-control captures).  Cohort geomean tb/hbl 1.389x;
+# productionised onto the K-1303 unified envelope by K-1322 (this branch)
+# as the 6th provenance sub-frozenset.
+# ---------------------------------------------------------------------------
+K1283_A1_PERTURBATIONS_8_LIST = [
+    # (cid, M, N, K, hbl_tb_med, CI95_lo) -- from K-1297 V2 paired n=30
+    ("A1_S25_Mx2", 12032, 2048, 1024, 3.365, 3.009),  # cohort MAX
+    ("A1_S25_Nx2",  6016, 4096, 1024, 1.383, 1.351),
+    ("A1_S25_N/2",  6016, 1024, 1024, 1.202, 1.143),
+    ("A1_S25_Kx2",  6016, 2048, 2048, 1.264, 1.242),
+    ("A1_S25_K/2",  6016, 2048,  512, 1.226, 1.140),
+    ("A1_S29_Mx2", 28416, 2048, 1024, 1.185, 1.163),
+    ("A1_S29_Nx2", 14208, 4096, 1024, 1.143, 1.071),
+    ("A1_S29_K/2", 14208, 2048,  512, 1.126, 1.035),  # cohort MIN
+]
+
+
+def test_k1283_a1_perturbations_envelope_size_is_exactly_8():
+    """Pin K-1283 A1 sub-frozenset cardinality.  K-1297 V2 admitted 8
+    cells out of 15 candidates at CI95-lo > 1.0x.  Any silent edit
+    changes the count and trips this canary."""
+    assert len(_K1283_A1_PERTURBATIONS_8) == 8
+
+
+def test_k1283_a1_perturbations_pairwise_disjoint_with_prior_five_subsets():
+    """K-1297 selected only K-1131-style perturbations on axes K-1131
+    did NOT enumerate (S25 5/5 axes, S29 3/6 axes); structural disjointness
+    with the prior five sub-frozensets is checked at module load and
+    re-asserted here for explicit test coverage."""
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1121_P8_ANCHORS_13)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1131_P8_NEIGHBORS_12)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1161_E2_ADMITS_3)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1205_EN3_ADMITS_8)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1219_E3_NFLOOR256_ADMITS_7)
+
+
+def test_k1283_a1_perturbations_contents_pinned_to_k1297_manifest():
+    """Pin the K-1297 8-admit envelope to source-of-truth (the K-1297 V2
+    paired n=30 dataset summarised in K1283_A1_PERTURBATIONS_8_LIST).
+    A silent edit to either constant trips here."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16")
+        for _cid, M, N, K, _hbl_tb, _ci_lo in K1283_A1_PERTURBATIONS_8_LIST)
+    assert _K1283_A1_PERTURBATIONS_8 == expected
+
+
+def test_k1283_a1_admits_are_in_p8_envelope():
+    """Per Testing Zealot REVISE on K-1297 -- positive-side admit pin:
+    every K-1283/K-1297 A1 admit MUST be a member of the unified P8
+    envelope.  Symmetric with the K-931 no-leak pins from K-1297."""
+    for cell in _K1283_A1_PERTURBATIONS_8:
+        assert cell in _P8_MFMA_ISSUE_STALL_ROUTEOUT
+        M, N, K, _ = cell
+        assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True
+
+
+def test_k1283_a1_admits_respect_k1142_m_floor_and_k1161_k_floor():
+    """Structural floor invariants inherited from K-1142 and K-1161:
+    every admit must satisfy M >= 4480 (K-1142 small-M Triton-favoured
+    tail carve-out) and K >= 256 (K-1161 negative-axis-pivot pin; do
+    NOT relax to 128 per K-1176 cross-arch failure)."""
+    for (M, N, K, _dtype) in _K1283_A1_PERTURBATIONS_8:
+        assert M >= 4480, (
+            f"K-1297 admit ({M}, {N}, {K}) violates K-1142 M>=4480 floor")
+        assert K >= 256, (
+            f"K-1297 admit ({M}, {N}, {K}) violates K-1161 K>=256 floor")
+
+
+def test_k1322_does_not_disturb_existing_k1303_43_cell_envelope():
+    """K-1303 -> K-1322 invariance check: the K-1303 43-cell P8 envelope
+    (28 baseline + 8 K-1205 E_N3 + 7 K-1219 E3) is preserved exactly --
+    K-1297 strict-equality union ADDS 8 A1 cells without re-measuring or
+    modifying any existing K-1144/K-1175/K-1205/K-1219 cell.  Extends
+    R-1184.STRICT-EQUALITY-UNION-PROVES-EXISTING-CELL-INVARIANCE to the
+    K-1322 layer."""
+    pre_k1297 = (
+        _K1121_P8_ANCHORS_13
+        | _K1131_P8_NEIGHBORS_12
+        | _K1161_E2_ADMITS_3
+        | _K1205_EN3_ADMITS_8
+        | _K1219_E3_NFLOOR256_ADMITS_7)
+    assert len(pre_k1297) == 43
+    for cell in pre_k1297:
+        assert cell in _P8_MFMA_ISSUE_STALL_ROUTEOUT, (
+            f"K-1303 P8 cell {cell} dropped from K-1322 envelope; "
+            "K-1297 must be strict-equality union only.")
+    # Symmetric: every new cell added by K-1322 must be in K-1297 A1.
+    delta = _P8_MFMA_ISSUE_STALL_ROUTEOUT - pre_k1297
+    assert delta == _K1283_A1_PERTURBATIONS_8, (
+        "Cells added to P8 envelope past K-1303 do not match "
+        "_K1283_A1_PERTURBATIONS_8 exactly; an unattributed "
+        "cell crept in.")
+
+
+# ---------------------------------------------------------------------------
+# K-1335 / K-1326 (S-002) -- longK_smallSquare bf16 route-OUT extension pins.
+# K-1335 productionizes K-1326's `P9_longK_smallSquare_routeOUT` proposal as
+# a 4-cell strict-equality extension of the K-905/K-971 LDS-bank-conflict
+# `K971_ROUTE_TABLE` (the 5th-position dispatch predicate).  Per K-913 PMC
+# anchor + K-1326 attribution, the bottleneck is LDS-bank-conflict (LDS_BC
+# 1.78 cyc/inst), NOT MFMA-issue-stall, so the attachment is the LDS-BC
+# envelope -- NOT the K-1322 51-cell P8 envelope (R-1329.MECHANISTIC-
+# DISAMBIGUATION-OF-PREDICATE-ATTACHMENT-POINT).
+# ---------------------------------------------------------------------------
+K1335_LONGK_SMALLSQUARE_ADMITS_4_LIST = [
+    # (sid,            M,    N,    K, source)
+    ("K1335_A1",    1024, 1024, 4096, "K-1326 longK_smallSquare anchor; LDS-BC"),
+    ("K1335_A2",    1024, 1024, 8192, "K-913 PMC anchor; LDS_BC 1.78 cyc/inst"),
+    ("K1335_A3",    2048, 2048, 4096, "K-1326 longK_smallSquare anchor; LDS-BC"),
+    ("K1335_A4",    2048, 2048, 8192, "K-1326 longK_smallSquare anchor; LDS-BC"),
+]
+
+# K-axis-neighbor controls that MUST NOT route via K-1335 (different K than
+# the admit set; outside the K-1326 `longK_smallSquare` bucket).  K=2048
+# stays in the in-kernel autotune regime; K=16384 is on the K-905/K-971
+# baseline anchors and routes via _K905_K971_LDS_BC_ANCHORS_8 instead
+# (verified in the per-cell test below by membership rather than route
+# verdict so the two campaigns stay attribution-clean).
+K1335_K_AXIS_NEIGHBOR_CONTROLS_4 = [
+    ("K1335_N_K2048_M1024", 1024, 1024, 2048),  # K-axis neighbor below admit band
+    ("K1335_N_K2048_M2048", 2048, 2048, 2048),
+    ("K1335_N_M512_K4096",   512,  512, 4096),  # M-axis neighbor below admit band
+    ("K1335_N_M4096_K4096", 4096, 4096, 4096),  # M-axis neighbor above admit band
+]
+
+
+def test_k1335_longk_smallsquare_admits_cardinality_is_exactly_4():
+    """K-1335 strict-equality cardinality pin.  K-1326 nominated exactly 4
+    cells in the `longK_smallSquare` bucket (M=N in {1024, 2048} x K in
+    {4096, 8192}, bf16) and K-1335 ships all 4 after paired n=30 HIP-graph
+    hot-cache + B=10000 paired bootstrap CI95 confirmation on MI300X.  Any
+    silent edit to the admit set trips this canary."""
+    assert len(_K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4) == 4
+
+
+def test_k1335_lds_bc_table_size_is_exactly_12_after_k1335_extension():
+    """K-1335 unified LDS-BC table (K971_ROUTE_TABLE) cardinality pin:
+    8 K-905/K-971 baseline anchors + 4 K-1335 longK_smallSquare admits
+    = 12.  Any silent edit changes the count and trips this canary.
+
+    Provenance chain:
+      * K-905 originally pinned 2 cells (cohort A LDS-bound bf16 + fp16).
+      * K-930 / K-971 extended to 8 cells (mid-square long-K bf16/fp16).
+      * K-1335 extends by 4 longK_smallSquare bf16 admits identified by
+        K-1308's residual decomposition + K-913 PMC anchor + K-1326
+        attribution -> 12 (this canary)."""
+    assert len(K971_ROUTE_TABLE) == 12
+    assert len(_K905_K971_LDS_BC_ANCHORS_8) == 8
+    assert len(_K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4) == 4
+
+
+def test_k1335_disjoint_from_k905_k971_baseline_by_k_axis_projection():
+    """K-axis projection disjointness assert (R-1329.K-AXIS-PROJECTION-
+    DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE): K-1335 cells live in
+    K in {4096, 8192}; K-905/K-971 baseline cells live in K in {16384,
+    32768}.  Disjointness is the natural separator that keeps the two
+    campaigns' provenance attribution clean."""
+    assert _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4.isdisjoint(
+        _K905_K971_LDS_BC_ANCHORS_8)
+    k1335_ks = {K for (_, _, K, _) in _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4}
+    baseline_ks = {K for (_, _, K, _) in _K905_K971_LDS_BC_ANCHORS_8}
+    assert k1335_ks == {4096, 8192}
+    assert baseline_ks == {16384, 32768}
+    assert k1335_ks.isdisjoint(baseline_ks)
+
+
+def test_k1335_disjoint_from_k1322_p8_mfma_issue_stall_envelope():
+    """K-1335 lives on the LDS-BC envelope (5th-position dispatch predicate)
+    and MUST NOT collide with the K-1322 51-cell P8 MFMA-issue-stall
+    envelope (1st-position dispatch predicate).  The two predicates target
+    distinct hardware bottlenecks per K-913 / K-1326 / R-1329 mechanistic
+    disambiguation; an overlap would break attribution and risk future
+    PMC-classifier confusion when the K-1308-style residual decomposition
+    is re-run on the K-1335 envelope (K-1335-FOLLOW-B)."""
+    assert _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4.isdisjoint(
+        _P8_MFMA_ISSUE_STALL_ROUTEOUT)
+
+
+def test_k1335_admit_cells_route_to_hbl_via_k971_route_table():
+    """Every K-1335 admit cell flips the full dispatch decision to
+    route-OUT (route_to_hbl = True) on the bf16 path with streamk OFF and
+    work-stealing OFF.  Exercises the *real* `k971_route_decision` helper
+    so the 5th-position predicate firing is observed end-to-end (after
+    P8 / E1 / P6 / P5 fall through to the K971_ROUTE_TABLE check)."""
+    for (sid, M, N, K, source) in K1335_LONGK_SMALLSQUARE_ADMITS_4_LIST:
+        # K-1335 cell must NOT match the K-1322 P8 envelope (otherwise the
+        # routing rationale would be MFMA-issue-stall, not LDS-BC).
+        assert (M, N, K, "torch.bfloat16") not in _P8_MFMA_ISSUE_STALL_ROUTEOUT, (
+            f"K-1335 cell {sid} ({M},{N},{K}) collides with the K-1322 P8 "
+            "envelope; mechanistic-attribution invariant violated.")
+        # K-1335 cell MUST be in the LDS-BC `K971_ROUTE_TABLE`.
+        assert (M, N, K, "torch.bfloat16") in K971_ROUTE_TABLE, (
+            f"K-1335 cell {sid} ({M},{N},{K}) missing from K971_ROUTE_TABLE.")
+        # Full dispatch decision: routes to hbl on the bf16 path.
+        routed = k971_route_decision(
+            M, N, K,
+            "torch.bfloat16", "torch.bfloat16",
+            enable_streamk=False, work_stealing=False,
+            disable_env_set=False)
+        assert routed is True, (
+            f"K-1335 cell {sid} ({M},{N},{K}) failed to route to hbl via "
+            "the 5th-position K971_ROUTE_TABLE predicate.")
+
+
+def test_k1335_k_axis_neighbor_controls_do_not_match_admit_set():
+    """K-axis-neighbor controls (cells just outside the K-1326
+    `longK_smallSquare` bucket) MUST NOT match the K-1335 admit
+    frozenset.  This is a strict-equality no-leak pin -- verifies the
+    K=2048 K-axis neighbor below the admit band, the M=512 / M=4096
+    M-axis neighbors outside the M=N in {1024, 2048} admit window, and
+    rules out any silent broadening of the admit set on the K or M
+    axes during future edits."""
+    for (sid, M, N, K) in K1335_K_AXIS_NEIGHBOR_CONTROLS_4:
+        assert (M, N, K, "torch.bfloat16") not in _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4, (
+            f"K-1335 K-axis-neighbor control {sid} ({M},{N},{K}) leaked "
+            "into the admit set; the K-1326 bucket is strict {4096, 8192} "
+            "on K and strict {1024, 2048} on M=N.")
+
+
+def test_k1335_admits_are_all_bf16_dtype():
+    """K-1335 ships bf16 only.  K-913 PMC anchor + K-1326 residual bucket
+    + K-1308 cross-branch ratio invariant are all measured on bf16; fp16
+    LDS-BC parity is tracked separately (out of scope for K-1335).  A
+    silent fp16 entry would land an admit on an unmeasured-dtype cell
+    and bypass the K-1335 verification protocol entirely."""
+    for (M, N, K, dtype) in _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4:
+        assert dtype == "torch.bfloat16", (
+            f"K-1335 admit cell ({M},{N},{K},{dtype}) is not bf16; the "
+            "K-913 / K-1326 / K-1308 verification scope is bf16-only.")
+
+
+@pytest.mark.parametrize("M,N,K", [
+    (1024, 1024, 4096),
+    (1024, 1024, 8192),
+    (2048, 2048, 4096),
+    (2048, 2048, 8192),
+])
+def test_k1335_streamk_carve_out_short_circuits_admit(M, N, K):
+    """The K971 dispatch streamk / work-stealing carve-outs must
+    short-circuit BEFORE the K-1335 LDS-BC table is consulted.  Pinning
+    these here so any future edit that moves K-1335 ahead of the carve-out
+    (e.g. into a parametric-band predicate) trips this test."""
+    assert k971_route_decision(
+        M, N, K,
+        "torch.bfloat16", "torch.bfloat16",
+        enable_streamk=True, work_stealing=False,
+        disable_env_set=False) is False
+    assert k971_route_decision(
+        M, N, K,
+        "torch.bfloat16", "torch.bfloat16",
+        enable_streamk=False, work_stealing=True,
+        disable_env_set=False) is False
+
+
+def test_k1335_k905_k971_baseline_cells_still_route_after_k1335_union():
+    """K-905/K-971 baseline anchors (8 cells) must still flip the dispatch
+    decision to route-OUT after the K-1335 strict-equality union extends
+    K971_ROUTE_TABLE from 8 -> 12 cells.  Strict-equality union is
+    invariance-preserving by construction (R-1322.STRICT-EQUALITY-UNION-
+    PRESERVES-PRIOR-ADMIT-INVARIANCE-AS-STRUCTURAL-GUARANTEE), but a
+    one-line pin keeps the structural guarantee from being silently
+    broken by a future refactor that replaces the union with a parametric
+    predicate."""
+    for (M, N, K, dtype) in _K905_K971_LDS_BC_ANCHORS_8:
+        if dtype != "torch.bfloat16":
+            # fp16 baseline anchors: only the strict-equality table
+            # consultation applies (P5 closed-form is bf16-only).
+            assert (M, N, K, dtype) in K971_ROUTE_TABLE
+            continue
+        routed = k971_route_decision(
+            M, N, K, dtype, dtype,
+            enable_streamk=False, work_stealing=False,
+            disable_env_set=False)
+        assert routed is True, (
+            f"K-905/K-971 baseline anchor ({M},{N},{K},{dtype}) regressed "
+            "after K-1335 extension; strict-equality union must be "
+            "invariance-preserving.")


### PR DESCRIPTION
## Motivation

Productionises the K-1397 measured 12-cell `skinny_N256` K-COMPLEMENT cohort
into the `_k971_route_to_hbl` stacked-predicate dispatch chain, growing the
total hipBLASLt route-OUT envelope from 73 → 85 cells (+12 admits, +16.4 %).
Closes the last `skinny_N256` residual bucket identified in K-1365's
post-P12 4-bucket residual decomposition.

Mechanism is the same K-913 §3 LDS-bank-conflict discriminator that motivated
the K-1367/K-1389 P13 (N=128) cohort, extended one notch wider to the N=256
column-narrow regime at the K-extreme corners (K=2048 wrapper-bound boundary,
K=32768 deep-K split-K dominated). Per-cell measured speedups land in
[1.04×, 1.12×]; projected cohort geomean lift on the K-1247 cohort is
+0.8–1.2 %.

User-facing impact: 12 additional shapes that were previously dispatched to
`triton.persistent_matmul` and ran 4–12 % slower than `hipBLASLt` will now
take the route-OUT path automatically. No API surface change; runtime
killswitch (`TRITONBLAS_DISABLE_K971=1`) preserved.

## Technical Details

**Files touched (404 LOC, 3 files):**

* `include/tritonblas/_route_predicate.py` (+141)
  - new frozenset `_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12`
    (M ∈ {2048, 4096, 8192} × N=256 × K ∈ {2048, 32768} × {bf16, fp16})
  - new predicate `_k1397_p13_skinny_n256_routeout`
  - 4 cross-frozenset disjointness asserts at module load
    (vs P8, K971_ROUTE_TABLE, P12, K-1367/K-1389 P13 N=128)
  - 8th-position OR-clause appended to `k971_route_decision`
* `include/tritonblas/matmul.py` (+13)
  - import the new predicate
  - 8th-position OR-clause appended to `_k971_route_to_hbl` after the
    K-1389 P13 N=128 block
* `tests/test_k1397_p13_skinny_n256.py` (+250, NEW, 42 tests)
  - cardinality (12) and total envelope (85) pins
  - exact membership pin (every cell enumerated)
  - 4 disjointness pins (P8 / K971 / P12 / K-1367 P13)
  - 12 per-cell predicate-admits-cell pins
  - 12 full-dispatch routes-to-hbl pins (default carve-out settings)
  - 5 boundary-control pins (K=4096, K=16384, N=128, N=512 must NOT match)
  - 3 carve-out short-circuit pins (streamk / work-stealing / mixed dtype)
  - 3 regression-firewall pins (prior K971 / P8 / K-1367 admits preserved)

**Design decisions:**

1. *Strict-equality frozenset, not parametric range.* Mirrors K-1367/K-1389
   convention. Boundary-perturbed cells (K=4096, K=16384, N=128, N=512) are
   asserted to NOT match — guards against axis over-relaxation when other
   contributors stack additional predicates.
2. *Intermediate K band excluded.* K ∈ {4096, 8192, 16384} on N=256 was
   measured balanced in K-1397 (CI95 straddles 1.0×) and is intentionally
   left to `triton.persistent_matmul`, preserving the K-1227 wrapper-bound
   triton-OUT region.
3. *Stacked LAST in dispatch chain.* Per K-1175 convention, new envelopes
   stack after existing ones; ordering is irrelevant for correctness because
   all sub-frozensets are pairwise disjoint (asserted at module load), but
   stable ordering makes per-PR review diffs minimal.

**Stacked-dependency disclosure (READ BEFORE REVIEW):**

This branch transitively depends on three earlier draft PRs that are not yet
merged to `ROCm/tritonBLAS:main`:

| Commit | Source ticket | LOC | What it adds |
|--------|---------------|-----|--------------|
| `656f9ce` | K-1367 | +3,786 | Initial `_route_predicate.py` framework + first 18-cell P13 N=128 envelope |
| `e17d446` | K-1387 | refactor | P13 N=128 productionisation (55 → 73) |
| `1ce0031` | K-1389 | +1,180 | Rename to `KCOMPL_ROUTEOUT_18` + tests |
| `c103958` | **K-1402 (this)** | +404 | K-1397 P13 N=256 productionisation (73 → 85) |

The K-1402 *contribution alone* is the top commit (`c103958`, 404 LOC). The
diff against `origin/main` is 5,370 LOC because the prerequisite stack has
not landed yet. Reviewers should `git diff c103958^...c103958` to see the
K-1402 delta in isolation, or wait until the prerequisite PRs merge and
this branch gets rebased.

## Test Plan

Login-node (pure-Python predicate path; no GPU required for these pins):

```bash
cd /home/ryaswann/mc2-workspaces/K-1402/repos/tritonblas
git checkout fix/K-1397-productionize-p13-skinny-n256-kcompl
PYTHONPATH=include python3 -m pytest tests/test_k1397_p13_skinny_n256.py -x --noconftest
```

Cluster (MI300X / gfx942, c42, ROCm 7.2 container) — paired n=30 HIP-graph
hot-cache benchmark with B=10000 vectorised paired bootstrap CI95
(K-1367/K-1389 protocol, R-1298/R-1367 numpy-advanced-indexing):

```bash
NODE=$(ssh ryaswann@10.245.143.43 'salloc -p mi300x -N1 --gpus=8 -t 02:00:00 \
    --no-shell -J mc2-K-1402 2>&1 | grep -oP "Granted.*nodes? \K\S+"')
ssh ryaswann@10.245.143.43 "ssh $NODE docker run -d --name mc2-K-1402 \
    --device=/dev/kfd --device=/dev/dri --group-add video \
    --network=host --ipc=host --shm-size=64g \
    -v /home:/home rocm/pytorch:rocm7.2_ubuntu24.04_py3.12_pytorch_release_2.10.0 \
    sleep infinity"
ssh ryaswann@10.245.143.43 "ssh $NODE docker exec mc2-K-1402 bash -lc '
  cd /home/ryaswann/mc2-workspaces/K-1402/repos/tritonblas &&
  pip install -e . &&
  python3 -m pytest tests/test_k1397_p13_skinny_n256.py -x &&
  python3 benchmarks/benchmark_gemm.py --shapes K-1397 --paired --n 30
'"
```

Tolerances:
- Admit set (12 cells): geomean speedup ≥ 1.0×, CI95-lo ≥ 0.97×.
- Boundary controls (8 cells): ≤ 2 % regression.
- All 42 unit-test pins must pass.

Cross-arch backtest (per K-1373/K-1356 protocol):
- MI325X (alola) — report per-cell speedups; recommend carve-OUT cells if
  any show CI95-lo < 0.95×.
- MI355X (rainier) — same protocol; carve-OUT cells flagged in PR comments.

## Test Result

Login-node (pure-Python pin path), commit `c103958` HEAD, 2026-05-09:

```
tests/test_k1397_p13_skinny_n256.py ......................................  [100%]
42 passed in 0.18s
```

Pre-existing K-971 / K-1367 / K-1389 test suite (regression-firewall):
- 355 tests, 354 pass, 1 pre-existing baseline failure on
  `L05 (4096,4096,4096,bf16)` reproduces on `fix/K-1389-prod` HEAD without
  this diff. Out of scope per CLAUDE.md ("Pre-existing test failures: do
  NOT fix tests that already fail on main").

GPU paired-bootstrap measurement (K-1397 RETRY data, reproduced here):

| M | N | K | dtype | speedup | CI95-lo | CI95-hi |
|---|---|---|-------|---------|---------|---------|
| 2048 | 256 | 2048 | bf16 | 1.07× | 1.04× | 1.10× |
| 2048 | 256 | 2048 | fp16 | 1.05× | 1.02× | 1.09× |
| 2048 | 256 | 32768 | bf16 | 1.11× | 1.08× | 1.14× |
| 2048 | 256 | 32768 | fp16 | 1.09× | 1.06× | 1.12× |
| 4096 | 256 | 2048 | bf16 | 1.06× | 1.03× | 1.09× |
| 4096 | 256 | 2048 | fp16 | 1.04× | 1.01× | 1.08× |
| 4096 | 256 | 32768 | bf16 | 1.12× | 1.09× | 1.15× |
| 4096 | 256 | 32768 | fp16 | 1.10× | 1.07× | 1.13× |
| 8192 | 256 | 2048 | bf16 | 1.05× | 1.02× | 1.08× |
| 8192 | 256 | 2048 | fp16 | 1.04× | 1.01× | 1.07× |
| 8192 | 256 | 32768 | bf16 | 1.11× | 1.08× | 1.14× |
| 8192 | 256 | 32768 | fp16 | 1.08× | 1.05× | 1.12× |

Cohort geomean: **1.076× (CI95 [1.054×, 1.099×])** — clears gate
(geomean ≥ 1.0×, CI95-lo ≥ 0.97×).

Boundary controls (8 cells, K ∈ {4096, 16384}, N ∈ {128, 512}): max
regression 0.8 %, all within ±2 % tolerance — no regression detected.

Cross-arch backtest pending; will post in PR comments once MI325X (alola)
and MI355X (rainier) allocations clear.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [x] Stacked-dependency disclosure included (K-1367 / K-1387 / K-1389 prerequisites).
- [x] Killswitch preserved (`TRITONBLAS_DISABLE_K971=1`).
- [x] Disjointness asserts at module load (4 frozenset pairs).
- [x] Boundary-perturbation negative pins included (4 cells).
- [x] Test plan covers admit-set + control-set + cross-arch backtest.
- [ ] Cross-arch backtest results posted to PR comments after MI325X/MI355X runs.
