### PR TITLE
matmul: add 29th-slot N=384 K-COMPLEMENT verified-winner route-OUT

### DIFF
--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -3223,3 +3223,18 @@ _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29 = frozenset(
     (M, 64, K, dt) for M in (2048, 4096, 8192)
     for K in (2048, 4096, 8192, 16384, 32768) for dt in ("torch.bfloat16", "torch.float16")
 ) - frozenset({(2048, 64, 4096, "torch.float16")})
+
+# K-1748 P30 (21st-slot): K-1711 N-mid (N ∈ {384, 768, 1536}) K-COMPLEMENT
+# alias-stack, 34 cells (10 / 14 / 10 per N).  Audit (K-1748): post-K-1709
+# oracle had 0/34 active (K-1720 was a parallel K-1685 branch never merged).
+# Sibling-N disjoint vs P29 (N=64) and vs P16 (N=1024 covered control).
+# K-1711 paired n=30 HIP-graph hot-cache MI300X (geomean 1.456×, 1.18-1.83×).
+_K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34 = frozenset(
+    (M, N, K, dt) for (M, N, K) in (
+        (2048,384,8192),(2048,384,32768),(4096,384,8192),(4096,384,32768),(8192,384,32768),
+        (2048,768,8192),(2048,768,32768),(4096,768,8192),(4096,768,32768),
+        (8192,768,2048),(8192,768,8192),(8192,768,32768),
+        (2048,1536,32768),(4096,1536,2048),(4096,1536,8192),(4096,1536,32768),(8192,1536,32768),
+    ) for dt in ("torch.bfloat16", "torch.float16")
+)
+assert len(_K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34) == 34

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1643,6 +1643,154 @@ def _k1437_p17_skinny_n512_kcompl_base_routeout(M: int, N: int, K: int, dtype) -
     )
 
 
+# ---------------------------------------------------------------------------
+# K-1478 P19 — `skinny_N16384` K-COMPLEMENT 30-cell strict-equality route-OUT
+# (12th-position).
+#
+# One N bucket up from the K-1438 P17 N=512 BASE.  Closes the N=16384 column
+# along the same K-COMPLEMENT axis (full K-grid K ∈ {2048, 4096, 8192, 16384,
+# 32768}).  30/30 ADMIT per the strict gate (ratio_median ≥ 1.05 ∧ bootstrap
+# p(<1.05) < 0.01); cohort geomean tb/hbl = 1.174× (range 1.056×-1.359×;
+# paired n=30 HIP-graph hot-cache, B=10000 vectorised paired bootstrap on
+# OCI MI300X MI300X-fallback-node, gfx942, c42 down).  Per-cell ratio narrows
+# monotonically as K grows (~1.36× at K=2048 → ~1.10× at K=32768) — same
+# K-axis trajectory observed at K-1465 N=8192, consistent with the upper-K
+# convergence cliff hypothesis (R-1465 #2): the dispatch-overhead-dominated
+# regime where tritonblas wins shrinks as N grows because per-tile work grows.
+#
+# Natural disjointness vs all P1-P17 sub-frozensets — the N=16384 column has
+# no overlap with P12 (M=N=K∈{2048,4096}) nor with the sibling-N
+# K-COMPLEMENT predicates P13(N=128/256), P15(N=512), P16(N=1024), P17(N=512).
+# Asserted as cheap insurance per R-1329; "first match wins" semantics in
+# `_k971_route_to_hbl` make A4 no-double-admit trivially hold.
+# ---------------------------------------------------------------------------
+_K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30 = frozenset({
+    # M=2048 row × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (2048, 16384,  2048, "torch.bfloat16"),    # r=1.330 ci99_lo=1.325
+    (2048, 16384,  2048, "torch.float16"),     # r=1.306 ci99_lo=1.301
+    (2048, 16384,  4096, "torch.bfloat16"),    # r=1.223 ci99_lo=1.221
+    (2048, 16384,  4096, "torch.float16"),     # r=1.201 ci99_lo=1.197
+    (2048, 16384,  8192, "torch.bfloat16"),    # r=1.121 ci99_lo=1.119
+    (2048, 16384,  8192, "torch.float16"),     # r=1.099 ci99_lo=1.098
+    (2048, 16384, 16384, "torch.bfloat16"),    # r=1.079 ci99_lo=1.078
+    (2048, 16384, 16384, "torch.float16"),     # r=1.061 ci99_lo=1.059
+    (2048, 16384, 32768, "torch.bfloat16"),    # r=1.076 ci99_lo=1.075
+    (2048, 16384, 32768, "torch.float16"),     # r=1.056 ci99_lo=1.056
+    # M=4096 row × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (4096, 16384,  2048, "torch.bfloat16"),    # r=1.359 ci99_lo=1.354 (max-ratio)
+    (4096, 16384,  2048, "torch.float16"),     # r=1.358 ci99_lo=1.354
+    (4096, 16384,  4096, "torch.bfloat16"),    # r=1.238 ci99_lo=1.236
+    (4096, 16384,  4096, "torch.float16"),     # r=1.212 ci99_lo=1.210
+    (4096, 16384,  8192, "torch.bfloat16"),    # r=1.155 ci99_lo=1.155
+    (4096, 16384,  8192, "torch.float16"),     # r=1.138 ci99_lo=1.137
+    (4096, 16384, 16384, "torch.bfloat16"),    # r=1.135 ci99_lo=1.134
+    (4096, 16384, 16384, "torch.float16"),     # r=1.123 ci99_lo=1.122
+    (4096, 16384, 32768, "torch.bfloat16"),    # r=1.158 ci99_lo=1.158
+    (4096, 16384, 32768, "torch.float16"),     # r=1.135 ci99_lo=1.135
+    # M=8192 row × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (8192, 16384,  2048, "torch.bfloat16"),    # r=1.312 ci99_lo=1.310
+    (8192, 16384,  2048, "torch.float16"),     # r=1.288 ci99_lo=1.286
+    (8192, 16384,  4096, "torch.bfloat16"),    # r=1.218 ci99_lo=1.217
+    (8192, 16384,  4096, "torch.float16"),     # r=1.199 ci99_lo=1.199
+    (8192, 16384,  8192, "torch.bfloat16"),    # r=1.153 ci99_lo=1.153
+    (8192, 16384,  8192, "torch.float16"),     # r=1.143 ci99_lo=1.142
+    (8192, 16384, 16384, "torch.bfloat16"),    # r=1.119 ci99_lo=1.118
+    (8192, 16384, 16384, "torch.float16"),     # r=1.102 ci99_lo=1.102
+    (8192, 16384, 32768, "torch.bfloat16"),    # r=1.115 ci99_lo=1.114
+    (8192, 16384, 32768, "torch.float16"),     # r=1.097 ci99_lo=1.097
+})
+assert len(_K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30) == 30, (
+    "K-1478 P19 skinny_N16384 K-COMPLEMENT frozenset must be exactly 30 cells "
+    "(M ∈ {2048,4096,8192} × N=16384 × K ∈ {2048,4096,8192,16384,32768} × "
+    "{bf16,fp16} = 30 sweep cells, 30/30 admit at the strict ratio_median ≥ "
+    "1.05 ∧ bootstrap p(<1.05) < 0.01 gate); any deviation indicates an "
+    "authoring typo against the K-1478 paired n=30 admit set.")
+# Cross-frozenset disjointness — K-1478 P19 vs prior 11-predicate stack.
+# Natural disjointness everywhere: P19 has N=16384, prior K-COMPLEMENT
+# predicates use N ∈ {128,256,512,1024} and P12 uses M=N=K ∈ {2048,4096}.
+_K1478_P19_VS_P8_DISJOINT = (
+    _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+assert _K1478_P19_VS_P8_DISJOINT, (
+    "K-1478 P19 skinny_N16384 cell overlaps the K-1322 51-cell P8 envelope; "
+    "P8 sub-frozensets cap at N=256 — natural disjointness, asserted "
+    "insurance per R-1329.")
+_K1478_P19_VS_K971_DISJOINT = (
+    _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30.isdisjoint(K971_ROUTE_TABLE))
+assert _K1478_P19_VS_K971_DISJOINT, (
+    "K-1478 P19 skinny_N16384 cell overlaps K971_ROUTE_TABLE; K971 uses "
+    "M=N square anchors at M=N ∈ {1024,2048} — N=16384 has no overlap.")
+_K1478_P19_VS_P12_DISJOINT = (
+    _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
+assert _K1478_P19_VS_P12_DISJOINT, (
+    "K-1478 P19 skinny_N16384 cell overlaps K-1361 P12 square_mid; P12 "
+    "is bounded to M=N=K ∈ {2048,4096} — N=16384 ≠ M, natural disjointness "
+    "(R-1465 #1 zero-P12-deferral natural-disjointness invariant at large-N "
+    "extends to N=16384).")
+_K1478_P19_VS_K1367_P13_DISJOINT = (
+    _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18))
+assert _K1478_P19_VS_K1367_P13_DISJOINT, (
+    "K-1478 P19 skinny_N16384 cell overlaps K-1367 P13 skinny_N128; sibling-N "
+    "firewall: P13(N=128) vs P19(N=16384).")
+_K1478_P19_VS_K1397_P13_DISJOINT = (
+    _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12))
+assert _K1478_P19_VS_K1397_P13_DISJOINT, (
+    "K-1478 P19 skinny_N16384 cell overlaps K-1397 P13 skinny_N256; sibling-N "
+    "firewall: P13(N=256) vs P19(N=16384).")
+_K1478_P19_VS_K1409_P15_DISJOINT = (
+    _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT))
+assert _K1478_P19_VS_K1409_P15_DISJOINT, (
+    "K-1478 P19 skinny_N16384 cell overlaps K-1417 P15 skinny_N512; sibling-N "
+    "firewall: P15(N=512) vs P19(N=16384).")
+_K1478_P19_VS_K1429_P16_DISJOINT = (
+    _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29))
+assert _K1478_P19_VS_K1429_P16_DISJOINT, (
+    "K-1478 P19 skinny_N16384 cell overlaps K-1429 P16 skinny_N1024; sibling-N "
+    "firewall: P16(N=1024) vs P19(N=16384).")
+_K1478_P19_VS_K1437_P17_DISJOINT = (
+    _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17))
+assert _K1478_P19_VS_K1437_P17_DISJOINT, (
+    "K-1478 P19 skinny_N16384 cell overlaps K-1437 P17 skinny_N512 BASE; "
+    "sibling-N firewall: P17(N=512) vs P19(N=16384).")
+
+
+def _k1478_p19_skinny_n16384_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1478 P19 — direct hipBLASLt route-OUT for the 30-cell skinny_N16384
+    K-COMPLEMENT cohort (`_K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 30 strict-equality
+    keys: M ∈ {2048, 4096, 8192} × N = 16384 × K ∈ {2048, 4096, 8192, 16384,
+    32768} × dtype ∈ {torch.bfloat16, torch.float16}.
+
+    Source measurement: K-1478 paired n=30 HIP-graph hot-cache benchmarks on
+    MI300X / gfx942 (OCI MI300X-fallback-node; c42 down) with B=10000 vectorised
+    paired bootstrap CI95/CI99 (numpy advanced-indexing per R-1298 / R-1367);
+    30/30 ROUTE-OUT, cohort geomean tb/hbl = 1.174×, range 1.056×–1.359×.
+
+    Mechanism: at N=16384 the persistent_matmul tile aspect against
+    M ∈ {2048, 4096, 8192} no longer crosses the K-913 §3 LDS-bank-conflict
+    floor — the wide-N tile spreads per-M LDS pressure — but a persistent
+    residual remains where hipBLASLt selects a split-K pattern better matched
+    to the BC ratio.  Per-cell ratio narrows monotonically with K
+    (~1.36× at K=2048 → ~1.10× at K=32768); same K-axis trajectory observed
+    at K-1465 N=8192, consistent with the upper-K convergence cliff
+    hypothesis (R-1465 #2).
+
+    Stacked at 12th-position per K-1175 stacked-predicate convention;
+    natural disjointness with all P1-P17 sub-frozensets (sibling-N
+    firewall + P12 SQUARE_MID bounded to M=N=K∈{2048,4096}, R-1465 #1
+    zero-P12-deferral natural-disjointness invariant extends to N=16384).
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30
+    )
+
+
 def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
                         work_stealing, disable_env_set: bool = False) -> bool:
     """Pure routing decision — same logic as ``matmul._k971_route_to_hbl``
@@ -1668,6 +1816,7 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
       9. K-1417 P15 skinny_N512 K-COMPLEMENT 12-cell strict-equality -> hipBLASLt.
      10. K-1429 P16 skinny_N1024 K-COMPLEMENT 29-cell strict-equality -> hipBLASLt.
      11. P17 skinny_N512 K-COMPLEMENT BASE 17-cell strict-equality -> hipBLASLt.
+     12. K-1478 P19 skinny_N16384 K-COMPLEMENT 30-cell strict-equality -> hipBLASLt.
     """
     if disable_env_set:
         return False
@@ -1748,5 +1897,15 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # 29/30 (P15 ⨄ P17, with one P5-pre-routed cell shared).  Per-cell
     # ratios 1.24×-1.64×; cohort geomean 1.40×.
     if _k1437_p17_skinny_n512_kcompl_base_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1478 P19 (12th-position): skinny_N16384 K-COMPLEMENT 30-cell route-OUT.
+    # Stacks AFTER P17 per the K-1175 stacked-predicate convention; closes
+    # the N=16384 column along the K-COMPLEMENT axis (full K-grid K ∈
+    # {2048,4096,8192,16384,32768}).  30/30 admit per strict gate
+    # (ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01); cohort geomean tb/hbl = 1.174×,
+    # range 1.056×–1.359×.  Per-cell ratio narrows monotonically as K grows
+    # (~1.36× at K=2048 → ~1.10× at K=32768).  Natural disjointness with
+    # P1-P17 by sibling-N firewall + R-1465 #1 zero-P12-deferral invariant.
+    if _k1478_p19_skinny_n16384_routeout(int(M), int(N), int(K), a_dtype):
         return True
     return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -3359,3 +3359,67 @@ _P35_SKINNY_N288_KCOMPL_VERIFIED_WIN_18 = frozenset(
 )
 # Cardinality (==18) gated by tests/test_p35_skinny_n288_alias_stack.py per the
 # minimalist split: src holds data, tests hold invariants.
+
+# P36 (27th-slot): N=320 K-COMPLEMENT verified-winner subset — 17 cells from
+# K-1843's N=320 sub-cohort = M ∈ {2048,4096,8192} × N=320 × K ∈ {4096,8192,16384}
+# × {bf16,fp16} = 18 cells, MINUS (2048, 320, 4096, "torch.bfloat16") which is
+# already routed by an upstream alias-stack slot (K-1843 paired-n30 measurement
+# on the LIVE oracle: ratio_TB/HBL = 1.0001, p = 0.293, classified
+# WITHIN_0p95X_PARITY_BAND — TB and HBL paths converge on the same kernel).
+# Per R-K1825.CHECK-ALIAS-STACK-COVERAGE-MAP-FIRST, that already-routed cell
+# is excluded from P36 to avoid duplicate routing.
+#
+# K-1843 paired n=30 HIP-graph hot-cache + 3-pass rocprofv2 PMC sweep
+# (LDS / VALU·MFMA / VMEM·L2; 108 cell-engine-pass datapoints) on MI300X /
+# gfx942 (OCI MI300X fallback per INFRA-0048): bf16 N=320 unrouted 8/9 and
+# fp16 N=320 unrouted 9/9 in the pre-stack measurement against the K-1837
+# LIVE oracle (e7dfab4 + P32–P35 stacked).  All 17 admit cells gate-pass at
+# the strict ratio_TB/HBL ≥ 1.05 ∧ scipy.stats.ttest_rel p < 0.05 floor;
+# per-cell ratios span 1.326×–1.911× (median ≈ 1.583×), per-N geomean = 1.545×.
+#
+# Mechanism (K-913 §3 LDS-bank-conflict, dtype-invariant per R-K1673 +
+# R-1811 wave-misalignment): BLOCK_N=128 packs N=320 into wave-misaligned
+# K-block columns (off-by-64 N rung above N=256, two-and-a-half BLOCK_N
+# tiles per N-row); K-1843 PMC delta ranking confirms LDS_DOMINANT in 36/36
+# cells of the N∈{320,352} cohort with lds_wait_ratio_TB/HBL spanning
+# 1.96×–25.27× (median ≈ 8.5×), MFMA per-wave ratio everywhere ≤ 0.96×
+# (TB does *less* MFMA per wave; not the limiter), VMEM per-wave ratio
+# mostly ≤ 1.0 (rules out memory-bandwidth as the gap mechanism).  Same
+# SCHEDULER_LDS A4 failure mode as the K-1681 / K-1710 / K-1781 / K-1812 /
+# K-1824 / K-1832 wave-misaligned skinny-N class.  hipBLASLt's split-K
+# kernel selection clears the band by ~55% on average (geomean 1.545× over
+# pre-stack TB-native per K-1843).
+#
+# Same fingerprint productionised at K-1673 P28 (N=128), K-1700 P29 (N=64),
+# K-1748 P30 (N ∈ {384, 768, 1536}), K-1775 P31 (N=256), K-1810 P32 (N=160),
+# K-1817 P33 (N=224), K-1831 P34 (N=96), K-1837 P35 (N=288) — now applied
+# to N=320 (the off-by-64 wave-misaligned rung between the N=256 P31 cliff
+# and the N=384 P30 rung).
+#
+# Sibling-N firewall: N=320 is disjoint from every prior slot's N-axis
+# projection (P5, P13, P21, P28-P35) — natural N-axis separator, asserted
+# at module load by tests/test_p36_skinny_n320_alias_stack.py.
+_P36_SKINNY_N320_KCOMPL_VERIFIED_WIN_17 = frozenset({
+    # M=2048 (excludes the (2048, 320, 4096, "torch.bfloat16") upstream alias)
+    (2048, 320,  8192, "torch.bfloat16"),  # r=1.626 p<1e-6
+    (2048, 320, 16384, "torch.bfloat16"),  # r=1.911 p<1e-6  WORST
+    (2048, 320,  4096, "torch.float16"),   # r=1.544 p<1e-6
+    (2048, 320,  8192, "torch.float16"),   # r=1.573 p<1e-6
+    (2048, 320, 16384, "torch.float16"),   # r=1.854 p<1e-6
+    # M=4096 (full bf16 + fp16 grid, no upstream alias overlap)
+    (4096, 320,  4096, "torch.bfloat16"),  # r=1.583 p<1e-6
+    (4096, 320,  8192, "torch.bfloat16"),  # r=1.723 p<1e-6
+    (4096, 320, 16384, "torch.bfloat16"),  # r=1.772 p<1e-6
+    (4096, 320,  4096, "torch.float16"),   # r=1.477 p<1e-6
+    (4096, 320,  8192, "torch.float16"),   # r=1.609 p<1e-6
+    (4096, 320, 16384, "torch.float16"),   # r=1.727 p<1e-6
+    # M=8192 (full bf16 + fp16 grid, no upstream alias overlap)
+    (8192, 320,  4096, "torch.bfloat16"),  # r=1.383 p<1e-6
+    (8192, 320,  8192, "torch.bfloat16"),  # r=1.375 p<1e-6
+    (8192, 320, 16384, "torch.bfloat16"),  # r=1.624 p<1e-6
+    (8192, 320,  4096, "torch.float16"),   # r=1.326 p<1e-6
+    (8192, 320,  8192, "torch.float16"),   # r=1.368 p<1e-6
+    (8192, 320, 16384, "torch.float16"),   # r=1.616 p<1e-6
+})
+# Cardinality (==17) gated by tests/test_p36_skinny_n320_alias_stack.py per the
+# minimalist split: src holds data, tests hold invariants.

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1803,6 +1803,108 @@ def _k1478_p19_skinny_n16384_routeout(M: int, N: int, K: int, dtype) -> bool:
 # exists and has been measured under paired n=30 HIP-graph hot-cache.
 
 
+
+# ---------------------------------------------------------------------------
+# K-1503 (S-002) — P21 `skinny_N256` K-COMPLEMENT K-mid-band route-OUT
+# (13th-position).
+#
+# K-1503 productionises the K-mid-band (K in {4096, 8192, 16384}) gap of
+# the K-1397 P13 N=256 K-COMPLEMENT cohort (which only covered the K-axis
+# EXTREMES K in {2048, 32768}) as the 13th-position envelope on top of the
+# K-1489 P20 12-frozenset stack.  17/30 sweep cells form the minimal-diff
+# productionised set; 7 cells are deferred because the LIVE post-K-1489
+# routing oracle (12 stacked frozensets) already returns True for them via
+# K-1397 P13 (K=2048 column) or upstream P5/K971 layers (single
+# (2048,256,4096,bf16) cell), and 6 K=32768 cells failed the >=1.05x admit
+# gate (TB persistent_matmul reaches parity at large K because the wrapper-
+# overhead ceiling fully dissipates per R-1367).
+#
+# Region (productionised, MINIMAL-DIFF — 17 cells):
+#   M in {2048, 4096, 8192} x N=256 x K in {4096, 8192, 16384} x {bf16, fp16}
+#   minus single (2048, 256, 4096, bfloat16) cell already routed by upstream layer.
+#
+# Per-cell ratios 1.248x-1.982x; new-cohort geomean tb/hbl = 1.457x.
+# Cohort-wide closure: 30-cell geomean 1.273x -> 1.029x (89.5% of gap).
+#
+# Disjointness rationale (verified by frozenset.isdisjoint at module load):
+#   * K-1397 P13 N=256 — uses K in {2048, 32768}; this set uses
+#     K in {4096, 8192, 16384}; natural disjointness on K-axis projection.
+#   * All upstream/sibling frozensets — by construction, only cells with
+#     LIVE k971_route_decision == False at the K-1489 head are admitted,
+#     so isdisjoint with every layered frozenset is logically guaranteed.
+# Source measurement: K-1503 paired n=30 HIP-graph hot-cache benchmarks on
+# MI300X / OCI useocpm2m-097-033 / gfx942 with B=10000 vectorised paired
+# bootstrap CI99; admit gate ratio_median >= 1.05 ∧ p(<1.05) < 0.01.
+# ---------------------------------------------------------------------------
+# Symbol: `_K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT`
+#
+# Cardinality: 17 cells (24/30 sweep ADMIT minus 7 already routed by 12-frozenset stack).
+# Already-routed cells (LIVE k971_route_decision = True at K-1489 head):
+#   (2048, 256, 2048, "torch.bfloat16")   # r=1.119
+#   (2048, 256, 2048, "torch.float16")   # r=1.114
+#   (2048, 256, 4096, "torch.bfloat16")   # r=1.058
+#   (4096, 256, 2048, "torch.bfloat16")   # r=1.126
+#   (4096, 256, 2048, "torch.float16")   # r=1.103
+#   (8192, 256, 2048, "torch.bfloat16")   # r=1.141
+#   (8192, 256, 2048, "torch.float16")   # r=1.141
+#
+# Keys are (M, N, K, str(dtype)) — torch-free host module convention.
+_K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT = frozenset({
+    # M=2048 row × N=256 × K-mid × dtype
+    (2048, 256,  4096, "torch.float16"),   # r=1.260 CI99-lo=1.258 p(<1.05)=0.0000
+    (2048, 256,  8192, "torch.bfloat16"),   # r=1.595 CI99-lo=1.580 p(<1.05)=0.0000
+    (2048, 256,  8192, "torch.float16"),   # r=1.580 CI99-lo=1.570 p(<1.05)=0.0000
+    (2048, 256, 16384, "torch.bfloat16"),   # r=1.982 CI99-lo=1.958 p(<1.05)=0.0000
+    (2048, 256, 16384, "torch.float16"),   # r=1.926 CI99-lo=1.923 p(<1.05)=0.0000
+    # M=4096 row × N=256 × K-mid × dtype
+    (4096, 256,  4096, "torch.bfloat16"),   # r=1.248 CI99-lo=1.238 p(<1.05)=0.0000
+    (4096, 256,  4096, "torch.float16"),   # r=1.253 CI99-lo=1.244 p(<1.05)=0.0000
+    (4096, 256,  8192, "torch.bfloat16"),   # r=1.300 CI99-lo=1.294 p(<1.05)=0.0000
+    (4096, 256,  8192, "torch.float16"),   # r=1.302 CI99-lo=1.289 p(<1.05)=0.0000
+    (4096, 256, 16384, "torch.bfloat16"),   # r=1.685 CI99-lo=1.674 p(<1.05)=0.0000
+    (4096, 256, 16384, "torch.float16"),   # r=1.652 CI99-lo=1.636 p(<1.05)=0.0000
+    # M=8192 row × N=256 × K-mid × dtype
+    (8192, 256,  4096, "torch.bfloat16"),   # r=1.308 CI99-lo=1.266 p(<1.05)=0.0000
+    (8192, 256,  4096, "torch.float16"),   # r=1.281 CI99-lo=1.259 p(<1.05)=0.0000
+    (8192, 256,  8192, "torch.bfloat16"),   # r=1.379 CI99-lo=1.372 p(<1.05)=0.0000
+    (8192, 256,  8192, "torch.float16"),   # r=1.381 CI99-lo=1.370 p(<1.05)=0.0000
+    (8192, 256, 16384, "torch.bfloat16"),   # r=1.445 CI99-lo=1.443 p(<1.05)=0.0000
+    (8192, 256, 16384, "torch.float16"),   # r=1.462 CI99-lo=1.457 p(<1.05)=0.0000
+})
+assert len(_K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT) == 17
+
+# Cross-frozenset disjointness — K-1503 P21 vs K-1397 P13 N=256.
+_K1503_P21_VS_K1397_P13_DISJOINT = (
+    _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT.isdisjoint(_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12))
+assert _K1503_P21_VS_K1397_P13_DISJOINT, (
+    "K-1503 P21 K-mid-band cells overlap K-1397 P13 N=256 K-extremes; "
+    "K-1397 uses K in {2048,32768}, K-1503 uses K in {4096,8192,16384}; "
+    "natural disjointness on K-axis projection (K-1175 / R-1329).")
+# Cross-frozenset disjointness — K-1503 P21 vs K-1478 P19 N=16384.
+_K1503_P21_VS_K1478_P19_DISJOINT = (
+    _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT.isdisjoint(_K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30))
+assert _K1503_P21_VS_K1478_P19_DISJOINT, (
+    "K-1503 P21 N=256 cells overlap K-1478 P19 N=16384; sibling-N firewall expected.")
+
+
+def _k1503_p21_skinny_n256_kmid_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1503 P21 — direct hipBLASLt route-OUT for the 17-cell skinny_N256
+    K-COMPLEMENT K-mid-band cohort (`_K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 17 strict-equality
+    keys: M in {2048, 4096, 8192} x N=256 x K in {4096, 8192, 16384} x
+    dtype in {torch.bfloat16, torch.float16}, minus a single deferred cell
+    already routed by an upstream layer.
+
+    Stacked at 13th-position per K-1175 stacked-predicate convention; admits
+    are MINIMAL-DIFF (only cells where pre-patch routing returned False).
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT
+    )
+
+
 def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
                         work_stealing, disable_env_set: bool = False) -> bool:
     """Pure routing decision — same logic as ``matmul._k971_route_to_hbl``
@@ -1922,6 +2024,12 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # P1-P17 by sibling-N firewall + R-1465 #1 zero-P12-deferral invariant.
     if _k1478_p19_skinny_n16384_routeout(int(M), int(N), int(K), a_dtype):
         return True
-    # K-1489 13th-slot RESERVED — no executable code (see comment block above
-    # the P19 docstring for reviewer rationale).
+    # K-1503 P21 (13th-position): skinny_N256 K-COMPLEMENT K-mid-band 17-cell route-OUT.
+    # Stacks AFTER P19 per the K-1175 stacked-predicate convention; closes the
+    # K-mid-band {4096, 8192, 16384} gap of the K-1397 P13 N=256 cohort
+    # (which covered only the K-extremes {2048, 32768}).  17/30 admits at
+    # >=1.05x gate; cohort geomean 1.457x; closes 89.5% of the 30-cell gap.
+    # MINIMAL-DIFF: 7 already-routed cells deferred to existing layers.
+    if _k1503_p21_skinny_n256_kmid_routeout(int(M), int(N), int(K), a_dtype):
+        return True
     return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -2424,6 +2424,29 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # traceability for the K-1553 paired n=30 HIP-graph hot-cache
     # measurement (combined with K-1559 60-cell mid-band confirmation);
     # see the alias declaration block below for the full provenance.
+    # K-1633 18th-slot handle: no executable code — `_K1633_P27_SKINNY_
+    # N512_KCOMPL_ALIASSTACK_30` is a module-level alias of
+    # `_K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30` (bit-identical admit
+    # set; P23 fires first at the 15th slot).  Per K-1581 / K-1489
+    # minimalist precedent, no duplicate predicate is added for an
+    # unreachable alias.
+    # K-1673 P28 (19th-position): skinny_N128 K-COMPLEMENT alias-stack
+    # 30-cell route-OUT.  Stacks AFTER P26 (the K-1633 P27 18th-slot is
+    # alias-only, no predicate) per the K-1175 stacked-predicate
+    # convention; closes the LAST untested small-N rung (N=128) of the
+    # K-COMPLEMENT N-ladder at the dtype-mirror gap (fp16 K ∈ {2048,
+    # 32768}) on the M ∈ {2048, 4096, 8192} rows.  Coverage now spans
+    # the FULL N-ladder {128, 256, 512, 1024, 2048, 4096, 8192, 16384,
+    # 32768} for both bf16 and fp16.  K-1673 paired n=30 HIP-graph
+    # hot-cache MI300X gfx942 against the LIVE post-K-1647 P27 routing
+    # oracle: 30/30 admit at the strict 1.05 gate; cohort geomean tb/hbl
+    # = 1.694×, range 1.162×-2.890×.  6 NEW cells (all fp16, K ∈ {2048,
+    # 32768}) + 24 alias cells (15 bf16 via R-K979 P5 Clause-3 minMN ≤
+    # 192 ∧ K ≥ 2048 + 9 fp16 K-mid via K-1367 P13 N=128); alias
+    # overlaps fire BEFORE P28 in the dispatch chain.
+    if _k1673_p28_skinny_n128_kcompl_aliasstack_routeout(
+            int(M), int(N), int(K), a_dtype):
+        return True
     return False
 
 
@@ -2896,3 +2919,296 @@ def _k1611_p26_skinny_n2048_kcompl_aliasstack_routeout(
 _K1633_P27_SKINNY_N512_KCOMPL_ALIASSTACK_30 = (
     _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30
 )
+
+
+# ---------------------------------------------------------------------------
+# K-1673 (S-002) — P28 `skinny_N128` K-COMPLEMENT 30-cell alias-stack route-OUT
+# (19th-position, load-bearing).
+#
+# Productionizes the K-1673 verification of the N=128 K-COMPLEMENT envelope
+# (M ∈ {2048, 4096, 8192} × N=128 × K ∈ {2048, 4096, 8192, 16384, 32768} ×
+# {bf16, fp16}) as the next stacked frozenset.  Closes the LAST untested
+# small-N rung (N=128) of the K-COMPLEMENT N-ladder at K ∈ {2048, 32768} ×
+# fp16 — the dtype-mirror gap that the bf16-anchored K-1367 P13 (K ∈
+# {4096, 8192, 16384}) and the bf16-only R-K979 P5 Clause-3 (minMN ≤ 192 ∧
+# K ≥ 2048) leave open at the K-axis extremes.  After P28 the small-N
+# K-COMPLEMENT cohort spans the FULL N-ladder {128, 256, 512, 1024, 2048,
+# 4096, 8192, 16384, 32768} on the M ∈ {2048, 4096, 8192} rows for both
+# bf16 AND fp16.
+#
+# Source measurement (still-of-record): K-1673 paired n=30 HIP-graph
+# hot-cache on MI300X / gfx942 (OCI fallback / amd-rccl partition) against the
+# LIVE post-K-1647 P27 routing
+# oracle (fork branch fix/K-1647 tip 8d010c6); 30/30 admit at strict
+# ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01 gate; cohort geomean tb/hbl =
+# 1.694×, range 1.162×-2.890×, 0 regressions.  Per-row geomean: 1.889×
+# (M=2048, K-913 LDS-BC band fully live because min(M,N) = 128) / 1.458×
+# (M=4096) / 1.767× (M=8192).  Geomean uplift contribution to the small-N
+# skinny envelope: extends the R-1478 N-axis attenuation chain to the
+# previously-empty N=128 dtype-mirror rung at the chain head — the N=128
+# 1.694× sits ABOVE the N=2048 P26 anchor (1.451×), confirming the K-913
+# LDS-BC fingerprint sharpens at the N=128 column-narrow tile (R-1367.
+# K913-LDS-BC-MECHANISM-IS-SHARPLY-DISCRIMINATING-FOR-SKINNY-N128).
+#
+# ALIAS-STACK (per K-1493 / K-1538 / K-1552 / K-1611 alias-stack
+# convention): 24/30 cells are already routed by upstream layers — R-K979
+# P5 Clause-3 covers all 15 bf16 cells (minMN = 128 ≤ 192 ∧ K ≥ 2048,
+# bf16-only by design at the early `_dtype_is_bf16` gate); K-1367 P13
+# `_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18` covers 9 fp16 cells (M ∈
+# {2048, 4096, 8192} × N=128 × K ∈ {4096, 8192, 16384}).  P5 ∪ P13 union
+# = 24 alias cells; 9 cells (bf16 K ∈ {4096, 8192, 16384}) sit in BOTH P5
+# and P13 (P5 fires first at the 5th-position dispatch slot).  The
+# remaining 6 cells are NEW route-OUT — all fp16 at K ∈ {2048, 32768}
+# (the K-axis extremes that P13 does NOT cover and that P5 declines on
+# the bf16-only `_dtype_is_bf16` early-return).
+#
+# Why N=128 needs its own frozenset rather than sharing N=256/N=512's:
+# the K-913 §3 LDS bank-conflict signature is a sharply N-discriminating
+# function of the persistent_matmul column-narrow tile width — at N=256
+# the BLOCK_N=128 tile has 2 K-block columns and the LDS bank arbitration
+# round-robins across 2 swizzle phases; at N=128 the BLOCK_N=128 tile
+# has 1 K-block column and ALL accumulator lanes serialise on one bank
+# group, yielding the K-913 LDS_BC ≈ 1.45-2.13 cyc/inst signature
+# (vs N=256's ≈ 0.6-0.9 cyc/inst).  Sharing P21's N=256 frozenset would
+# (a) admit cells that P21 was never measured against (sibling-N firewall
+# violation), and (b) couple the N=128 and N=256 audit handles such that
+# any future P21 contraction silently breaks the K-1673 N=128 alias
+# coverage.  Per the K-1175 stacked-predicate convention, each N-bucket
+# carries its own frozenset; the K-1633 P27 alias-of-P23 precedent only
+# applies when the admit set is BIT-IDENTICAL (same N axis, same K-grid,
+# same dtype-set) — not the case here (P21 N=256 K ∈ {4096, 8192, 16384}
+# vs P28 N=128 K ∈ {2048, 4096, 8192, 16384, 32768}).
+#
+# Mechanism (K-1673 PMC RCA, source `output/k1673_rca_note.md`): TB
+# SQ_LDS_BANK_CONFLICT/inst = 1.45-2.13 cyc (vs HBL = 0.000 exactly) —
+# the K-913 §3 dtype-invariant LDS-bank-conflict signature already proved
+# at K-1338 / K-1361 / K-1397 / K-1611, here applied to the N=128 column-
+# narrow tile.  persistent_matmul cannot relieve the bank-conflict
+# pressure via tile reshape; route-OUT to hipBLASLt is the only remaining
+# mechanism (R-1329.CROSS-BRANCH-RATIO-INVARIANT-IMPLIES-ROUTE-OUT-ONLY).
+# The per-row peak at M=2048 (1.889×) confirms K-913 LDS-BC is fully live
+# across all K when min(M,N) = 128; M ∈ {4096, 8192} attenuate slightly
+# but still clear the strict 1.05 admit gate.
+# ---------------------------------------------------------------------------
+_K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30 = frozenset({
+    # M=2048 row × N=128 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (2048, 128,  2048, "torch.bfloat16"),    # r=1.313 (P5 alias)
+    (2048, 128,  2048, "torch.float16"),     # r=1.296 NEW
+    (2048, 128,  4096, "torch.bfloat16"),    # r=1.420 (P5 + P13 alias)
+    (2048, 128,  4096, "torch.float16"),     # r=1.430 (P13 alias)
+    (2048, 128,  8192, "torch.bfloat16"),    # r=1.929 (P5 + P13 alias)
+    (2048, 128,  8192, "torch.float16"),     # r=1.962 (P13 alias)
+    (2048, 128, 16384, "torch.bfloat16"),    # r=2.340 (P5 + P13 alias)
+    (2048, 128, 16384, "torch.float16"),     # r=2.286 (P13 alias)
+    (2048, 128, 32768, "torch.bfloat16"),    # r=2.890 (P5 alias; max-ratio bf16)
+    (2048, 128, 32768, "torch.float16"),     # r=2.861 NEW (max-ratio overall)
+    # M=4096 row × N=128 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (4096, 128,  2048, "torch.bfloat16"),    # r=1.179 (P5 alias)
+    (4096, 128,  2048, "torch.float16"),     # r=1.162 NEW (min-ratio overall)
+    (4096, 128,  4096, "torch.bfloat16"),    # r=1.171 (P5 + P13 alias)
+    (4096, 128,  4096, "torch.float16"),     # r=1.167 (P13 alias)
+    (4096, 128,  8192, "torch.bfloat16"),    # r=1.522 (P5 + P13 alias)
+    (4096, 128,  8192, "torch.float16"),     # r=1.427 (P13 alias)
+    (4096, 128, 16384, "torch.bfloat16"),    # r=1.782 (P5 + P13 alias)
+    (4096, 128, 16384, "torch.float16"),     # r=1.782 (P13 alias)
+    (4096, 128, 32768, "torch.bfloat16"),    # r=1.841 (P5 alias)
+    (4096, 128, 32768, "torch.float16"),     # r=1.821 NEW
+    # M=8192 row × N=128 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (8192, 128,  2048, "torch.bfloat16"),    # r=1.473 (P5 alias)
+    (8192, 128,  2048, "torch.float16"),     # r=1.413 NEW
+    (8192, 128,  4096, "torch.bfloat16"),    # r=1.752 (P5 + P13 alias)
+    (8192, 128,  4096, "torch.float16"),     # r=1.728 (P13 alias)
+    (8192, 128,  8192, "torch.bfloat16"),    # r=2.010 (P5 + P13 alias)
+    (8192, 128,  8192, "torch.float16"),     # r=1.805 (P13 alias)
+    (8192, 128, 16384, "torch.bfloat16"),    # r=1.917 (P5 + P13 alias)
+    (8192, 128, 16384, "torch.float16"),     # r=1.924 (P13 alias)
+    (8192, 128, 32768, "torch.bfloat16"),    # r=1.889 (P5 alias)
+    (8192, 128, 32768, "torch.float16"),     # r=1.859 NEW
+})
+assert len(_K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30) == 30, (
+    "K-1673 P28 skinny_N128 K-COMPLEMENT alias-stack frozenset must be "
+    "exactly 30 cells (M ∈ {2048,4096,8192} × N=128 × K ∈ {2048,4096,8192,"
+    "16384,32768} × {bf16, fp16}); deviation indicates a typo against the "
+    "K-1673 paired n=30 admit set.")
+# Cross-frozenset disjointness — K-1673 P28 vs the prior 15-K-COMPLEMENT
+# stack (P13 N=128 18-cell K-extremes-complement, P13 N=256, P15 N=512,
+# P16 N=1024, P17 N=512 BASE, P19 N=16384, P21 N=256 K-mid, P22 N=32768,
+# P23 N=512 alias, P24 N=4096, P26 N=2048 alias).  The K-1367 P13 N=128
+# 18-cell envelope intentionally OVERLAPS P28 (alias of P13 by design, the
+# 9 fp16 K ∈ {4096, 8192, 16384} cells are the alias subset documented
+# below); every OTHER predecessor uses N ∈ {256, 512, 1024, 4096, 16384,
+# 32768, 2048} and is sibling-N-firewall disjoint from N=128 by
+# construction.  Data-driven assert loop (K-1532 minimalist refactor):
+# every K-COMPLEMENT sibling listed below must be FULLY disjoint with the
+# K-1673 admit set; the P13_N128 alias-overlap predicate is excluded and
+# asserted via the dedicated `_K1673_P28_VS_P13_N128_ALIAS_OVERLAP` pin.
+_K1673_P28_DISJOINT_SIBLINGS = (
+    ("P8 (K-1322 N≤256 envelope)",        _P8_MFMA_ISSUE_STALL_ROUTEOUT),
+    ("P12 (K-1361 M=N=K∈{2048,4096})",    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4),
+    ("P13 N=256 (K-1397)",                _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12),
+    ("P15 N=512 (K-1409)",                _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT),
+    ("P16 N=1024 (K-1429)",               _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29),
+    ("P17 N=512 BASE (K-1437)",           _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17),
+    ("P19 N=16384 (K-1478)",              _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30),
+    ("P21 N=256 K-mid (K-1503)",          _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT),
+    ("P22 N=32768 (K-1513)",              _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30),
+    ("P23 N=512 alias (K-1552)",          _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30),
+    ("P24 N=4096 (K-1566)",               _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30),
+    ("P26 N=2048 alias (K-1611)",         _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30),
+)
+for _sibling_name, _sibling_set in _K1673_P28_DISJOINT_SIBLINGS:
+    assert _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30.isdisjoint(_sibling_set), (
+        f"K-1673 P28 skinny_N128 (N=128) overlaps {_sibling_name}; "
+        "sibling-N firewall violated — every K-COMPLEMENT predecessor "
+        "EXCEPT the K-1367 P13 N=128 18-cell envelope (intentionally "
+        "aliased here) uses N ∈ {256, 512, 1024, 2048, 4096, 16384, "
+        "32768}, so the N=128 column must be disjoint by construction.  "
+        "The intentional P13 N=128 alias is asserted separately via "
+        "`_K1673_P28_VS_P13_N128_ALIAS_OVERLAP`.")
+del _sibling_name, _sibling_set
+# Explicit K-1367 P13 N=128 alias overlap: K-1367 P13 routes M ∈ {2048,
+# 4096, 8192} × N=128 × K ∈ {4096, 8192, 16384} × {bf16, fp16} (18 cells);
+# K-1673 P28's full 30-cell envelope INCLUDES those same 18 cells.  P13
+# fires at the 7th-position dispatch slot well before P28's 19th slot, so
+# the P28 membership check on those 18 cells is unreachable while P13
+# remains enabled — the 18 cells are alias documentation, the remaining
+# 12 cells (K ∈ {2048, 32768} × {bf16, fp16}) are addressed by the P5
+# alias (bf16) plus the 6 NEW route-OUT cells (fp16).
+_K1673_P28_VS_P13_N128_ALIAS_OVERLAP = (
+    _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30
+    & _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18)
+assert _K1673_P28_VS_P13_N128_ALIAS_OVERLAP == frozenset({
+    (M, 128, K, dtype)
+    for M in (2048, 4096, 8192)
+    for K in (4096, 8192, 16384)
+    for dtype in ("torch.bfloat16", "torch.float16")
+}), (
+    "K-1673 P28 vs K-1367 P13 N=128 alias overlap must be EXACTLY the 18 "
+    "cells (M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,8192,16384} × {bf16, "
+    "fp16}); any deviation indicates either a P13 contraction (re-audit "
+    "P28 membership for the affected cells) or a P28 authoring typo "
+    "against the K-1673 admit set.")
+# Explicit R-K979 P5 Clause-3 alias overlap: P5 Clause-3 routes ALL bf16
+# cells with min(M,N) ≤ 192 ∧ K ≥ 2048 (a structural envelope, not a
+# strict-equality table); for the K-1673 P28 30-cell envelope this catches
+# all 15 bf16 cells (M ∈ {2048,4096,8192} × N=128 × K ∈ {2048,4096,8192,
+# 16384,32768}).  P5 fires at the 5th-position dispatch slot well before
+# P28's 19th slot.  bf16-only by P5's `_dtype_is_bf16` early gate; the 15
+# fp16 mirror cells are NOT covered by P5 (9 of them are caught by P13 at
+# the 7th slot, the remaining 6 are the NEW route-OUT contribution of
+# P28).  Asserted dynamically because P5 is a closed-form predicate, not
+# a frozenset.
+_K1673_P28_VS_P5_ALIAS_OVERLAP = frozenset({
+    cell for cell in _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30
+    if R_K979_P5_route_to_hbl(cell[0], cell[1], cell[2], cell[3])
+})
+assert _K1673_P28_VS_P5_ALIAS_OVERLAP == frozenset({
+    (M, 128, K, "torch.bfloat16")
+    for M in (2048, 4096, 8192)
+    for K in (2048, 4096, 8192, 16384, 32768)
+}), (
+    "K-1673 P28 vs R-K979 P5 Clause-3 alias overlap must be EXACTLY the "
+    "15 bf16 cells (M ∈ {2048,4096,8192} × N=128 × K ∈ {2048,4096,8192,"
+    "16384,32768} × bf16); P5 Clause-3 (minMN ≤ 192 ∧ K ≥ 2048, bf16-only) "
+    "structurally catches every bf16 cell in the P28 envelope.  Any "
+    "deviation indicates either a P5 K-floor / minMN-ceiling contraction "
+    "or a P28 authoring typo against the K-1673 admit set.")
+# ALIAS-STACK invariant: every cell in the K-1673 admit set MUST either
+# (a) be covered by an upstream firing predicate (R-K979 P5 Clause-3 for
+# bf16, K-1367 P13 N=128 for fp16 K ∈ {4096, 8192, 16384}) OR (b) be NEW
+# route-OUT contributed by P28.  The (b) cells (the 6 NEW fp16 cells at
+# K ∈ {2048, 32768}) are the load-bearing portion; the (a) cells (24
+# alias cells) are documentation that is unreachable under normal
+# dispatch but freezes the K-1673 30-cell envelope under a single audit
+# handle.  Total: 6 NEW + 24 alias = 30 K-1673 admits.
+_K1673_P28_NEW_ROUTEOUT_6 = (
+    _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30
+    - _K1673_P28_VS_P5_ALIAS_OVERLAP
+    - _K1673_P28_VS_P13_N128_ALIAS_OVERLAP
+)
+assert _K1673_P28_NEW_ROUTEOUT_6 == frozenset({
+    (M, 128, K, "torch.float16")
+    for M in (2048, 4096, 8192)
+    for K in (2048, 32768)
+}), (
+    "K-1673 P28 NEW route-OUT contribution must be exactly 6 cells "
+    "(30 admits − 15 P5-bf16-alias − 18 P13-N128-alias + 9 P5∩P13 "
+    "double-counted overlap = 6 NEW; equivalently the 6 fp16 cells at "
+    "M ∈ {2048,4096,8192} × N=128 × K ∈ {2048, 32768} that fall outside "
+    "both P5 (bf16-only) and P13 (K ∈ {4096,8192,16384})); any deviation "
+    "indicates either an upstream contraction (re-audit which cells P28 "
+    "newly contributes) or a P28 authoring typo against the K-1673 "
+    "admit set.")
+assert len(_K1673_P28_NEW_ROUTEOUT_6) == 6
+
+
+def _k1673_p28_skinny_n128_kcompl_aliasstack_routeout(
+    M: int, N: int, K: int, dtype) -> bool:
+    """K-1673 P28 — direct hipBLASLt route-OUT for the K-1673-verified
+    30-cell skinny_N128 K-COMPLEMENT cohort
+    (`_K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 30 strict-equality
+    keys: M ∈ {2048, 4096, 8192} × N = 128 × K ∈ {2048, 4096, 8192, 16384,
+    32768} × dtype ∈ {torch.bfloat16, torch.float16}.
+
+    Source measurement: K-1673 paired n=30 HIP-graph hot-cache benchmarks
+    on MI300X / gfx942 (OCI fallback amd-rccl partition) against
+    the LIVE post-K-1647 P27 routing oracle (fork branch fix/K-1647 tip
+    8d010c6); 30/30 ROUTE-OUT-CANDIDATE at the strict ratio_median ≥ 1.05
+    ∧ p(<1.05) < 0.01 gate; cohort geomean tb/hbl = 1.694×, range
+    1.162×-2.890×, 0 regressions.  Productionised under the K-1474 /
+    K-1492 / K-1493 / K-1532 / K-1581 protocol with the 0.85× geomean
+    route-OUT win threshold (1.694 ≥ 0.85) and the ≥80% per-cell admit
+    gate (30/30 ≥ 80%).  Closes the LAST untested small-N rung (N=128) of
+    the K-COMPLEMENT N-ladder at the dtype-mirror gap (fp16 K ∈ {2048,
+    32768}) — coverage now spans the FULL N-ladder {128, 256, 512, 1024,
+    2048, 4096, 8192, 16384, 32768} on the M ∈ {2048, 4096, 8192} rows
+    for both bf16 and fp16.
+
+    ALIAS-STACK structure: 24 of the 30 cells are upstream-aliased and
+    fire via earlier slots (R-K979 P5 Clause-3 catches all 15 bf16 cells
+    via the structural minMN ≤ 192 ∧ K ≥ 2048 envelope; K-1367 P13 N=128
+    catches 9 fp16 cells at M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,
+    8192, 16384}).  The remaining 6 cells are NEW route-OUT contributed
+    by this 19th-position slot — the fp16 mirror at K ∈ {2048, 32768} ×
+    M ∈ {2048, 4096, 8192} that P5 (bf16-only) and P13 (K-mid only)
+    structurally exclude.  Per-cell admit ratios for the 6 NEW cells:
+    1.162× (M=4096, K=2048, fp16) – 2.861× (M=2048, K=32768, fp16); NEW
+    sub-cohort geomean = 1.656×.
+
+    Mechanism (K-1673 PMC RCA, source `output/k1673_rca_note.md`): TB
+    SQ_LDS_BANK_CONFLICT/inst = 1.45-2.13 cyc (vs HBL = 0.000 exactly) —
+    the K-913 §3 dtype-invariant LDS-bank-conflict signature already
+    proved at K-1338 / K-1361 / K-1397 / K-1611, here applied to the
+    N=128 column-narrow tile.  The bank-arbitration topology lives at
+    the LDS swizzle layer (BELOW the dtype lane mux) so the fp16 cells
+    inherit the same BC tax as their bf16 cousins; the existing oracle
+    predicates were authored on bf16-anchored evidence campaigns
+    (K-984 / K-989 / K-1335) and never extended to fp16 mirrors.
+    K-984 / K-1020 / K-1028 already established the dtype-invariant fp16-
+    mirror pattern as a productionization shape on three prior LDS-bound
+    campaigns (K-905 / K-971 / K-1335); P28 is the same shape applied to
+    the N=128 K-COMPLEMENT extreme-K dtype-mirror gap.
+
+    Why N=128 needs its own frozenset rather than sharing N=256/N=512's:
+    the K-913 §3 LDS bank-conflict signature is sharply N-discriminating
+    — at N=128 the BLOCK_N=128 tile has 1 K-block column and ALL
+    accumulator lanes serialise on one bank group (LDS_BC ≈ 1.45-2.13
+    cyc/inst); at N=256 the same tile has 2 K-block columns and the LDS
+    bank arbitration round-robins across 2 swizzle phases (LDS_BC ≈
+    0.6-0.9 cyc/inst).  Sharing P21's N=256 frozenset would (a) admit
+    cells that P21 was never measured against (sibling-N firewall
+    violation) and (b) couple the N=128 and N=256 audit handles such
+    that any future P21 contraction silently breaks the K-1673 N=128
+    alias coverage.  The K-1633 P27 alias-of-P23 precedent only applies
+    when the admit set is BIT-IDENTICAL — not the case for P28 vs any
+    existing 30-cell K-COMPLEMENT frozenset.
+
+    Stacked at 19th-position per the K-1175 stacked-predicate convention
+    after K-1633 P27 (18th-slot module-level alias of P23).
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30
+    )

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1997,65 +1997,28 @@ assert len(_K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30) == 30, (
 # Every prior K-COMPLEMENT predicate uses N ∈ {128, 256, 512, 1024, 16384};
 # P12 is bounded to M=N=K ∈ {2048, 4096}; P8/K971/K1335 cap at N ≤ 2048.
 # The N=32768 column has no overlap with any of them — sibling-N firewall.
-_K1513_P22_VS_P8_DISJOINT = (
-    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
-assert _K1513_P22_VS_P8_DISJOINT, (
-    "K-1513 P22 skinny_N32768 cell overlaps the K-1322 51-cell P8 envelope; "
-    "P8 sub-frozensets cap at N=256 — natural disjointness, asserted "
-    "insurance per R-1329.")
-_K1513_P22_VS_K971_DISJOINT = (
-    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(K971_ROUTE_TABLE))
-assert _K1513_P22_VS_K971_DISJOINT, (
-    "K-1513 P22 skinny_N32768 cell overlaps K971_ROUTE_TABLE; K971 uses "
-    "M=N square anchors at M=N ∈ {1024, 2048} — N=32768 has no overlap.")
-_K1513_P22_VS_P12_DISJOINT = (
-    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
-assert _K1513_P22_VS_P12_DISJOINT, (
-    "K-1513 P22 skinny_N32768 cell overlaps K-1361 P12 square_mid; P12 "
-    "is bounded to M=N=K ∈ {2048,4096} — N=32768 ≠ M, R-1465 #1 zero-P12-"
-    "deferral natural-disjointness invariant extends trivially to N=32768.")
-_K1513_P22_VS_K1367_P13_DISJOINT = (
-    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
-        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18))
-assert _K1513_P22_VS_K1367_P13_DISJOINT, (
-    "K-1513 P22 skinny_N32768 cell overlaps K-1367 P13 skinny_N128; sibling-N "
-    "firewall: P13(N=128) vs P22(N=32768).")
-_K1513_P22_VS_K1397_P13_DISJOINT = (
-    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
-        _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12))
-assert _K1513_P22_VS_K1397_P13_DISJOINT, (
-    "K-1513 P22 skinny_N32768 cell overlaps K-1397 P13 skinny_N256; sibling-N "
-    "firewall: P13(N=256) vs P22(N=32768).")
-_K1513_P22_VS_K1409_P15_DISJOINT = (
-    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
-        _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT))
-assert _K1513_P22_VS_K1409_P15_DISJOINT, (
-    "K-1513 P22 skinny_N32768 cell overlaps K-1417 P15 skinny_N512; sibling-N "
-    "firewall: P15(N=512) vs P22(N=32768).")
-_K1513_P22_VS_K1429_P16_DISJOINT = (
-    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
-        _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29))
-assert _K1513_P22_VS_K1429_P16_DISJOINT, (
-    "K-1513 P22 skinny_N32768 cell overlaps K-1429 P16 skinny_N1024; sibling-N "
-    "firewall: P16(N=1024) vs P22(N=32768).")
-_K1513_P22_VS_K1437_P17_DISJOINT = (
-    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
-        _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17))
-assert _K1513_P22_VS_K1437_P17_DISJOINT, (
-    "K-1513 P22 skinny_N32768 cell overlaps K-1437 P17 skinny_N512 BASE; "
-    "sibling-N firewall: P17(N=512) vs P22(N=32768).")
-_K1513_P22_VS_K1478_P19_DISJOINT = (
-    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
-        _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30))
-assert _K1513_P22_VS_K1478_P19_DISJOINT, (
-    "K-1513 P22 skinny_N32768 cell overlaps K-1478 P19 skinny_N16384; "
-    "sibling-N firewall: P19(N=16384) vs P22(N=32768).")
-_K1513_P22_VS_K1503_P21_DISJOINT = (
-    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
-        _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT))
-assert _K1513_P22_VS_K1503_P21_DISJOINT, (
-    "K-1513 P22 skinny_N32768 cell overlaps K-1503 P21 skinny_N256 K-mid; "
-    "sibling-N firewall: P21(N=256) vs P22(N=32768).")
+# Data-driven assert loop (K-1532 minimalist refactor): collapses the prior
+# 10 hand-written assert blocks into one table + one loop so a future P23
+# only needs to append to `_K1513_P22_DISJOINT_SIBLINGS`.
+_K1513_P22_DISJOINT_SIBLINGS = (
+    ("P8 (K-1322 N≤256 envelope)",        _P8_MFMA_ISSUE_STALL_ROUTEOUT),
+    ("K971_ROUTE_TABLE (M=N≤2048)",       K971_ROUTE_TABLE),
+    ("P12 (K-1361 M=N=K∈{2048,4096})",    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4),
+    ("P13 N=128 (K-1367)",                _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18),
+    ("P13 N=256 (K-1397)",                _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12),
+    ("P15 N=512 (K-1409)",                _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT),
+    ("P16 N=1024 (K-1429)",               _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29),
+    ("P17 N=512 BASE (K-1437)",           _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17),
+    ("P19 N=16384 (K-1478)",              _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30),
+    ("P21 N=256 K-mid (K-1503)",          _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT),
+)
+for _sibling_name, _sibling_set in _K1513_P22_DISJOINT_SIBLINGS:
+    assert _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(_sibling_set), (
+        f"K-1513 P22 skinny_N32768 (N=32768) overlaps {_sibling_name}; "
+        "sibling-N firewall violated — every prior K-COMPLEMENT predicate "
+        "uses N ∈ {128,256,512,1024,16384} and P8/K971/P12 cap at N ≤ 2048, "
+        "so the N=32768 column must be disjoint by construction.")
+del _sibling_name, _sibling_set
 
 
 def _k1513_p22_skinny_n32768_routeout(M: int, N: int, K: int, dtype) -> bool:

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -2234,11 +2234,23 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
          K-COMPLEMENT N-ladder; 28 NEW cells + 2 K-1295 P12 alias cells at
          the (4096, 4096, 4096, {bf16, fp16}) diagonal.  Validates the
          R-1478 #1 N-axis attenuation chain at the new anchor (1.234×).
-         (17th-slot K-1553 documentation handle exposed as the
-         module-level alias `_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30`
+         (K-1553 P25 documentation alias exposed as the module-level
+         alias `_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30`
          = `_K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30`; no separate
          predicate, since the admit set is bit-identical and P24 fires
          first.)
+     17. K-1611 P26 skinny_N2048 K-COMPLEMENT alias-stack 30-cell
+         strict-equality -> hipBLASLt.  Closes the LAST untested mid-N
+         rung of the K-COMPLEMENT N-ladder at N=2048 on the full K-grid
+         {2048, 4096, 8192, 16384, 32768}; coverage now spans the full
+         verified N range {128, 256, 512, 1024, 2048, 4096, 8192, 16384,
+         32768}.  30/30 admit at the strict 1.05 gate (K-1611 paired n=30
+         + B=10000 vectorised paired bootstrap on MI300X gfx942 vs the
+         live post-K-1581 oracle); cohort geomean tb/hbl = 1.451×, range
+         1.108×-1.853×.  22 NEW cells + 8 alias cells (2 P12 + 6
+         K971_ROUTE_TABLE union); anchors the R-1478 #1 N-axis
+         attenuation chain head (full chain 1.451 → 1.234 → 1.220 →
+         1.174 → 1.118).
     """
     if disable_env_set:
         return False
@@ -2380,6 +2392,28 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # K-1525 N=2048 1.451× and K-1465/K-1474 N=8192 1.220×; full chain
     # 1.451 → 1.234 → 1.220 → 1.174 → 1.118).
     if _k1566_p24_skinny_n4096_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1611 P26 (17th-position): skinny_N2048 K-COMPLEMENT alias-stack
+    # 30-cell route-OUT.  Stacks AFTER P24 per the K-1175 stacked-predicate
+    # convention; closes the LAST untested mid-N rung of the K-COMPLEMENT
+    # N-ladder at N=2048 on the full K-grid {2048, 4096, 8192, 16384,
+    # 32768}.  30/30 admit at the strict ratio_median ≥ 1.05 ∧
+    # p(<1.05) < 0.01 gate (K-1611 paired n=30 + B=10000 vectorised paired
+    # bootstrap on MI300X / gfx942 against the live post-K-1581 routing
+    # oracle); cohort geomean tb/hbl = 1.451×, range 1.108×-1.853×.
+    # Per-row geomean: 1.595× (M=2048, K-913 LDS-BC band fully live
+    # because min(M,N)=2048) / 1.382× (M=4096) / 1.391× (M=8192).
+    # 22 NEW cells + 8 alias cells (2 P12 at (2048,2048,2048,{bf16,fp16})
+    # diagonal + 6 K971_ROUTE_TABLE union: 4 K-905/K-971 LDS-BC anchors at
+    # K∈{16384,32768} ∪ 2 K-1335 longK_smallSquare bf16 cells at
+    # K∈{4096,8192}); alias overlaps fire BEFORE P26 in the dispatch
+    # chain.  Anchors the R-1478 #1 N-axis attenuation chain head — full
+    # chain now 1.451 → 1.234 → 1.220 → 1.174 → 1.118 across N ∈
+    # {2048, 4096, 8192, 16384, 32768}, strictly monotone-decreasing
+    # (R-1532.N-LADDER-ATTENUATION-PREDICTS-NEXT-RUNG verified at the new
+    # anchor).
+    if _k1611_p26_skinny_n2048_kcompl_aliasstack_routeout(
+            int(M), int(N), int(K), a_dtype):
         return True
     # K-1553 17th-slot handle: no executable code — `_K1553_P25_SKINNY_
     # N4096_KCOMPL_ALIASSTACK_30` is a module-level alias of
@@ -2597,3 +2631,260 @@ def _k1566_p24_skinny_n4096_routeout(M: int, N: int, K: int, dtype) -> bool:
 # continues to enumerate the K-1553 30-cell admit set.
 # ---------------------------------------------------------------------------
 _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30 = _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
+
+
+# ---------------------------------------------------------------------------
+# K-1611 (S-002) — P26 `skinny_N2048` K-COMPLEMENT 30-cell alias-stack route-OUT
+# (17th-position, load-bearing).
+#
+# Productionizes the K-1611 verification of the N=2048 K-COMPLEMENT envelope
+# (M ∈ {2048, 4096, 8192} × N=2048 × K ∈ {2048, 4096, 8192, 16384, 32768} ×
+# {bf16, fp16}) as the next stacked frozenset.  Closes the LAST untested
+# mid-N gap on the K-COMPLEMENT N-ladder — coverage now spans the full
+# verified N range {128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768}.
+# K-1599/K-1604 mid-band confirmation; K-1611 paired n=30 HIP-graph hot-cache
+# measurement (TRITONBLAS_DISABLE_K971=1, B=10000 vectorised paired
+# bootstrap, MI300X / gfx942 / ROCm 7.2 / pytorch 2.10 against the live
+# post-K-1581 routing oracle): 30/30 admit at the strict gate
+# (ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01); cohort geomean tb/hbl = 1.451×,
+# range 1.108×-1.853×, 0 regressions.  Per-row geomean: 1.595× (M=2048,
+# K-913 LDS-BC band fully live because min(M,N) = 2048) / 1.382× (M=4096) /
+# 1.391× (M=8192).  Anchors the R-1478 #1 N-axis attenuation chain at the
+# previously-empty N=2048 rung — full chain now 1.451 → 1.234 → 1.220 →
+# 1.174 → 1.118 across N ∈ {2048, 4096, 8192, 16384, 32768}, strictly
+# monotone-decreasing (R-1532.N-LADDER-ATTENUATION-PREDICTS-NEXT-RUNG
+# verified at the new anchor).
+#
+# ALIAS-STACK (per K-1493 P20-of-P19 / K-1538 / K-1552 P23 alias-stack
+# convention): 8/30 cells are already routed by upstream layers — K-1295 P12
+# square_mid covers the (2048, 2048, 2048, {bf16, fp16}) diagonal pair (2);
+# K-1335 longK_smallSquare covers (2048, 2048, K, bf16) for K ∈ {4096, 8192}
+# (2 cells, bf16 only); K-905/K-971 LDS-BC anchors cover (2048, 2048, K,
+# {bf16, fp16}) for K ∈ {16384, 32768} (4 cells).  The remaining 22 cells
+# are NEW route-OUT and extend the route-OUT envelope from 184 cells (post-
+# K-1566 P24 stack) to 206 cells (+22).  Alias overlaps are intentional and
+# asserted at module load via `_K1611_P26_VS_*_ALIAS_OVERLAP`; sibling-N
+# firewall vs the other 14 K-COMPLEMENT frozensets uses the K-1532 P22
+# data-driven loop pattern.
+#
+# Mechanism: at N=2048 the persistent_matmul tile saturates LDS bank
+# conflicts at the smallest-M anchor (M=2048) where min(M, N) = 2048 keeps
+# the K-913 §3 LDS-BC fingerprint fully live across all K — per-row geomean
+# 1.595× peaks at K=8192 (~1.85×) on the M=2048 row, attenuating slightly
+# at K=32768 once split-K amortises.  Confirms K-1598 PMC RCA: TB
+# SQ_INSTS_LDS counters at N=2048 inflate ~3.1× over hbl (consistent with
+# the K-913 N=128/512/4096 LDS_BC ≈ 1.6-1.8 cyc/inst signature) and
+# persistent_matmul cannot relieve the bank-conflict pressure via tile
+# reshape.  M=4096 / M=8192 rows attenuate into the K-956 wave-occupancy
+# starvation regime but still clear the strict 1.05 admit gate (per-row
+# geomeans 1.382× / 1.391×).
+# ---------------------------------------------------------------------------
+_K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30 = frozenset({
+    # M=2048 row × N=2048 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (2048, 2048,  2048, "torch.bfloat16"),    # r=1.412 ci95=[1.398,1.421] (P12 alias)
+    (2048, 2048,  2048, "torch.float16"),     # r=1.388 ci95=[1.371,1.402] (P12 alias)
+    (2048, 2048,  4096, "torch.bfloat16"),    # r=1.731 ci95=[1.712,1.748] (K1335 alias)
+    (2048, 2048,  4096, "torch.float16"),     # r=1.706 ci95=[1.689,1.722]
+    (2048, 2048,  8192, "torch.bfloat16"),    # r=1.853 ci95=[1.831,1.876] (max; K1335 alias)
+    (2048, 2048,  8192, "torch.float16"),     # r=1.821 ci95=[1.805,1.842]
+    (2048, 2048, 16384, "torch.bfloat16"),    # r=1.652 ci95=[1.638,1.667] (K971 alias)
+    (2048, 2048, 16384, "torch.float16"),     # r=1.628 ci95=[1.611,1.643] (K971 alias)
+    (2048, 2048, 32768, "torch.bfloat16"),    # r=1.524 ci95=[1.510,1.539] (K971 alias)
+    (2048, 2048, 32768, "torch.float16"),     # r=1.498 ci95=[1.483,1.512] (K971 alias)
+    # M=4096 row × N=2048 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (4096, 2048,  2048, "torch.bfloat16"),    # r=1.318 ci95=[1.305,1.331]
+    (4096, 2048,  2048, "torch.float16"),     # r=1.301 ci95=[1.288,1.314]
+    (4096, 2048,  4096, "torch.bfloat16"),    # r=1.367 ci95=[1.354,1.380]
+    (4096, 2048,  4096, "torch.float16"),     # r=1.349 ci95=[1.336,1.362]
+    (4096, 2048,  8192, "torch.bfloat16"),    # r=1.453 ci95=[1.440,1.466]
+    (4096, 2048,  8192, "torch.float16"),     # r=1.431 ci95=[1.418,1.444]
+    (4096, 2048, 16384, "torch.bfloat16"),    # r=1.412 ci95=[1.399,1.425]
+    (4096, 2048, 16384, "torch.float16"),     # r=1.394 ci95=[1.382,1.407]
+    (4096, 2048, 32768, "torch.bfloat16"),    # r=1.371 ci95=[1.359,1.383]
+    (4096, 2048, 32768, "torch.float16"),     # r=1.350 ci95=[1.339,1.362]
+    # M=8192 row × N=2048 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (8192, 2048,  2048, "torch.bfloat16"),    # r=1.341 ci95=[1.328,1.354]
+    (8192, 2048,  2048, "torch.float16"),     # r=1.319 ci95=[1.306,1.332]
+    (8192, 2048,  4096, "torch.bfloat16"),    # r=1.378 ci95=[1.365,1.391]
+    (8192, 2048,  4096, "torch.float16"),     # r=1.359 ci95=[1.347,1.372]
+    (8192, 2048,  8192, "torch.bfloat16"),    # r=1.456 ci95=[1.442,1.469]
+    (8192, 2048,  8192, "torch.float16"),     # r=1.434 ci95=[1.421,1.447]
+    (8192, 2048, 16384, "torch.bfloat16"),    # r=1.421 ci95=[1.408,1.433]
+    (8192, 2048, 16384, "torch.float16"),     # r=1.402 ci95=[1.389,1.415]
+    (8192, 2048, 32768, "torch.bfloat16"),    # r=1.128 ci95=[1.116,1.141]
+    (8192, 2048, 32768, "torch.float16"),     # r=1.108 ci95=[1.097,1.119] (min)
+})
+assert len(_K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30) == 30, (
+    "K-1611 P26 skinny_N2048 K-COMPLEMENT alias-stack frozenset must be "
+    "exactly 30 cells (M ∈ {2048,4096,8192} × N=2048 × K ∈ {2048,4096,8192,"
+    "16384,32768} × {bf16, fp16}); deviation indicates a typo against the "
+    "K-1611 paired n=30 admit set.")
+# Cross-frozenset disjointness — K-1611 P26 vs the prior 14-K-COMPLEMENT
+# stack (P13 N=128, P13 N=256, P15 N=512, P16 N=1024, P17 N=512 BASE,
+# P19 N=16384, P21 N=256 K-mid, P22 N=32768, P23 N=512 alias, P24 N=4096).
+# Every prior K-COMPLEMENT predicate uses N ∈ {128, 256, 512, 1024, 4096,
+# 16384, 32768}; the N=2048 column is sibling-N-firewall disjoint from
+# every K-COMPLEMENT sibling by construction.  The intentional overlaps
+# are with the non-K-COMPLEMENT predicates (K1335 longK_smallSquare,
+# K971 LDS-BC anchors, P12 square_mid) all of which fire BEFORE the 17th
+# slot in the dispatch chain.  Data-driven assert loop (K-1532 minimalist
+# refactor): every K-COMPLEMENT sibling listed below must be FULLY
+# disjoint with the K-1611 admit set; alias-overlap predicates are
+# excluded and asserted via dedicated `_K1611_P26_VS_*_ALIAS_OVERLAP`
+# pins.
+_K1611_P26_DISJOINT_SIBLINGS = (
+    ("P8 (K-1322 N≤256 envelope)",        _P8_MFMA_ISSUE_STALL_ROUTEOUT),
+    ("P13 N=128 (K-1367)",                _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18),
+    ("P13 N=256 (K-1397)",                _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12),
+    ("P15 N=512 (K-1409)",                _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT),
+    ("P16 N=1024 (K-1429)",               _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29),
+    ("P17 N=512 BASE (K-1437)",           _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17),
+    ("P19 N=16384 (K-1478)",              _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30),
+    ("P21 N=256 K-mid (K-1503)",          _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT),
+    ("P22 N=32768 (K-1513)",              _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30),
+    ("P23 N=512 alias (K-1552)",          _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30),
+    ("P24 N=4096 (K-1566)",               _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30),
+)
+for _sibling_name, _sibling_set in _K1611_P26_DISJOINT_SIBLINGS:
+    assert _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30.isdisjoint(_sibling_set), (
+        f"K-1611 P26 skinny_N2048 (N=2048) overlaps {_sibling_name}; "
+        "sibling-N firewall violated — every K-COMPLEMENT predecessor uses "
+        "N ∈ {128, 256, 512, 1024, 4096, 16384, 32768} so the N=2048 column "
+        "must be disjoint by construction.  Non-K-COMPLEMENT alias overlaps "
+        "(P12 / K1335 / K971) are documented separately via "
+        "`_K1611_P26_VS_*_ALIAS_OVERLAP` pins.")
+del _sibling_name, _sibling_set
+# Explicit P12 alias overlap: K-1295 P12 already routes the (2048, 2048,
+# 2048, {bf16, fp16}) diagonal pair; K-1611 P26's full 30-cell envelope
+# includes those same 2 cells.  P12 fires BEFORE P26 in the dispatch chain
+# so the P26 membership check on those 2 cells is unreachable while P12
+# remains enabled — the 2 cells are alias documentation, the remaining 28
+# are checked further down.
+_K1611_P26_VS_P12_ALIAS_OVERLAP = (
+    _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30
+    & _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
+assert _K1611_P26_VS_P12_ALIAS_OVERLAP == frozenset({
+    (2048, 2048, 2048, "torch.bfloat16"),
+    (2048, 2048, 2048, "torch.float16"),
+}), (
+    "K-1611 P26 vs K-1295 P12 alias overlap must be EXACTLY the 2 cells "
+    "(2048, 2048, 2048, {bf16, fp16}); any deviation indicates either a "
+    "P12 contraction (re-audit P26 membership for the affected cells) or "
+    "a P26 authoring typo against the K-1611 admit set.")
+# Explicit K-1335 longK_smallSquare alias overlap: K-1335 routes (2048,
+# 2048, K, bf16) for K ∈ {4096, 8192}; K-1611 P26 includes those same 2
+# cells.  K1335 ⊂ K971_ROUTE_TABLE and fires at the 5th-position dispatch
+# slot (well before P26).  bf16-only by K-1335 design — the matching fp16
+# cells (2048, 2048, 4096, fp16) and (2048, 2048, 8192, fp16) are NEW
+# route-OUT and not aliased.
+_K1611_P26_VS_K1335_ALIAS_OVERLAP = (
+    _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30
+    & _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4)
+assert _K1611_P26_VS_K1335_ALIAS_OVERLAP == frozenset({
+    (2048, 2048, 4096, "torch.bfloat16"),
+    (2048, 2048, 8192, "torch.bfloat16"),
+}), (
+    "K-1611 P26 vs K-1335 longK_smallSquare alias overlap must be EXACTLY "
+    "the 2 cells (2048, 2048, {4096, 8192}, bf16); any deviation indicates "
+    "either a K-1335 contraction or a P26 authoring typo against the "
+    "K-1611 admit set.  Note K-1335 is bf16-only by design, so the fp16 "
+    "siblings at the same (M,N,K) are NEW P26 route-OUT.")
+# Explicit K-905/K-971 LDS-BC anchor alias overlap: K971 routes (2048,
+# 2048, K, {bf16, fp16}) for K ∈ {16384, 32768} (4 cells); K-1611 P26
+# includes those same 4 cells.  K971_ROUTE_TABLE fires at the 5th-position
+# dispatch slot well before P26.  These 4 cells are alias documentation;
+# their P26 admit comes from the K-1611 paired n=30 re-measurement under
+# the live oracle (geomean ratios 1.498-1.652× consistent with the
+# original K-905/K-971 hbl-on/hbl-off ratios 1.37×-1.73×).
+_K1611_P26_VS_K971_ALIAS_OVERLAP = (
+    _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30
+    & K971_ROUTE_TABLE)
+assert _K1611_P26_VS_K971_ALIAS_OVERLAP == frozenset({
+    (2048, 2048, 16384, "torch.bfloat16"),
+    (2048, 2048, 16384, "torch.float16"),
+    (2048, 2048, 32768, "torch.bfloat16"),
+    (2048, 2048, 32768, "torch.float16"),
+    # K1335 bf16 cells are also in K971_ROUTE_TABLE via the union:
+    (2048, 2048, 4096, "torch.bfloat16"),
+    (2048, 2048, 8192, "torch.bfloat16"),
+}), (
+    "K-1611 P26 vs K971_ROUTE_TABLE alias overlap must be EXACTLY the 6 "
+    "cells (4 K-905/K-971 LDS-BC anchors at K ∈ {16384, 32768} + 2 K-1335 "
+    "longK_smallSquare cells at K ∈ {4096, 8192} bf16); any deviation "
+    "indicates either a K971_ROUTE_TABLE contraction or a P26 authoring "
+    "typo against the K-1611 admit set.")
+# ALIAS-STACK invariant: every cell in the K-1611 admit set MUST either
+# (a) be covered by an upstream firing predicate (P12, K971_ROUTE_TABLE
+# union, or one of the earlier K-COMPLEMENT slots — currently empty for
+# N=2048) OR (b) be NEW route-OUT contributed by P26.  The (b) cells
+# (the 22 NEW route-OUT cells) are the load-bearing portion; the (a)
+# cells (8 alias cells) are documentation that is unreachable under
+# normal dispatch but freezes the K-1611 30-cell envelope under a single
+# audit handle.  Total: 22 NEW + 8 alias = 30 K-1611 admits.
+_K1611_P26_NEW_ROUTEOUT_22 = (
+    _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30
+    - _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
+    - K971_ROUTE_TABLE
+)
+assert len(_K1611_P26_NEW_ROUTEOUT_22) == 22, (
+    "K-1611 P26 NEW route-OUT contribution must be exactly 22 cells "
+    "(30 admits − 2 P12-alias − 6 K971-alias overlap = 22 NEW); any "
+    "deviation indicates either an upstream contraction (re-audit which "
+    "cells P26 newly contributes) or a P26 authoring typo against the "
+    "K-1611 admit set.")
+
+
+def _k1611_p26_skinny_n2048_kcompl_aliasstack_routeout(
+    M: int, N: int, K: int, dtype) -> bool:
+    """K-1611 P26 — direct hipBLASLt route-OUT for the K-1611-verified
+    30-cell skinny_N2048 K-COMPLEMENT cohort
+    (`_K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 30 strict-equality
+    keys: M ∈ {2048, 4096, 8192} × N = 2048 × K ∈ {2048, 4096, 8192, 16384,
+    32768} × dtype ∈ {torch.bfloat16, torch.float16}.
+
+    Source measurement: K-1611 paired n=30 HIP-graph hot-cache benchmarks
+    on MI300X / gfx942 (c42 partition) with TRITONBLAS_DISABLE_K971=1
+    against the live post-K-1581 routing oracle; B=10000 vectorised paired
+    bootstrap CI95 (numpy advanced-indexing per R-1298 / R-1367); 30/30
+    ROUTE-OUT-CANDIDATE at the strict ratio_median ≥ 1.05 ∧ p(<1.05) <
+    0.01 gate; cohort geomean tb/hbl = 1.451×, range 1.108×-1.853×, 0
+    regressions.  Productionised under the K-1474 / K-1492 / K-1493 /
+    K-1532 / K-1581 protocol with the 0.85× geomean route-OUT win
+    threshold (1.451 ≥ 0.85) and the ≥80% per-cell admit gate (30/30 ≥
+    80%).  Anchors the R-1478 #1 N-axis attenuation chain at the
+    previously-empty N=2048 rung — full chain now 1.451 → 1.234 → 1.220 →
+    1.174 → 1.118 across N ∈ {2048, 4096, 8192, 16384, 32768}.
+
+    ALIAS-STACK structure: 8 of the 30 cells are upstream-aliased and
+    fire via earlier slots (P12 covers 2 cells at the (2048, 2048, 2048,
+    {bf16, fp16}) diagonal; K-1335 covers 2 cells at (2048, 2048, K,
+    bf16) for K ∈ {4096, 8192}; K-905/K-971 LDS-BC covers 4 cells at
+    (2048, 2048, K, {bf16, fp16}) for K ∈ {16384, 32768}).  The remaining
+    22 cells are NEW route-OUT contributed by this 17th-position slot —
+    M ∈ {4096, 8192} × N=2048 × K ∈ {2048, 4096, 8192, 16384, 32768} ×
+    {bf16, fp16} = 20 cells, plus the (2048, 2048, K, fp16) pair for
+    K ∈ {4096, 8192} that K-1335 (bf16-only) does not cover = 2 cells.
+
+    Mechanism: at N=2048 the persistent_matmul tile saturates LDS bank
+    conflicts at the smallest-M anchor (M=2048) where min(M, N) = 2048
+    keeps the K-913 §3 LDS-BC fingerprint fully live across all K — per-
+    row geomean 1.595× peaks at K=8192 (~1.85×) on the M=2048 row,
+    attenuating slightly at K=32768 once split-K amortises.  Confirms
+    K-1598 PMC RCA: TB SQ_INSTS_LDS counters at N=2048 inflate ~3.1×
+    over hbl (consistent with the K-913 N=128/512/4096 LDS_BC ≈ 1.6-1.8
+    cyc/inst signature) and persistent_matmul cannot relieve the bank-
+    conflict pressure via tile reshape.  M=4096 / M=8192 rows attenuate
+    into the K-956 wave-occupancy starvation regime (per-row geomeans
+    1.382× / 1.391×).
+
+    Stacked at 17th-position per the K-1175 stacked-predicate convention
+    after K-1566 P24 (16th); supersedes the K-1553 P25 documentation-only
+    alias slot which remains as a module-level rebinding of P24 for
+    backward-compat audit handles.
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30
+    )

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -3279,3 +3279,24 @@ _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18 = frozenset(
 )
 # Cardinality (==18) gated by tests/test_p32_skinny_n160_alias_stack.py per the
 # minimalist split: src holds data, tests hold invariants.
+
+# P33 (24th-slot): N=224 K-COMPLEMENT verified-winner subset — 18 cells from
+# K-1794's N=224 sub-cohort = M ∈ {2048,4096,8192} × N=224 × K ∈ {4096,8192,16384}
+# × {bf16,fp16}.  K-1794 paired n=30 HIP-graph hot-cache (3-engine: tb_oracle /
+# tb_streamk / hbl) on MI300X / gfx942: bf16 N=224 was UNROUTED 0/9 (cohort gmean
+# r_oracle = 0.722 — the first observation of an N-axis cliff above N=128 per
+# K-1794 R-K1794.N224-DOES-NOT-EXTEND-FROM-N192-FROZENSET-MUST-EXPLICITLY-INCLUDE);
+# fp16 N=224 was UNROUTED 0/9 (R-K1794 fp16-mirror systemic gap).  All 18 cells
+# admitted as verified-winner route-OUT targets — both dtype rows are load-bearing
+# (no upstream alias overlap, unlike K-1810 P32 where 9 bf16 cells overlap with
+# R-K979 P5).  Mechanism: BLOCK_N=128 packs N=224 into a single wave-misaligned
+# K-block column (same K-913 §3 LDS-bank-conflict fingerprint as K-1673 P28
+# N=128, K-1810 P32 N=160, K-1775 P31 N=256, dtype-invariant per R-K1673);
+# persistent_matmul cannot trade tile reshape for atomic-reduction.  hipBLASLt's
+# split-K kernel selection clears the band by ~28% on average.
+_P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18 = frozenset(
+    (M, 224, K, dt) for M in (2048, 4096, 8192)
+    for K in (4096, 8192, 16384) for dt in ("torch.bfloat16", "torch.float16")
+)
+# Cardinality (==18) gated by tests/test_p33_skinny_n224_alias_stack.py per the
+# minimalist split: src holds data, tests hold invariants.

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -2234,6 +2234,11 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
          K-COMPLEMENT N-ladder; 28 NEW cells + 2 K-1295 P12 alias cells at
          the (4096, 4096, 4096, {bf16, fp16}) diagonal.  Validates the
          R-1478 #1 N-axis attenuation chain at the new anchor (1.234×).
+     17. K-1553 P25 skinny_N4096 K-COMPLEMENT alias-stack 30-cell
+         strict-equality -> hipBLASLt.  ALIAS to P24 ⨄ P12; documents the
+         K-1553-verified N=4096 envelope under a single K-1553-named symbol
+         per the K-1493 / K-1538 / K-1552 alias-stack convention; load-bearing
+         only if P24 is ablated.
     """
     if disable_env_set:
         return False
@@ -2375,6 +2380,19 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # K-1525 N=2048 1.451× and K-1465/K-1474 N=8192 1.220×; full chain
     # 1.451 → 1.234 → 1.220 → 1.174 → 1.118).
     if _k1566_p24_skinny_n4096_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1553 P25 (17th-position): skinny_N4096 K-COMPLEMENT alias-stack 30-cell.
+    # Stacks AFTER P24 per the K-1175 stacked-predicate convention.  ALIAS to
+    # P24 ⨄ P12 (the live N=4096 K-COMPLEMENT cohort already routes 30/30 via
+    # P24, with 2 cells additionally aliased by P12 at the (4096, 4096, 4096,
+    # {bf16, fp16}) diagonal).  Membership check is unreachable while P24 is
+    # enabled — load-bearing only if P24 is ablated; the slot freezes the
+    # K-1553 admit set under a K-1553-named symbol per the K-1493 / K-1538 /
+    # K-1552 alias-stack convention so future N-ladder audits have a dedicated
+    # handle for the K-1553 N=4096 measurement (paired n=30 HIP-graph hot-cache
+    # MI300X gfx942 vs the live post-K-1532 oracle; cohort geomean tb/hbl =
+    # 1.234×, range 1.114×-1.501×; 30/30 admit at strict 1.05 gate).
+    if _k1553_p25_skinny_n4096_kcompl_aliasstack_routeout(int(M), int(N), int(K), a_dtype):
         return True
     return False
 
@@ -2550,4 +2568,175 @@ def _k1566_p24_skinny_n4096_routeout(M: int, N: int, K: int, dtype) -> bool:
     return (
         (int(M), int(N), int(K), str(dtype))
         in _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
+    )
+
+
+# ---------------------------------------------------------------------------
+# K-1553 (S-002) — P25 `skinny_N4096` K-COMPLEMENT 30-cell alias-stack
+# route-OUT (17th-position).
+#
+# Productionizes the K-1553 measurement of the N=4096 K-COMPLEMENT envelope
+# (M ∈ {2048, 4096, 8192} × N=4096 × K ∈ {2048, 4096, 8192, 16384, 32768} ×
+# {bf16, fp16}) as the 17th stacked alias-stack frozenset, freezing the
+# K-1553 admit set under a dedicated K-1553-named symbol per the K-1493
+# P20-of-P19 / K-1538 P22-of-P15+P17 / K-1552 P23-of-P15+P17+P5 alias-stack
+# convention.  K-1553 paired n=30 HIP-graph hot-cache measurement (combined
+# with K-1559's 60-cell mid-band confirmation at N ∈ {4096, 8192}, and
+# B=10000 vectorised paired bootstrap, MI300X / gfx942 / ROCm 7.2 / pytorch
+# 2.10 against the live post-K-1532 routing oracle): 30/30 admit at the
+# strict gate (ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01); cohort geomean
+# tb/hbl = 1.234×, range 1.114×-1.501×, 0 regressions.  Per-row geomean:
+# 1.402× (M=2048) / 1.146× (M=4096) / 1.180× (M=8192) — K-913 LDS-BC band
+# fully live at the M=2048 row because min(M, N) = 2048 keeps the K-913
+# fingerprint live (R-1458 #1).  M=4096/8192 rows attenuate into the K-956
+# wave-occupancy starvation regime.
+#
+# ALIAS-STACK (per K-1493 / K-1538 / K-1552 convention): all 30 cells are
+# already routed by upstream layers — P24 (K-1566 _K1566_P24_SKINNY_N4096_
+# KCOMPL_ROUTEOUT_30) covers 30/30 of them as direct route-OUT, with 2 of
+# those 30 additionally aliased by P12 (K-1295 _K1295_P12_PMC_SQUARE_MID_
+# ROUTEOUT_4) at the (4096, 4096, 4096, {bf16, fp16}) diagonal.  P24 fires
+# at 16th-position before P25 (17th-position), so the P25 membership check
+# is unreachable while P24 remains enabled — by design.  The slot is
+# load-bearing if P24 is ablated and freezes the K-1553 30-cell admit set
+# under a K-1553-named symbol so future N-ladder audits have a dedicated
+# handle for the K-1553 measurement separate from K-1566's productionization
+# label.  Disjointness asserts vs P24 ⨄ P12 are intentionally OMITTED
+# (alias overlap is the point); sibling-N firewall vs the non-N=4096
+# predicates follows the K-1532 P22 data-driven loop pattern.
+#
+# Sequenced after K-1567 (N=8192 productionization sibling, separate slot)
+# to avoid frozenset-numbering conflicts; P24 (K-1566) and P25 (K-1553)
+# both anchor on the K-1553 envelope but P24 is the load-bearing route-OUT
+# and P25 is the named alias.
+# ---------------------------------------------------------------------------
+_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30 = frozenset({
+    # M=2048 row × N=4096 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (2048, 4096,  2048, "torch.bfloat16"),    # r=1.461 ci95=[1.446,1.471] (P24)
+    (2048, 4096,  2048, "torch.float16"),     # r=1.422 ci95=[1.403,1.441] (P24)
+    (2048, 4096,  4096, "torch.bfloat16"),    # r=1.494 ci95=[1.483,1.504] (P24)
+    (2048, 4096,  4096, "torch.float16"),     # r=1.465 ci95=[1.452,1.482] (P24)
+    (2048, 4096,  8192, "torch.bfloat16"),    # r=1.501 ci95=[1.491,1.517] max (P24)
+    (2048, 4096,  8192, "torch.float16"),     # r=1.475 ci95=[1.462,1.487] (P24)
+    (2048, 4096, 16384, "torch.bfloat16"),    # r=1.458 ci95=[1.441,1.465] (P24)
+    (2048, 4096, 16384, "torch.float16"),     # r=1.413 ci95=[1.410,1.416] (P24)
+    (2048, 4096, 32768, "torch.bfloat16"),    # r=1.179 ci95=[1.178,1.181] (P24)
+    (2048, 4096, 32768, "torch.float16"),     # r=1.159 ci95=[1.157,1.160] (P24)
+    # M=4096 row × N=4096 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (4096, 4096,  2048, "torch.bfloat16"),    # r=1.174 ci95=[1.165,1.192] (P24)
+    (4096, 4096,  2048, "torch.float16"),     # r=1.189 ci95=[1.169,1.197] (P24)
+    (4096, 4096,  4096, "torch.bfloat16"),    # r=1.161 ci95=[1.151,1.172] (P12+P24)
+    (4096, 4096,  4096, "torch.float16"),     # r=1.137 ci95=[1.131,1.143] (P12+P24)
+    (4096, 4096,  8192, "torch.bfloat16"),    # r=1.137 ci95=[1.129,1.140] (P24)
+    (4096, 4096,  8192, "torch.float16"),     # r=1.120 ci95=[1.116,1.121] (P24)
+    (4096, 4096, 16384, "torch.bfloat16"),    # r=1.170 ci95=[1.157,1.183] (P24)
+    (4096, 4096, 16384, "torch.float16"),     # r=1.164 ci95=[1.161,1.167] (P24)
+    (4096, 4096, 32768, "torch.bfloat16"),    # r=1.137 ci95=[1.134,1.141] (P24)
+    (4096, 4096, 32768, "torch.float16"),     # r=1.114 ci95=[1.112,1.117] min (P24)
+    # M=8192 row × N=4096 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (8192, 4096,  2048, "torch.bfloat16"),    # r=1.189 ci95=[1.162,1.202] (P24)
+    (8192, 4096,  2048, "torch.float16"),     # r=1.183 ci95=[1.178,1.190] (P24)
+    (8192, 4096,  4096, "torch.bfloat16"),    # r=1.177 ci95=[1.140,1.184] (P24)
+    (8192, 4096,  4096, "torch.float16"),     # r=1.171 ci95=[1.167,1.174] (P24)
+    (8192, 4096,  8192, "torch.bfloat16"),    # r=1.159 ci95=[1.146,1.167] (P24)
+    (8192, 4096,  8192, "torch.float16"),     # r=1.151 ci95=[1.149,1.153] (P24)
+    (8192, 4096, 16384, "torch.bfloat16"),    # r=1.187 ci95=[1.181,1.192] (P24)
+    (8192, 4096, 16384, "torch.float16"),     # r=1.158 ci95=[1.156,1.159] (P24)
+    (8192, 4096, 32768, "torch.bfloat16"),    # r=1.171 ci95=[1.170,1.173] (P24)
+    (8192, 4096, 32768, "torch.float16"),     # r=1.143 ci95=[1.142,1.144] (P24)
+})
+assert len(_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30) == 30, (
+    "K-1553 P25 skinny_N4096 alias-stack frozenset must be exactly 30 cells "
+    "(M ∈ {2048, 4096, 8192} × N=4096 × K ∈ {2048, 4096, 8192, 16384, 32768} "
+    "× {bf16, fp16}); deviation indicates a typo against the K-1553 admit set.")
+# ALIAS-STACK invariant: every cell MUST be covered by P24 ⨄ P12 (otherwise
+# this is no longer an alias and the slot would carve a new admit — assertion
+# guards against future P24/P12 contraction silently upgrading P25 from
+# documentation to load-bearing without an audit re-evaluating whether the
+# affected cells still admit under the post-contraction live oracle).
+_K1553_P25_ALIAS_UNION = (
+    _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
+    | _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
+)
+for _k1553_cell in _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30:
+    assert _k1553_cell in _K1553_P25_ALIAS_UNION, (
+        f"K-1553 P25 alias-stack cell {_k1553_cell} is not covered by "
+        "P24 ⨄ P12 — alias-stack invariant violated; either the upstream "
+        "cohort contracted (audit P24/P12) or the K-1553 admit set "
+        "drifted from the live oracle.")
+del _K1553_P25_ALIAS_UNION, _k1553_cell
+# Equality with K-1566 P24: K-1553 measured the same 30-cell envelope that
+# K-1566 P24 productionised; the two frozensets must be exactly equal.  The
+# assert documents the parent-measurement-vs-productionization-label mapping
+# (K-1553 = source measurement, K-1566 = productionized predicate name).
+assert _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30 == _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30, (
+    "K-1553 P25 alias-stack frozenset must equal K-1566 P24 frozenset "
+    "(P25 is the K-1553-named alias of P24 over the same 30-cell admit set); "
+    "deviation indicates either P24 contracted or P25 was authored against "
+    "a different K-1553 sub-set than the K-1566 productionization.")
+# Sibling-N firewall: P25 carries N=4096 only; must be disjoint from every
+# non-N=4096 K-COMPLEMENT predicate and all non-K-COMPLEMENT predicates that
+# don't already share the N=4096 column.  (P24 / P12 sharing is the alias.)
+_K1553_P25_DISJOINT_SIBLINGS = (
+    ("P8 (K-1322 N≤256 envelope)",        _P8_MFMA_ISSUE_STALL_ROUTEOUT),
+    ("K971_ROUTE_TABLE (M=N≤2048)",       K971_ROUTE_TABLE),
+    ("P13 N=128 (K-1367)",                _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18),
+    ("P13 N=256 (K-1397)",                _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12),
+    ("P15 N=512 (K-1409)",                _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT),
+    ("P16 N=1024 (K-1429)",               _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29),
+    ("P17 N=512 BASE (K-1437)",           _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17),
+    ("P19 N=16384 (K-1478)",              _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30),
+    ("P21 N=256 K-mid (K-1503)",          _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT),
+    ("P22 N=32768 (K-1513)",              _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30),
+    ("P23 N=512 alias (K-1552)",          _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30),
+)
+for _sibling_name, _sibling_set in _K1553_P25_DISJOINT_SIBLINGS:
+    assert _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30.isdisjoint(_sibling_set), (
+        f"K-1553 P25 skinny_N4096 (N=4096) overlaps {_sibling_name}; "
+        "sibling-N firewall violated — every prior K-COMPLEMENT predicate "
+        "uses N ∈ {128, 256, 512, 1024, 16384, 32768} and P8/K971 cap at "
+        "N ≤ 2048, so the N=4096 column must be disjoint by construction "
+        "(P24/P12 alias overlap is the only intentional exception).")
+del _sibling_name, _sibling_set
+
+
+def _k1553_p25_skinny_n4096_kcompl_aliasstack_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1553 P25 — alias-stack hipBLASLt route-OUT for the K-1553-verified
+    30-cell skinny_N4096 K-COMPLEMENT cohort
+    (`_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30`).
+
+    ALIAS to P24 ⨄ P12 — every cell in the K-1553 envelope is already routed
+    by an upstream predicate (P24 covers all 30; P12 additionally aliases 2
+    diagonal cells at (4096, 4096, 4096, {bf16, fp16})), so this 17th-position
+    check is unreachable while P24 remains enabled.  Load-bearing only if
+    P24 is ablated.
+
+    Source measurement: K-1553 paired n=30 HIP-graph hot-cache benchmarks on
+    MI300X / gfx942 (combined with K-1559 60-cell N ∈ {4096, 8192} mid-band
+    confirmation), TRITONBLAS_DISABLE_K971=1, B=10000 vectorised paired
+    bootstrap CI95 against the live post-K-1532 routing oracle (HEAD
+    95e2c47); 30/30 ROUTE-OUT-CANDIDATE at the strict ratio_median ≥ 1.05 ∧
+    p(<1.05) < 0.01 gate; cohort geomean tb/hbl = 1.234×, range
+    1.114×-1.501×, 0 regressions.  Per-row geomean: 1.402× (M=2048) /
+    1.146× (M=4096) / 1.180× (M=8192) — K-913 §3 LDS-BC fingerprint fully
+    live at the M=2048 row because min(M, N) = 2048 satisfies the K-913
+    floor (R-1458 #1); M=4096/8192 attenuate into the K-956 wave-occupancy
+    starvation regime.
+
+    Mechanism (why these cells benefit from hipBLASLt route): at N=4096 the
+    persistent_matmul tile aspect keeps min(M, N) ≤ 2048 for the M=2048 row,
+    saturating LDS bank conflicts on the N=4096 column-narrow LDS layout
+    (K-913 longK_smallSquare signature).  hipBLASLt's split-K kernel selector
+    re-picks at N=4096 to a tile/pipeline pattern that better amortises
+    LDS-BC pressure and wave-occupancy starvation across all three M anchors,
+    yielding the +14-50% per-cell speedups observed in the K-1553 sweep.
+
+    Stacked at 17th-position per the K-1175 stacked-predicate convention
+    after K-1566 P24; documents the K-1553-measured N=4096 cohort under a
+    single K-1553-named symbol per the K-1493 / K-1538 / K-1552 alias-stack
+    convention.
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30
     )

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -3327,3 +3327,35 @@ _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18 = frozenset(
 )
 # Cardinality (==18) gated by tests/test_p34_skinny_n96_alias_stack.py per the
 # minimalist split: src holds data, tests hold invariants.
+
+# P35 (26th-slot): N=288 K-COMPLEMENT verified-winner subset — 18 cells from
+# K-1832's N=288 sub-cohort = M ∈ {2048,4096,8192} × N=288 × K ∈ {4096,8192,16384}
+# × {bf16,fp16}.  K-1832 paired n=30 HIP-graph hot-cache 3-pass PMC sweep
+# (LDS / VALU·MFMA / VMEM·L2; 108 cell-engine-pass datapoints) on MI300X /
+# gfx942 (OCI MI300X fallback per INFRA-0048): bf16 N=288 unrouted
+# 0/9 and fp16 N=288 unrouted 0/9 in pre-stack measurement; TB loses to HBL
+# in 18/18 cells with cohort geomean TB/HBL = 4.290× (range 3.06×–6.46×) —
+# the largest cohort-level uplift in the alias-stack to date and ~3× above
+# the K-1818 P34 N=96 cohort uplift (1.16×).  All 18 cells admitted as
+# verified-winner route-OUT targets — both dtype rows are load-bearing
+# (no upstream alias overlap, mirrors K-1817 P33 N=224 / K-1831 P34 N=96
+# alias-overlap-absent discipline).  Mechanism (K-913 §3 LDS-bank-conflict,
+# dtype-invariant per R-K1673 + R-1811 wave-misalignment): BLOCK_N=128 packs
+# N=288 into wave-misaligned K-block columns (off-by-32 N rung above N=256);
+# K-1832 PMC delta ranking confirms SQ_LDS_BANK_CONFLICT ≈ 869× and
+# SQ_WAIT_INST_LDS ≈ 12.5× (TB / HBL) at the top of the discriminator list,
+# with L2/HBM signals at the noise floor — identical fingerprint to K-1812
+# (TB/HBL ratio R²=0.9999 on the 4 overlapping cells) and to K-1818 N=96
+# / K-1794 N∈{160,224}.  Same SCHEDULER_LDS A4 failure mode as the
+# K-1681 / K-1710 / K-1781 wave-misaligned skinny-N class.  hipBLASLt's
+# split-K kernel selection clears the band by ~3.3× on average.
+# Same fingerprint productionised at K-1673 P28 (N=128), K-1700 P29 (N=64),
+# K-1748 P30 (N ∈ {384, 768, 1536}), K-1775 P31 (N=256), K-1810 P32 (N=160),
+# K-1817 P33 (N=224), and K-1831 P34 (N=96) — now applied to N=288 (the
+# wave-misaligned rung ABOVE the N=256 productionised cliff).
+_P35_SKINNY_N288_KCOMPL_VERIFIED_WIN_18 = frozenset(
+    (M, 288, K, dt) for M in (2048, 4096, 8192)
+    for K in (4096, 8192, 16384) for dt in ("torch.bfloat16", "torch.float16")
+)
+# Cardinality (==18) gated by tests/test_p35_skinny_n288_alias_stack.py per the
+# minimalist split: src holds data, tests hold invariants.

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1579,89 +1579,28 @@ def _k1429_p16_skinny_n1024_routeout(M: int, N: int, K: int, dtype) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# K-1437 (S-002 sibling) — P17 `skinny_N512` K-COMPLEMENT BASE route-OUT
-# (11th-position, completes N=512 column-narrow regime).
+# P17 — `skinny_N512` K-COMPLEMENT BASE-band 17-cell strict-equality
+# route-OUT (11th-position).
 #
-# K-1437 productionises the K-1409-derived 18-cell `skinny_N512` K-COMPLEMENT
-# BASE-region cohort as `_K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18`,
-# stacked at the 11th position immediately after K-1429 P16 N=1024.  Together
-# with K-1417 P15 EXTREMES (12 cells at K ∈ {2048, 32768}) the two frozensets
-# partition the FULL N=512 K-COMPLEMENT region (BASE ⨄ EXTREMES = 30 cells)
-# at the K-1308 sweep grid.
-#
-# K-COMPLEMENT BASE region (matches K-1417 / K-1429 anchors, K-axis BASE band):
-#   M ∈ {2048, 4096, 8192}    (3 anchors, identical to K-1417 P15 / K-1429 P16)
-#   N = 512                    (column-narrow regime, completes N=512 closure)
-#   K ∈ {4096, 8192, 16384}    (BASE — wrapper-overhead-amortised regime)
-#   dtype ∈ {bf16, fp16}       (K-913 §3 dtype invariance preserved)
-# = 3 × 1 × 3 × 2 = 18 cells.
-#
-# Selection rationale (K-1437 iter-2/iter-3 residual decomposition vs LIVE
-# oracle at K-1429 head 0fae3c3):
-#   * K-1429 P16 N=1024 K-COMPL FULL (29 cells, 2.23×) takes 10th position;
-#     remaining residuals ranked by (cell-count × geomean):
-#       - **N=512 BASE 18-cell, geomean 1.397×, score 23.7  ← P17 (this)**
-#       - N=256 BASE 18-cell mi300x, geomean 1.509×, score 27.2 — partial
-#         cross-arch failures (5/18 mi355x cells fail strict 1.05 gate);
-#         deferred pending mi355x carve-out per K-1410 follow-up.
-#       - square_mid 8192³ admit, 2 cells, 1.331× — too narrow for P17
-#         envelope; tracked as P18 candidate (K-1404 successor).
-#   * Mirrors K-1429 PR pattern: K-1429 closed N=1024 K-COMPL FULL in one
-#     step.  K-1437 P17 closes the N=512 BASE band (EXTREMES already
-#     shipped by K-1417 P15) — N=512 K-COMPL goes 12/30 → 30/30 closed.
-#
-# Convention note (resolved K-1437 iter-3 OQ-A):
-#   The bucket-rule frozenset enumeration is the K-1417 / K-1429 canonical
-#   form: include EVERY (M, N, K, dtype) tuple matching the bucket rule,
-#   excluding only those that fail the strict 1.05 admit gate per source
-#   measurement.  P5-overlap cells are NOT pre-subtracted from the
-#   frozenset — chain ordering at runtime ensures that an earlier
-#   predicate (e.g. P5 at chain pos 4) catches the cell first; the
-#   downstream P17 hit at pos 11 is structurally unreachable but
-#   set-theoretically correct.  This matches K-1417 P15 (which included
-#   no P5-overlap rows because EXTREMES K ∈ {2048, 32768} are entirely
-#   outside the P5 range) and K-1429 P16 (which included no P5-overlap
-#   rows because N=1024 is outside P5's sub-range).  K-1437 P17 includes
-#   exactly 1 P5-overlap cell (2048, 512, 4096, bf16) per K-1418 oracle
-#   JSON; included for arithmetic completeness, harmless at runtime.
-#
-# PMC mechanism (consistent with K-913 / K-1397 / K-1417 findings):
-#   At BASE K (4096-16384) the wrapper-overhead ceiling has dissipated
-#   (R-1367.WRAPPER-OVERHEAD-CEILING-DISAPPEARS-AT-LARGE-K) but the
-#   N=512 persistent_matmul tile aspect still accumulates LDS bank
-#   conflicts beyond the K-913 §3 floor.  hipBLASLt's split-K kernel
-#   re-selects to a pattern that better matches the M ∈ {2048, 4096, 8192}
-#   anchors — same mechanism as K-1417 EXTREMES at N=512 but with smaller
-#   per-cell margin (1.26×–1.65× vs EXTREMES 1.36×–14.06×) since the
-#   wrapper overhead is no longer a multiplier in the ratio.
-#
-# Verification (paired n=30 HIP-graph hot-cache, B=10000 vectorised paired
-# bootstrap CI95 on MI300X gfx942 / OCI MI300X fallback — c42 down):
-#   17/18 ROUTE-OUT (every cell ratio_median ≥ 1.05; 1 cell P5-pre-routed
-#                    via R_K979_P5_route_to_hbl at (2048,512,4096,bf16))
-#   cohort geomean tb/hbl = **1.397×** (K-1409 paired n=30, K-1418 #2)
-#   min ratio_median       = **1.244×** at (2048, 512, 4096, fp16)
-#   max ratio_median       = **1.644×** at (4096, 512, 16384, bf16)
-#   envelope grows         126 → 144 cells (10 → 11 predicate stack)
-#
-# Disjointness rationale (verified by frozenset.isdisjoint at module load):
-#   * P8 sub-frozensets — N != 512 in any P8 anchor.
-#   * K971_ROUTE_TABLE — M=N ∈ {1024, 2048}; no N=512.
-#   * K-1361 P12 — M=N=K ∈ {2048, 4096}; N != 512.
-#   * K-1367 P13 — N=128.
-#   * K-1397 P13 — N=256.
-#   * K-1417 P15 — N=512 EXTREMES K ∈ {2048, 32768}; this P17 covers
-#                  N=512 BASE K ∈ {4096, 8192, 16384}: NATURAL-DISJOINT
-#                  by K-axis partition (BASE ⨄ EXTREMES = full K-COMPL).
-#   * K-1429 P16 — N=1024.
-# All asserted at module load.
+# Closes the N=512 column-narrow K-COMPLEMENT region begun by P15 EXTREMES
+# (12 cells at K ∈ {2048, 32768}); together the two frozensets cover the
+# full 30-cell N=512 K-COMPLEMENT region at the K-1308 sweep grid (one
+# P5-pre-routed cell — (2048,512,4096,bf16) — is excluded from this
+# frozenset because R_K979_P5 catches it earlier in the chain at position
+# 4; that cell is pinned by tests to route via P5).  17/17 admit at the
+# strict 1.05 gate; cohort geomean tb/hbl = 1.40×, range 1.24×-1.64×
+# (paired n=30 HIP-graph hot-cache, B=10000 vectorised bootstrap CI95).
+# Mechanism: at BASE K the wrapper-overhead ceiling has dissipated
+# (R-1367) but the N=512 persistent_matmul tile aspect still accumulates
+# LDS bank conflicts beyond the K-913 §3 floor; hipBLASLt's split-K
+# kernel re-selects to a pattern better matched to M ∈ {2048, 4096, 8192}.
+# Disjointness vs prior P8/K971/P12/P13(N=128)/P13(N=256)/P15/P16
+# frozensets is asserted in tests/test_k1437_p17_skinny_n512_kcompl_base.py.
 # ---------------------------------------------------------------------------
-_K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18 = frozenset({
-    # M=2048 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
-    (2048, 512,  4096, "torch.bfloat16"),     # P5-overlap; included for
-                                              # frozenset-completeness, no harm
-                                              # (P5 fires at chain pos 4 < pos 11)
-    (2048, 512,  4096, "torch.float16"),      # r=1.244 ci_lo>=1.20
+_K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17 = frozenset({
+    # M=2048 row (K ∈ {4096, 8192, 16384} × {bf16, fp16}; (2048,512,4096,bf16)
+    # excluded — P5-pre-routed at chain pos 4)
+    (2048, 512,  4096, "torch.float16"),      # r=1.244
     (2048, 512,  8192, "torch.bfloat16"),     # r=1.474
     (2048, 512,  8192, "torch.float16"),      # r=1.395
     (2048, 512, 16384, "torch.bfloat16"),     # r=1.633
@@ -1681,92 +1620,26 @@ _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18 = frozenset({
     (8192, 512, 16384, "torch.bfloat16"),     # r=1.370
     (8192, 512, 16384, "torch.float16"),      # r=1.344
 })
-assert len(_K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18) == 18, (
-    "K-1437 P17 skinny_N512 K-COMPLEMENT BASE frozenset must be exactly 18 "
-    "cells (M ∈ {2048,4096,8192} × N=512 × K ∈ {4096,8192,16384} × {bf16,fp16}); "
-    "any deviation indicates an authoring typo against the K-1409 paired n=30 "
-    "BASE admit set (R-1437.SKINNY-N512-K-COMPLEMENT-BASE-CLOSES-N512-COLUMN).")
-# Cross-frozenset disjointness — K-1437 P17 vs prior 10-predicate stack.
-_K1437_P17_VS_P8_DISJOINT = (
-    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
-assert _K1437_P17_VS_P8_DISJOINT, (
-    "K-1437 P17 skinny_N512 BASE cell overlaps P8 envelope; P8 anchors use "
-    "N ∈ {128, 256} or M=N square — P17 uses N=512 non-square. "
-    "Natural disjointness, asserted insurance.")
-_K1437_P17_VS_K971_DISJOINT = (
-    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE))
-assert _K1437_P17_VS_K971_DISJOINT, (
-    "K-1437 P17 N=512 BASE cell overlaps K971_ROUTE_TABLE; K971 uses M=N ∈ "
-    "{1024, 2048}; P17 cells all use N=512 — natural disjointness.")
-_K1437_P17_VS_P12_DISJOINT = (
-    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
-assert _K1437_P17_VS_P12_DISJOINT, (
-    "K-1437 P17 N=512 BASE cell overlaps K-1361 P12; P12 cells M=N=K ∈ "
-    "{2048, 4096}; P17 uses N=512, natural disjointness.")
-_K1437_P17_VS_K1367_P13_DISJOINT = (
-    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
-        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18))
-assert _K1437_P17_VS_K1367_P13_DISJOINT, (
-    "K-1437 P17 N=512 BASE cell overlaps K-1367 P13 N=128; P13(N=128) cells "
-    "use N=128, P17 uses N=512 — natural disjointness (A4 sibling-N firewall).")
-_K1437_P17_VS_K1397_P13_DISJOINT = (
-    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
-        _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12))
-assert _K1437_P17_VS_K1397_P13_DISJOINT, (
-    "K-1437 P17 N=512 BASE cell overlaps K-1397 P13 N=256; P13(N=256) cells "
-    "use N=256, P17 uses N=512 — natural disjointness (A4 sibling-N firewall).")
-_K1437_P17_VS_K1409_P15_DISJOINT = (
-    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
-        _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT))
-assert _K1437_P17_VS_K1409_P15_DISJOINT, (
-    "K-1437 P17 N=512 BASE overlaps K-1417 P15 N=512 EXTREMES; "
-    "BASE K ∈ {4096, 8192, 16384} vs EXTREMES K ∈ {2048, 32768} — natural "
-    "K-axis disjointness, asserted (BASE ⨄ EXTREMES = full N=512 K-COMPL).")
-_K1437_P17_VS_K1429_P16_DISJOINT = (
-    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
-        _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29))
-assert _K1437_P17_VS_K1429_P16_DISJOINT, (
-    "K-1437 P17 N=512 BASE overlaps K-1429 P16 N=1024 FULL; "
-    "P17 uses N=512, P16 uses N=1024 — natural disjointness "
-    "(A4 sibling-N firewall).")
 
 
 def _k1437_p17_skinny_n512_kcompl_base_routeout(M: int, N: int, K: int, dtype) -> bool:
-    """K-1437 P17 — direct hipBLASLt route-OUT for the 18-cell skinny_N512
-    K-COMPLEMENT BASE-region cohort
-    (`_K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18`).
+    """P17 — direct hipBLASLt route-OUT for the 17-cell skinny_N512
+    K-COMPLEMENT BASE-band cohort.
 
-    Returns True iff (M, N, K, dtype) matches one of the 18 strict-equality
-    keys: M ∈ {2048, 4096, 8192} × N = 512 × K ∈ {4096, 8192, 16384} ×
-    dtype ∈ {torch.bfloat16, torch.float16}.  Completes the N=512 column-
-    narrow K-COMPLEMENT closure begun by K-1417 P15 EXTREMES (12 cells at
-    K ∈ {2048, 32768}); together the two frozensets partition the full
-    N=512 K-COMPLEMENT region at the K-1308 sweep grid.
+    Returns True iff (M, N, K, dtype) is a member of
+    ``_K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17``: M ∈ {2048, 4096,
+    8192} × N = 512 × K ∈ {4096, 8192, 16384} × dtype ∈ {bf16, fp16},
+    excluding (2048, 512, 4096, bf16) which is P5-routed at chain pos 4.
 
-    Source measurement: K-1409 paired n=30 HIP-graph hot-cache benchmarks
-    on MI300X / gfx942 (OCI MI300X fallback per
-    R-1409.OCI-AMD-ARAD-MI300X-IS-ESTABLISHED-FALLBACK; c42 down) with
-    B=10000 vectorised paired bootstrap CI95 (numpy advanced-indexing per
-    R-1298 / R-1367); 17/18 admit at strict 1.05 gate (1 P5-pre-routed cell
-    included for arithmetic completeness — chain pos 4 << pos 11), cohort
-    geomean tb/hbl = 1.397×, range 1.244×–1.644×.
-
-    Mechanism: at BASE K the wrapper-overhead ceiling has dissipated
-    (R-1367.WRAPPER-OVERHEAD-CEILING-DISAPPEARS-AT-LARGE-K) but the N=512
-    persistent_matmul tile aspect still accumulates LDS bank conflicts
-    beyond the K-913 §3 floor; hipBLASLt's split-K kernel re-selects to a
-    pattern that better matches the M ∈ {2048, 4096, 8192} anchors — same
-    mechanism as K-1417 EXTREMES at N=512 but with smaller per-cell margin
-    (1.24×–1.64× vs EXTREMES 1.36×–14.06×) since the wrapper overhead is
-    no longer a multiplier in the ratio.
-
-    Stacked at 11th-position per K-1175 stacked-predicate convention;
-    disjoint by construction with all P1–P16 sub-frozensets via the
-    cross-frozenset asserts above.
+    Source: paired n=30 HIP-graph hot-cache benchmarks on MI300X (gfx942)
+    with B=10000 vectorised paired bootstrap CI95.  17/17 admit at strict
+    1.05; cohort geomean tb/hbl = 1.40×, range 1.24×-1.64×.  Stacked at
+    11th-position per the K-1175 stacked-predicate convention; disjointness
+    vs prior P1-P16 sub-frozensets is exercised by the test suite.
     """
     return (
         (int(M), int(N), int(K), str(dtype))
-        in _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18
+        in _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17
     )
 
 
@@ -1794,7 +1667,7 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
       8. K-1397 P13 skinny_N256 K-COMPLEMENT 12-cell strict-equality -> hipBLASLt.
       9. K-1417 P15 skinny_N512 K-COMPLEMENT 12-cell strict-equality -> hipBLASLt.
      10. K-1429 P16 skinny_N1024 K-COMPLEMENT 29-cell strict-equality -> hipBLASLt.
-     11. K-1437 P17 skinny_N512 K-COMPLEMENT BASE 18-cell strict-equality -> hipBLASLt.
+     11. P17 skinny_N512 K-COMPLEMENT BASE 17-cell strict-equality -> hipBLASLt.
     """
     if disable_env_set:
         return False
@@ -1868,18 +1741,12 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # Envelope grows 97 → 126 cells.
     if _k1429_p16_skinny_n1024_routeout(int(M), int(N), int(K), a_dtype):
         return True
-    # K-1437 P17 (11th-position): skinny_N512 K-COMPLEMENT BASE 18-cell
-    # route-OUT.  Stacks AFTER K-1429 P16 per K-1175 stacked-predicate
-    # convention; closes the K-1417 P15 EXTREMES sibling at N=512 BASE
-    # band (K ∈ {4096, 8192, 16384}) — N=512 K-COMPLEMENT goes from
-    # 12/30 (40%, EXTREMES only) to 30/30 (100%, BASE ⨄ EXTREMES).
-    # Mechanism: at BASE K the wrapper-overhead ceiling has dissipated
-    # (R-1367.WRAPPER-OVERHEAD-CEILING-DISAPPEARS-AT-LARGE-K) but the
-    # N=512 persistent_matmul tile aspect still accumulates LDS bank
-    # conflicts beyond the K-913 §3 floor; hipBLASLt's split-K kernel
-    # re-selects to a pattern that better matches the M ∈ {2048, 4096,
-    # 8192} anchors.  Per-cell ratios 1.244×–1.644×; cohort geomean
-    # 1.397×; envelope grows 126 → 144 cells (10 → 11 predicate stack).
+    # P17 (11th-position): skinny_N512 K-COMPLEMENT BASE 17-cell route-OUT.
+    # Stacks AFTER P16 per the K-1175 stacked-predicate convention; closes
+    # the P15 N=512 EXTREMES sibling at the BASE K band (K ∈ {4096, 8192,
+    # 16384}) so N=512 K-COMPLEMENT goes from 12/30 (P15 EXTREMES only) to
+    # 29/30 (P15 ⨄ P17, with one P5-pre-routed cell shared).  Per-cell
+    # ratios 1.24×-1.64×; cohort geomean 1.40×.
     if _k1437_p17_skinny_n512_kcompl_base_routeout(int(M), int(N), int(K), a_dtype):
         return True
     return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -938,7 +938,7 @@ def _k1361_p12_square_mid_routeout(M: int, N: int, K: int, dtype) -> bool:
 # K-1367 (S-002) — P13 `skinny_N128` K-COMPLEMENT route-OUT (7th-position).
 #
 # K-1379 productionises the K-1367 RETRY-winning 18-cell cohort as
-# `_K1367_P13_SKINNY_N128_ROUTEOUT_18`, layered as the
+# `_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18`, layered as the
 # 7th-position envelope in the dispatch precedence chain on top of the
 # K-1361 P12 55-cell baseline (envelope grows 55 → 73 cells; +18 admits).
 #
@@ -1005,7 +1005,7 @@ def _k1361_p12_square_mid_routeout(M: int, N: int, K: int, dtype) -> bool:
 #   * K-1361 P12 — uses M=N=K ∈ {2048, 4096} with N != 128; no collision.
 # All asserted at module load.
 # ---------------------------------------------------------------------------
-_K1367_P13_SKINNY_N128_ROUTEOUT_18 = frozenset({
+_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 = frozenset({
     # M=2048 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
     (2048, 128,  4096, "torch.bfloat16"),
     (2048, 128,  4096, "torch.float16"),
@@ -1028,14 +1028,14 @@ _K1367_P13_SKINNY_N128_ROUTEOUT_18 = frozenset({
     (8192, 128, 16384, "torch.bfloat16"),
     (8192, 128, 16384, "torch.float16"),
 })
-assert len(_K1367_P13_SKINNY_N128_ROUTEOUT_18) == 18, (
+assert len(_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18) == 18, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT frozenset must be exactly 18 cells "
     "(M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,8192,16384} × {bf16,fp16}); "
     "any deviation indicates an authoring typo against the K-1308 bucket rule "
     "or the K-1227 wrapper-bound K-COMPLEMENT scoping.")
 # Cross-frozenset disjointness — P13 vs prior envelopes.
 _K1367_P13_VS_P8_DISJOINT = (
-    _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
 assert _K1367_P13_VS_P8_DISJOINT, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps the K-1322 51-cell P8 "
     "envelope; P8's K-1205 N=128 sub-frozenset uses K ∈ {2048, 8192} with "
@@ -1044,14 +1044,14 @@ assert _K1367_P13_VS_P8_DISJOINT, (
     "tuples must be enumerated to overlap; disjointness verified by frozenset "
     "intersection at module load).")
 _K1367_P13_VS_K971_DISJOINT = (
-    _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE))
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE))
 assert _K1367_P13_VS_K971_DISJOINT, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps K971_ROUTE_TABLE; "
     "K971_ROUTE_TABLE (K-905/K-971 + K-1335) uses M=N ∈ {1024, 2048}; "
     "P13 cells all use N=128 — natural disjointness, but assert as cheap "
     "insurance per R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.")
 _K1367_P13_VS_P12_DISJOINT = (
-    _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
 assert _K1367_P13_VS_P12_DISJOINT, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps K-1361 P12 square_mid; "
     "P12 cells use M=N=K ∈ {2048, 4096}; P13 cells all use N=128 — natural "
@@ -1060,7 +1060,7 @@ assert _K1367_P13_VS_P12_DISJOINT, (
 
 def _k1367_p13_skinny_n128_routeout(M: int, N: int, K: int, dtype) -> bool:
     """K-1367 P13 — direct hipBLASLt route-OUT for the 18-cell skinny_N128
-    K-COMPLEMENT cohort (`_K1367_P13_SKINNY_N128_ROUTEOUT_18`).
+    K-COMPLEMENT cohort (`_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18`).
 
     Returns True iff (M, N, K, dtype) matches one of the 18 strict-equality
     keys: M ∈ {2048, 4096, 8192} × N = 128 × K ∈ {4096, 8192, 16384} ×
@@ -1080,7 +1080,7 @@ def _k1367_p13_skinny_n128_routeout(M: int, N: int, K: int, dtype) -> bool:
     """
     return (
         (int(M), int(N), int(K), str(dtype))
-        in _K1367_P13_SKINNY_N128_ROUTEOUT_18
+        in _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18
     )
 
 

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1219,7 +1219,7 @@ def _k1397_p13_skinny_n256_routeout(M: int, N: int, K: int, dtype) -> bool:
 # (9th-position).
 #
 # K-1417 productionises the K-1409-derived 12-cell `skinny_N512` K-COMPLEMENT
-# EXTENSION cohort as `_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12`, layered
+# EXTENSION cohort as `_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT`, layered
 # as the 9th-position envelope in the dispatch precedence chain on top of
 # the K-1406 P14 8-predicate baseline (envelope grows by +12 admits at the
 # K-axis EXTREMES of the N=512 column-narrow regime).
@@ -1275,7 +1275,7 @@ def _k1397_p13_skinny_n256_routeout(M: int, N: int, K: int, dtype) -> bool:
 #   * K-1397 P13 — uses N=256.
 # All asserted at module load.
 # ---------------------------------------------------------------------------
-_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12 = frozenset({
+_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT = frozenset({
     # M=2048 row × K ∈ {2048, 32768} × {bf16, fp16}
     (2048, 512,  2048, "torch.bfloat16"),
     (2048, 512,  2048, "torch.float16"),
@@ -1292,41 +1292,41 @@ _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12 = frozenset({
     (8192, 512, 32768, "torch.bfloat16"),
     (8192, 512, 32768, "torch.float16"),
 })
-assert len(_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12) == 12, (
+assert len(_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT) == 12, (
     "K-1417 P15 skinny_N512 K-COMPLEMENT EXTENSION frozenset must be exactly "
     "12 cells (M ∈ {2048,4096,8192} × N=512 × K ∈ {2048,32768} × {bf16,fp16}); "
     "any deviation indicates an authoring typo against the K-1397 K-COMPLEMENT "
     "EXTREMES scoping at N=512 (R-1417.SKINNY-N512-K-COMPLEMENT-EXTENSION-IS-EXTREMES).")
 # Cross-frozenset disjointness — K-1417 P15 vs prior 8-predicate stack.
 _K1409_P15_VS_P8_DISJOINT = (
-    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
 assert _K1409_P15_VS_P8_DISJOINT, (
     "K-1417 P15 skinny_N512 K-COMPLEMENT EXTENSION cell overlaps the K-1322 "
     "51-cell P8 envelope; P8's K-1219 E3 N=256 sub-frozenset uses N=256 — "
     "P15 uses N=512, natural disjointness, asserted as cheap insurance per "
     "R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.")
 _K1409_P15_VS_K971_DISJOINT = (
-    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12.isdisjoint(K971_ROUTE_TABLE))
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT.isdisjoint(K971_ROUTE_TABLE))
 assert _K1409_P15_VS_K971_DISJOINT, (
     "K-1417 P15 skinny_N512 K-COMPLEMENT EXTENSION cell overlaps "
     "K971_ROUTE_TABLE; K971_ROUTE_TABLE (K-905/K-971 + K-1335) uses M=N ∈ "
     "{1024, 2048}; P15 cells all use N=512 — natural disjointness, asserted "
     "insurance.")
 _K1409_P15_VS_P12_DISJOINT = (
-    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
 assert _K1409_P15_VS_P12_DISJOINT, (
     "K-1417 P15 skinny_N512 K-COMPLEMENT EXTENSION cell overlaps K-1361 P12 "
     "square_mid; P12 cells use M=N=K ∈ {2048, 4096}; P15 cells all use N=512 "
     "— natural disjointness, asserted for completeness (A4 no-double-admit).")
 _K1409_P15_VS_K1367_P13_DISJOINT = (
-    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12.isdisjoint(
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT.isdisjoint(
         _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18))
 assert _K1409_P15_VS_K1367_P13_DISJOINT, (
     "K-1417 P15 skinny_N512 cell overlaps K-1367 P13 skinny_N128; P13(N=128) "
     "cells use N=128, P15 cells use N=512 — natural disjointness, asserted "
     "for completeness (A4 sibling-N firewall).")
 _K1409_P15_VS_K1397_P13_DISJOINT = (
-    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12.isdisjoint(
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT.isdisjoint(
         _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12))
 assert _K1409_P15_VS_K1397_P13_DISJOINT, (
     "K-1417 P15 skinny_N512 cell overlaps K-1397 P13 skinny_N256; P13(N=256) "
@@ -1338,7 +1338,7 @@ assert _K1409_P15_VS_K1397_P13_DISJOINT, (
 
 def _k1409_p15_skinny_n512_routeout(M: int, N: int, K: int, dtype) -> bool:
     """K-1417 P15 — direct hipBLASLt route-OUT for the 12-cell skinny_N512
-    K-COMPLEMENT EXTENSION cohort (`_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12`).
+    K-COMPLEMENT EXTENSION cohort (`_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT`).
 
     Returns True iff (M, N, K, dtype) matches one of the 12 strict-equality
     keys: M ∈ {2048, 4096, 8192} × N = 512 × K ∈ {2048, 32768} ×
@@ -1362,7 +1362,7 @@ def _k1409_p15_skinny_n512_routeout(M: int, N: int, K: int, dtype) -> bool:
     """
     return (
         (int(M), int(N), int(K), str(dtype))
-        in _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12
+        in _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT
     )
 
 

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -3490,3 +3490,19 @@ _P37_SKINNY_N352_KCOMPL_VERIFIED_WIN_18 = frozenset({
 })
 # Cardinality (==18) gated by tests/test_p37_skinny_n352_alias_stack.py per the
 # minimalist split: src holds data, tests hold invariants.
+
+# P38 (29th-slot): K-1857 N=384 K-COMPLEMENT verified-winner subset — 14 cells
+# (18-cell M×K cohort minus 4 K-1748 P30 N-mid overlap cells at K=8192,
+# M ∈ {2048,4096}).  K-1857 paired n=30 HIP-graph + 3-pass rocprofv2 PMC on
+# MI300X / gfx942: 18/18 measured cells admit at strict ratio≥1.05 ∧ p<0.05;
+# per-N geomean=1.283× (range 1.135×–1.555×).  N=384 = 1.5 × BN=256 → tail
+# half-wave leaves 50% MFMA lanes idle; SQ_LDS_BANK_CONFLICT TB nonzero in
+# all 18 / HBL ZERO in all 18; SCHEDULER_LDS A4 fingerprint per K-1843/K-1853.
+_P38_SKINNY_N384_KCOMPL_VERIFIED_WIN_14 = frozenset(
+    (M, 384, K, dt) for M in (2048, 4096, 8192) for K in (4096, 8192, 16384)
+    for dt in ("torch.bfloat16", "torch.float16")
+) - frozenset({
+    (2048, 384, 8192, "torch.bfloat16"), (2048, 384, 8192, "torch.float16"),
+    (4096, 384, 8192, "torch.bfloat16"), (4096, 384, 8192, "torch.float16"),
+})
+# Cardinality (==14) gated by tests/test_p38_skinny_n384_alias_stack.py.

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -3239,3 +3239,21 @@ _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34 = frozenset(
 )
 # Cardinality (==34) gated by tests/test_k1748_p30_skinny_nmid_alias_stack.py per
 # the minimalist split: src holds data, tests hold invariants (R-1532 / R-1720).
+
+# P31 (22nd-slot): N=256 K-COMPLEMENT verified-winner subset — 28 cells (the
+# 30-cell M ∈ {2048,4096,8192} × N=256 × K ∈ {2048,4096,8192,16384,32768} ×
+# {bf16,fp16} cohort minus 2 paired-n30 LOSER cells at (M=2048, K=2048): TB-native
+# beats hipBLASLt by 2% in bfloat16 (HBL/TB=0.98) and ties in float16 (HBL/TB=1.02,
+# p=0.79 — fails the strict ≥1.05 ∧ p<0.05 gate).
+# 28-cell winner subset paired n=30 hot-cache HIP-graph TB-native-vs-HBL on MI300X
+# (route-OUT ablated): geomean HBL/TB = 1.392×, range 1.07×–2.12×, 28/28 pass the
+# ≥1.05 ∧ p<0.05 gate; full-cohort geomean (all 30) = 1.359×, 28/30 pass the gate.
+_P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28 = frozenset(
+    (M, 256, K, dt) for M in (2048, 4096, 8192)
+    for K in (2048, 4096, 8192, 16384, 32768) for dt in ("torch.bfloat16", "torch.float16")
+) - frozenset({
+    (2048, 256, 2048, "torch.bfloat16"),
+    (2048, 256, 2048, "torch.float16"),
+})
+# Cardinality (==28) gated by tests/test_p31_skinny_n256_alias_stack.py per the
+# minimalist split: src holds data, tests hold invariants.

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1,0 +1,1150 @@
+"""K-1003 R-K979 P5 Gate-0 admission predicate (torch-free).
+
+Hosts the closed-form structural-pathology predicate plus the K-905/K-971
+mid-square long-K strict-equality anchors. Imported by ``matmul.py`` for the
+runtime dispatch; importable on its own (no torch / triton chain) so unit
+and integration tests can exercise it without booting a GPU stack.
+
+The predicate keys solely on ``(M, N, K, dtype)`` where ``dtype`` is matched by
+``str(dtype) == "torch.bfloat16"``; any object whose ``str()`` repr is
+``"torch.bfloat16"`` (i.e. ``torch.bfloat16`` itself, or the literal string
+``"torch.bfloat16"`` used in tests) selects the bf16 path.
+"""
+from __future__ import annotations
+
+import os
+
+# fp16 K-905/K-971 anchors stay as exact-tuple lookups because their shapes
+# structurally collide with K-950 LAND cells (e.g. (1024,1024,16384,bf16) is
+# both a K-912 LAND and a K-905 route-OUT — only an exact tuple can express
+# "fire on this exact shape but not on its baseline-LAND twin").
+_K905_K971_LDS_BC_ANCHORS_8 = frozenset({
+    (1024, 1024, 16384, "torch.bfloat16"),  # K-905 baseline
+    (1024, 1024, 16384, "torch.float16"),
+    (1024, 1024, 32768, "torch.bfloat16"),  # K-971 (K-905 N4: hbl/off=1.73x)
+    (1024, 1024, 32768, "torch.float16"),
+    (2048, 2048, 16384, "torch.bfloat16"),  # K-971 (K-905 N2: hbl/off=1.37x)
+    (2048, 2048, 16384, "torch.float16"),
+    (2048, 2048, 32768, "torch.bfloat16"),  # K-971 (K-905 N5: hbl/off=1.38x)
+    (2048, 2048, 32768, "torch.float16"),
+})
+
+# ---------------------------------------------------------------------------
+# K-1335 / K-1326 (S-002) — longK_smallSquare bf16 route-OUT extension
+# (the 5th-position dispatch predicate; K971_ROUTE_TABLE).
+#
+# K-1335 productionizes K-1326's `P9_longK_smallSquare_routeOUT` proposal as
+# a 4-cell strict-equality extension to the K-905/K-971 LDS-bank-conflict
+# (LDS-BC) anchor family.  Cells were identified by K-1308's per-shape
+# residual decomposition of the K-1322 51-cell P8 envelope sweep:
+# `longK_smallSquare` (M=N∈{1024, 2048}, K∈{4096, 8192}, bf16; 4 cells,
+# residual mean 0.695, aggregate gap 2.779) is the worst residual bucket
+# AND zero admit predicate fires on any of these cells (any-pred-fired = N
+# for the bucket).  K-1326 then attributed the bottleneck via PMC features
+# carried over from the K-913 baseline triage:
+#
+#   LDS_BC      1.78 cyc/inst  (vs 0.00 on hbl baseline)
+#   MFMA%       9.33%          (vs 15.85% on hbl baseline)
+#   SQ_INSTS_LDS  4.00x inflated vs hbl
+#
+# This is the same LDS-bank-conflict fingerprint as K-905 / K-930 / K-971
+# (mechanism-shape-invariant per K-913 §3, ±19% across the 4-cell
+# neighborhood) — NOT the K-1144 P8 MFMA-issue-stall pathology (different
+# counter signature).  Per R-1329.MECHANISTIC-DISAMBIGUATION-OF-PREDICATE-
+# ATTACHMENT-POINT, the attachment site must match the mechanism, so the 4
+# K-1335 admits attach to the K-905/K-971 LDS-BC envelope (the 5th-position
+# dispatch predicate `K971_ROUTE_TABLE`), NOT to the K-1322 51-cell P8
+# `_P8_MFMA_ISSUE_STALL_ROUTEOUT` envelope.  The K-1322 P8 envelope and its
+# 6 named sub-frozensets remain byte-identical; the dispatch ladder
+# precedence is unchanged.
+#
+# The autotune in-kernel path has converged on a single config that is
+# structurally LDS-bank-conflict-bound — K-1308's cross-branch ratio
+# invariant (4-pred ratio == main ratio within paired-n30 ±3% CV) holds
+# on these 4 cells, ruling out any (BM, BN, BK, WPEU, NS, NW) catalog
+# perturbation that could close the gap.  Route-OUT is the only remaining
+# mechanism (R-1329.CROSS-BRANCH-RATIO-INVARIANT-IMPLIES-ROUTE-OUT-ONLY).
+#
+# Verification (paired n=30 HIP-graph hot-cache, B=10000 paired bootstrap,
+# MI300X / gfx942 dedicated, 4 admit cells + 4 K-axis-neighbor controls):
+#   - 4-cell admit-set geomean: ~1.30x route-OUT win (CI95 strictly > 1.0)
+#   - 4-cell neighbor controls: no significant regression (CI95-hi >= 0)
+# Per R-1329.ADMIT-ON-DEDICATED-GPU-NOT-COTENANT, paired n=30 selection
+# uses dedicated-GPU measurement; co-tenant measurements admissible only
+# as the regression-firewall lower bound.
+#
+# Disjointness (K-axis projection per R-1329.K-AXIS-PROJECTION-DISJOINTNESS-
+# ASSERTS-ARE-CHEAP-INSURANCE): K-1335 K∈{4096, 8192}; K-905/K-971
+# K∈{16384, 32768} — natural K-axis separator, asserted at module load.
+# bf16-only by design (K-913 anchor + K-1326 bucket are bf16; fp16 parity
+# tracked separately on the K-1093 / K-1125 line).
+# ---------------------------------------------------------------------------
+_K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4 = frozenset({
+    (1024, 1024,  4096, "torch.bfloat16"),  # K-1326 A1; K-913 PMC anchor neighborhood (LDS_BC 1.78 cyc/inst)
+    (1024, 1024,  8192, "torch.bfloat16"),  # K-1326 A2; K-913 PMC anchor (1024,1024,8192) bf16
+    (2048, 2048,  4096, "torch.bfloat16"),  # K-1326 A3; same LDS-BC fingerprint per K-913 §3 ±19%
+    (2048, 2048,  8192, "torch.bfloat16"),  # K-1326 A4; same LDS-BC fingerprint per K-913 §3 ±19%
+})
+
+# Composed K-905/K-971/K-1335 LDS-BC route-OUT table (the 5th-position
+# dispatch predicate).  Two named provenance frozensets; consulted as a
+# strict-equality union by `_k971_route_to_hbl` after P8 / E1 / P6 / P5.
+# Per R-1144.DUAL-FROZENSET-PROVENANCE (lifted to the LDS-BC envelope per
+# R-1329.MECHANISTIC-DISAMBIGUATION-OF-PREDICATE-ATTACHMENT-POINT), each
+# measurement campaign keeps its own named set with a runtime cardinality
+# pin and a K-axis-projection disjointness assert.
+K971_ROUTE_TABLE = (
+    _K905_K971_LDS_BC_ANCHORS_8
+    | _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4
+)
+assert len(K971_ROUTE_TABLE) == 12, (
+    "K-1335 unified LDS-BC route-OUT table must be exactly 12 cells "
+    "(8 K-905/K-971 anchors + 4 K-1335 longK_smallSquare admits); a "
+    "duplicate or stray entry has crept in.")
+assert len(_K905_K971_LDS_BC_ANCHORS_8) == 8
+assert len(_K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4) == 4
+# K-axis-projection disjointness: K-1335 K∈{4096, 8192}; K-905/K-971
+# K∈{16384, 32768}.  Cheap module-load-time assert per R-1329.K-AXIS-
+# PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.
+assert _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4.isdisjoint(
+    _K905_K971_LDS_BC_ANCHORS_8), (
+    "K-1335 longK_smallSquare admits overlap K-905/K-971 LDS-BC anchors; "
+    "K-axis-projection disjointness (K-1335 K∈{4096, 8192} vs K-905/K-971 "
+    "K∈{16384, 32768}) is the structural separator and a violation "
+    "indicates an authoring typo in one of the two frozensets.")
+
+
+def _dtype_is_bf16(dtype) -> bool:
+    """Match torch.bfloat16 without importing torch.
+
+    Both the ``torch.bfloat16`` singleton and the literal string
+    ``"torch.bfloat16"`` (used by tests) pass; anything else fails.
+    """
+    return str(dtype) == "torch.bfloat16"
+
+
+def R_K979_P5_route_to_hbl(M: int, N: int, K: int, dtype) -> bool:
+    """R-K979 v3 / P5 — closed-form 4-clause structural pathology predicate.
+
+    Returns True when shape (M, N, K, dtype) sits in the NO-LAND-for-Triton-
+    override regime (i.e. tritonblas should route to hipBLASLt). Translates
+    P5's PMC predicate into structural (M, N, K, dtype) proxies:
+
+      Clause-1 (over-tile / LDS-bound mid-rect):
+          mid-rect non-square with K in the [1240, 8064] LDS-pressure band
+          and one axis pinned to the {1792, 2048, 3072} LDS-bound family.
+      Clause-2 (hbl-strong / LMhead projection):
+          large-M skinny  M >= 5000, N == 2048, K in {256, 1024}.
+      Clause-3 (tb-weak / extreme aspect or tiny):
+          aspect ratio max(M,N)/min(M,N) >= 100, or min(M,N) <= 192 AND
+          K >= 2048 (waves under-utilised on the small axis).
+      Clause-4 (over-tile dual / N=1792 shallow-K):
+          N == 1792 and 512 <= K <= 768 (K-1062 raised the K floor from
+          0 to 512 = 8*BK64 to silence the K=256 false-positive surfaced
+          by the K-1017 PMC sweep and confirmed by the K-1043 per-clause
+          confusion matrix; S07=(2048,1792,256,bf16) gap_x=1.044 is
+          inside the per-engine ~5% CV noise floor — routing buys a
+          measured-zero-gain dispatch detour), with M either large-
+          skinny (>= 5000) or in the K-984/K-989 mid-rect band
+          [256, 2048].  K-984/K-989 anchors S06 (K=736) and S18 (K=768)
+          both have K >= 736 so neither is regressed.
+
+    bf16-only: K-984/K-989 ship cohort and K-931 measurement scope are bf16;
+    fp16 K-905/K-971 anchors stay in :data:`K971_ROUTE_TABLE`.
+
+    Verification (K-1003):
+      - K-984+K-989 union (14 unique shapes): 14/14 FIRE
+      - K-950 LAND set (9 cells): 0/9 FIRE (zero leakage)
+      - K-931 top-40: 29/40 FIRE (15 net beyond strict-equality)
+    """
+    if not _dtype_is_bf16(dtype):
+        return False
+    minMN = min(M, N)
+    maxMN = max(M, N)
+    # Clause-1: over-tile, LDS-bound, mid-rect non-square with mid-band K.
+    if (minMN < maxMN
+            and 256 <= minMN <= 2304
+            and 1792 <= maxMN <= 3072
+            and 1240 <= K <= 8064):
+        return True
+    # Clause-2: hbl-strong LMhead-style large-M skinny.
+    if M >= 5000 and N == 2048 and K in (256, 1024):
+        return True
+    # Clause-3: tb-weak — extreme aspect or skinny-and-long-K.
+    if maxMN >= 100 * max(1, minMN):
+        return True
+    if minMN <= 192 and K >= 2048:
+        return True
+    # Clause-4: N=1792 shallow-K dual of clause-1.  K-1062 K-floor=512
+    # (8*BK64) — see docstring; closes the K=256 S07 false positive
+    # without affecting the K=736 / K=768 K-984+K-989 anchors.
+    if N == 1792 and 512 <= K <= 768 and (M >= 5000 or 256 <= M <= 2048):
+        return True
+    return False
+
+
+# K-1109 (S-002) brief deliverable (1): explicit shape-key allowlist for
+# the K-1074 MFMA-issue-stall candidate cells (originally 8 cells: S26,
+# S31-S35, S37, S39).  Brief asked for "minimal diff (<30 LOC) gated behind
+# explicit shape-key allowlist initially, with strict-equality fallback for
+# the validated 8-cell set as a safety net".
+#
+# Gated by env var (default OFF) because the only paired n=30 round-robin
+# timing on c42/MI300X available at PR time (k1109_k1074_timing.json,
+# derived from K-1074/output/rr_summary.csv) showed 0/8 cells clear the
+# K-901 +2% LAND margin.  Set TRITONBLAS_K1109_P6_ALLOWLIST=1 in the
+# runtime env to enable for further validation.
+#
+# REGRESSION CARVE-OUT (per K-1109 reviewer consensus, 4/4 REVISE votes):
+# Two of the original 8 cells — S32 (20352,2048,1024) and S37
+# (25600,2048,256) — are CI95-confirmed REGRESSIONS in the same n=30 paired
+# timing (S32: mean -0.51%, CI95 [-0.872, -0.148]; S37: mean -0.68%, CI95
+# [-1.129, -0.232]).  Shipping a "safety net" allowlist that admits known-
+# regressing cells, even default-OFF, is a hazard not a safety net — the
+# gate exists precisely so operators can flip it on without a code change,
+# so the contents must never include cells where paired evidence already
+# proves harm.  S32 and S37 are therefore EXCLUDED.  The
+# K1074_REGRESSION_CARVE_OUT_PINS test in tests/test_k971_route_predicate.py
+# documents this with the exact CI95 numbers so any silent re-add of those
+# cells fails CI loudly.
+#
+# Pin tests exercise both gate states so any change to the allowlist or
+# gate semantics surfaces in CI.
+_K1109_P6_K1074_ALLOWLIST = frozenset({
+    ( 8064, 2048, 1024, "torch.bfloat16"),  # S26  mean +0.51%, CI95 [+0.13,+0.88]
+    (18304, 2048, 1024, "torch.bfloat16"),  # S31  mean -2.96%, CI95 [-7.06,+1.14]  (overlaps zero)
+    (22400, 2048, 1024, "torch.bfloat16"),  # S33  mean +1.34%, CI95 [-0.06,+2.75]
+    (24448, 2048, 1024, "torch.bfloat16"),  # S34  mean +0.65%, CI95 [+0.47,+0.83]
+    (26496, 2048, 1024, "torch.bfloat16"),  # S35  mean +0.77%, CI95 [-0.15,+1.69]
+    (49152, 2048,  256, "torch.bfloat16"),  # S39  mean +0.24%, CI95 [-0.18,+0.66]
+    # EXCLUDED — CI95-confirmed regressions in K-1074 paired n=30 timing:
+    #   S32 (20352,2048,1024): mean -0.51%, CI95 [-0.872, -0.148]
+    #   S37 (25600,2048, 256): mean -0.68%, CI95 [-1.129, -0.232]
+})
+_K1109_P6_ALLOWLIST_ENV = "TRITONBLAS_K1109_P6_ALLOWLIST"
+
+# Pinned regression evidence for the two cells excluded from the allowlist.
+# Re-adding either cell to _K1109_P6_K1074_ALLOWLIST without first refuting
+# this evidence will fail the K1074_REGRESSION_CARVE_OUT_PINS test.
+_K1109_P6_K1074_REGRESSION_EXCLUSIONS = frozenset({
+    (20352, 2048, 1024, "torch.bfloat16"),  # S32
+    (25600, 2048,  256, "torch.bfloat16"),  # S37
+})
+
+
+def _k1109_p6_allowlist_admit(M: int, N: int, K: int, dtype) -> bool:
+    """K-1109 brief deliverable (1) — strict-equality safety-net allowlist.
+
+    Returns True iff the env gate is set AND (M, N, K, dtype) is one of the
+    6 K-1074 MFMA-issue-stall candidate cells whose paired n=30 timing did
+    NOT fall entirely below the zero line (S32 and S37 carved out per
+    reviewer consensus — see comment block above the allowlist). Default-OFF;
+    see module-level docstring above the allowlist for the rationale.
+    """
+    if os.environ.get(_K1109_P6_ALLOWLIST_ENV) != "1":
+        return False
+    return (int(M), int(N), int(K), str(dtype)) in _K1109_P6_K1074_ALLOWLIST
+
+
+def R_K1037_P6_admit_wpeu1(M: int, N: int, K: int, dtype) -> bool:
+    """K-1089 — Structural surrogate of K-1037 P6 MFMA-issue-stall classifier.
+
+    Returns True iff the (M, N, K, dtype) shape's structural fingerprint
+    matches K-1037's paired-PMC P6 admit condition
+
+        waves_per_CU_ratio (tb/hbl) < 1.70x
+        AND MFMA_pct_tb >= 1.0%
+        AND LDS_BC_cyc_per_inst_tb < 1.5
+
+    K-1037 verified perfect 18/18 agreement of the 3-clause PMC predicate
+    against K-1017's `route_action_table.csv` (TP=2/2 on S24, S29; TN=16/16
+    on the remaining 15 occupancy + 1 HBM-L2-stall cells). K-1051 separately
+    confirmed via 4-iter PMC research that wpeu=1 wins are predictable from
+    2-3 counter clauses on K-1032 cells.
+
+    K-1037's P6 reads paired runtime PMC (`pmc_view.tb` AND `pmc_view.hbl`)
+    so it cannot run in a hot dispatch path (R-1037.A-PRIORI-PMC-CLASSIFIERS-
+    LAND-AS-OFFLINE-CLASSIFIED-SHAPE-TABLES-NOT-LIVE-PMC-PREDICATES). This
+    function regresses each PMC clause onto structural shape features so the
+    same admit decision can be taken at dispatch time on the four fields
+    (M, N, K, dtype) available without instrumentation.
+
+    Surrogate-C2 (MFMA_pct_tb >= 1.0%):
+        Translated to K >= 512. K-1037 P6 positives have MFMA% in
+        [3.79, 4.79]; K-1017 cell S38 (K=200, MFMA%=0.07) is the only
+        false-positive risk and is excluded by this floor.
+    Surrogate-C3 (LDS_BC_cpi_tb < 1.5):
+        Translated to "not in P5 LDS-bound regime". Composition: caller
+        consults R_K979_P5_route_to_hbl first; this admit only fires on
+        shapes NOT already silenced by P5 clauses 1+3 (LDS-port-contention
+        and asymmetric-aspect axes).
+    Surrogate-C1 (waves_per_CU_ratio < 1.70x — load-bearing):
+        Two regression envelopes drawn from K-1017 + K-1032 + K-1044
+        paired-PMC corpus:
+
+        Envelope A (S29 wide-rect family):
+            N == 2048 AND K == 1024 AND 13000 <= M <= 14999.
+            Catches S29 (M=14208, ratio=1.51) only. Bounded above by S30
+            (M=16256, ratio=1.75 — OCC) and below by K-984/K-989 LAND
+            anchors S25 (M=6016), S27 (M=10112), S28 (M=12160) which all
+            route-OUT cleanly under the existing P5 Clause-2 and gain
+            5.31x-5.63x speedup; tightening to M>=13000 preserves those
+            anchors while admitting only the K-1037-verified positive.
+            (K-1044 B3b=(6016, 2048, 1024) collides with S25 anchor — it
+            stays route-OUT under K-989's strict-equality table; the
+            streamk-LAND verdict K-1044 reports is orthogonal to wpeu=1.)
+        Envelope B (S24 + K-1044 B3a moderate-square mid-K family):
+            minMN >= 2048 AND maxMN <= 4500 AND 512 <= K <= 1024.
+            Catches S24 (4480, 3072, 768) (ratio=1.53). Bounded above by
+            maxMN<=4500 to preserve K-984/K-989 LAND anchors (S18 maxMN=5972
+            and S25 maxMN=6016 sit clear above).
+
+    bf16-only by design (K-1037 / K-1017 / K-1044 ground truth scope).
+
+    Composition with K-1062-style hardening: like P5 Clause-4's K-floor=512
+    architectural bound, both envelopes are bounded BELOW by floors tied to
+    the calibration set's lowest M/K positives. The ROUTE_OUT_HBL effect
+    is delegated upstream to caller (matmul.py); this function only reports
+    the structural P6 admit verdict.
+
+    Calibration verification on K-1017 18-cell set:
+        S24 -> True   (P6 positive, ratio=1.532)        ENVELOPE B
+        S29 -> True   (P6 positive, ratio=1.514)        ENVELOPE A
+        all 16 negatives -> False                       neither envelope
+
+    K-1031 NO-LAND set (K-1017 cells where P5 does not fire) regression:
+        S07 (2048, 1792, 256)  -> False (K=256<512 / N=1792)
+        S16 (256, 256, 2048)   -> False (minMN=256<2048)
+        S38 (384, 128, 200)    -> False (K=200<512)
+
+    K-1104 NULL-RESULT (do not relax these envelopes):
+        K-1098 4-iteration RESEARCH (primary-source-verified) showed that
+        the 8 K-1074 candidate cells (S26, S31, S32, S33, S34, S35, S37,
+        S39) fire P6 on **0/8** under K-1037's paired-PMC classifier --
+        all 8 fail load-bearing C1 with waves_per_CU_ratio (tb/hbl) in
+        [1.753, 2.740]. The K-1074 paired n=30 round-robin on c42/MI300X
+        confirmed: 0/8 cells clear the K-901 +2% LAND margin under wpeu=1,
+        2/8 (S32, S37) are confirmed regressions (CI95 hi < 0), cohort
+        geomean ~= 1.000x. P5 Clause-2 already routes the K=1024 family
+        OUT to hipBLASLt with 2.6x-3.1x measured speedup on K-989 anchors
+        (S25, S27, S28), which is the structurally-correct production
+        behaviour for those cells.
+
+        Hard separation wall blocks any C1 relaxation: K-1037 NEG cell
+        S30 (M=16256, waves_ratio=1.7530) and K-1074 candidate S34
+        (M=24448, waves_ratio=1.7530) collide exactly on C1, so no cutoff
+        in the (1.5320, 1.7530) feasibility band can admit S34 without
+        producing a false-positive on S30.
+
+        Envelope A's M-band [13000, 14999] is therefore architecturally
+        bounded -- the upper bound (14999) sits below S30's M=16256, and
+        the lower bound (13000) sits above K-984/K-989 LAND anchors
+        S25/S27/S28 (M in {6016, 10112, 12160}) which carry verified
+        2.6x-3.1x P5 Clause-2 routing speedup.
+
+        References: K-1098 backtest (output/p6_clause_by_clause_k1074.csv),
+        K-1074 paired n=30 (rr_summary.csv), K-1049/K-1055/K-1062 adversarial
+        gate (FAIL: zero NEW NO-LAND-leak gain).
+
+    K-1109 reproduction (productionizes the K-1066 lock-the-envelope pattern):
+        Independently re-derived K-1037 P6 from the primary-source paired-
+        PMC CSV for all 8 K-1074 cohort-extension cells + the 4 K-1044
+        anchor cells called out in the K-1109 brief + 8 K-1017 held-out
+        OCC/HBM negatives.  Result: 0/8 K-1074 FIRE (brief premise of 8/8
+        FALSIFIED), 2/2 K-1037 P6 positives still FIRE (S24, S29), 0/8
+        K-1017 NEG false positives, S30/S34 C1 collinearity wall confirmed
+        at waves_ratio=1.7530.  K-1044 B3a (S18, 5972,1792,768) and B3b
+        (S25, 6016,2048,1024) fire exact PMC P6 but the surrogate's
+        Envelope-A M>=13000 floor and Envelope-B minMN>=2048 floor
+        correctly preserve them as K-989 LAND anchors (5.31x-5.63x
+        routing speedup).  Envelopes A and B are LOCKED -- pin tests in
+        tests/test_k971_route_predicate.py (P6_NEGATIVES_K1074,
+        P6_NEGATIVES_K1044_ANCHORS, test_p6_c1_collinearity_wall_*)
+        gate any future relaxation through CI.
+
+        Reproduction artifact: /home/ryaswann/mc2-workspaces/K-1109/output/
+        k1109_p6_audit.csv (re-derivable via scripts/k1109_p6_verification.py).
+    """
+    if not _dtype_is_bf16(dtype):
+        return False
+    # K-1109 brief deliverable (1): strict-equality safety-net allowlist
+    # (env-gated, default OFF). Consulted FIRST so it can admit cells that
+    # the structural envelopes reject (the K-1074 cohort fails C1 by design,
+    # so it would never fire through the envelope path below).
+    if _k1109_p6_allowlist_admit(M, N, K, dtype):
+        return True
+    if K < 512:
+        return False  # Surrogate-C2: insufficient MFMA work density
+    minMN, maxMN = min(M, N), max(M, N)
+    # Envelope A: K-931 wide-rect (N=2048, K=1024) family at moderate M.
+    # K-1017 paired ratios: S26 M=8064 (2.03x — OCC), S29 M=14208 (1.51x —
+    # P6+), S30 M=16256 (1.75x — OCC). K-984/K-989 LAND anchors S25 M=6016
+    # / S27 M=10112 / S28 M=12160 sit clear below the M>=13000 floor and
+    # remain route-OUT under P5 Clause-2 with 5.31x-5.63x routing speedup.
+    if N == 2048 and K == 1024 and 13000 <= M <= 14999:
+        return True
+    # Envelope B: moderate-square mid-K family (S24 fingerprint).
+    # Ceiling maxMN<=4500 preserves K-984 anchor S18 (5972,1792,768) and
+    # K-989 anchor S25 (6016,2048,1024) which both sit clear above.
+    if 2048 <= minMN and maxMN <= 4500 and 512 <= K <= 1024:
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# K-1144 P8 — MFMA-issue-stall direct hipBLASLt route-OUT (productionizes
+# K-1121 + K-1131).
+#
+# Brief context: K-1074 paired n=30 LAND audit on c42/MI300X falsified the
+# K-1089 wpeu=1 in-kernel admit for the 13-cell MFMA-issue-stall cohort
+# (5 K-1051 + 8 K-1031 leakage); 0/13 cells cleared the K-901 +2% margin
+# (2/13 — S32, S37 — were CI95-confirmed regressions, see K-1109's carve-
+# out documentation).  K-1121 measured paired n=30 HIP-graph hot-cache on
+# the same 13 cells with `OFF=tritonblas`/`ON=hipBLASLt` and reported
+# 13/13 admit at hbl/tb >= 1.10x (cohort geomean 1.226x, range
+# 1.158x-1.365x; CI95-lower clears the K-1007 >=1.05x admission floor on
+# every cell).  K-1127 then adversarially backtested the 13-cell envelope
+# against the K-931 always-uncovered top-40 production catalog and reported
+# 0 false positives at n=20.  K-1131 perturbed the 13 anchors along
+# +/-1 power-of-2 in M, N, K and admitted all 12/12 neighbors at the
+# stricter generalization gate (ratio >= 1.15x AND CI95-lo > 1.00; geomean
+# 1.367x, max 1.657x, scatter 0.0%).  Triple-validated: original cohort
+# (K-1121) + adversarial backtest (K-1127) + neighbor envelope (K-1131).
+#
+# Composition with the existing predicate stack (no overlap, no precedence
+# inversion):
+#   * P8 fires BEFORE the K-1089 R_K1037_P6_admit_wpeu1 admit-back-to-kernel
+#     check, because S24 (4480, 3072, 768) and S29 (14208, 2048, 1024) sit
+#     inside K-1089 Envelopes B and A respectively and would otherwise be
+#     short-circuited back to in-kernel by P6 -- but K-1074's paired n=30
+#     evidence falsified that admit and K-1121's paired n=30 confirms
+#     hipBLASLt wins on these exact cells (S24 ratio ~1.20x, S29 ratio
+#     ~1.22x).  K-1131 neighbor N11 (2240, 3072, 768) is also inside
+#     P6 Envelope B and is similarly reverted to route-OUT by P8.  This
+#     is the "no precedence inversion vs K-1089" composition rule
+#     codified.
+#   * P8 is independent of (composes safely with) K-1062 P5 Clause-4
+#     K-floor=512: P8 cells either don't hit Clause-4 at all (none use
+#     N=1792 with 512<=K<=768 except S18, see below) or already route-OUT
+#     via Clause-4 (S18 = 5972, 1792, 768; K=768 is in-band).  Strict-
+#     equality dispatch on P8 returns True regardless, so even on overlap
+#     the routing decision is identical -- no double-routing.
+#   * P8 is also independent of K-1066 R-K979 P5 generalized clauses.
+#     Cells covered by both P5 (Clause-2 large-M skinny) and P8 simply
+#     return True via whichever check fires first; the dispatch outcome
+#     is unchanged ("route to hipBLASLt").  Strict-equality is a frozenset
+#     hash; lookup cost is O(1) per K-1060 round-robin harness analysis.
+#   * P8 is also independent of the K-1109 env-gated allowlist.  The
+#     K-1109 allowlist (default OFF) admits 6 of the K-1074 cells back
+#     to in-kernel; with the env unset (production default) those cells
+#     route via P5 Clause-2.  P8 makes the route-OUT explicit and does
+#     not depend on the K-1109 env state.  When the K-1109 env IS set,
+#     P8's BEFORE-P6 placement still wins -- the brief's "no double-
+#     routing" guarantee holds in both env states.
+#
+# Anti-overshoot discipline (R-1131): the route table is STRICT-EQUALITY
+# only.  K-1131 deliberately did NOT widen to a parametric envelope despite
+# 12/12 + zero-scatter neighbor admission, because the K-1097->K-1115 PMC
+# classifier exhaustion chain forecloses any non-strict-equality predicate
+# on this cohort that hasn't survived held-out validation.  Future shape-
+# class consolidation (R-1121.SHAPE-CLASS-PREDICATE-CANDIDATE-WHEN-COHORT-
+# SHARES-NK-SIGNATURE-WITH-M-SWEEP) is filed as a follow-up; it must
+# re-derive thresholds from already-admitted P8 cells (not raw counter
+# data) to avoid re-opening the predicate-fit trap.
+#
+# 25 cells = 13 K-1121 anchors + 12 K-1131 neighbors, all bf16.
+# K-1121 admission gate: hbl/tb >= 1.10x mean AND CI95-lo >= 1.05x (K-1007).
+# K-1131 generalization gate: ratio >= 1.15x AND CI95-lo > 1.00.
+# All cells satisfy both gates per source manifests.
+# ---------------------------------------------------------------------------
+
+# K-1121 anchors (5 K-1051 PMC counter-matrix cells + 8 K-1031 leakage
+# cohort cells).  Per-cell mean speedup (hbl/tb) annotated from K-1121's
+# paired n=30 HIP-graph hot-cache on rad-mi300x-1 / MI300X / ROCm 7.2;
+# range 1.158x-1.365x; cohort geomean 1.226x.
+_K1121_P8_ANCHORS_13 = frozenset({
+    # ----- K-1051 PMC counter-matrix cells (overlap with K-1089 P6) -----
+    ( 4480, 3072,  768, "torch.bfloat16"),  # S24  ~1.20x  (P6 Env-B overlap)
+    (14208, 2048, 1024, "torch.bfloat16"),  # S29  ~1.22x  (P6 Env-A overlap)
+    ( 5972, 1792,  768, "torch.bfloat16"),  # S18  ~1.16x  (P5 C4 K=768)
+    ( 6016, 2048, 1024, "torch.bfloat16"),  # S25  ~1.21x  (P5 C2)
+    (16256, 2048, 1024, "torch.bfloat16"),  # S30  ~1.24x  (P5 C2)
+    # ----- K-1031 leakage MFMA-issue-stall candidates -----
+    ( 8064, 2048, 1024, "torch.bfloat16"),  # S26  ~1.22x  (P5 C2)
+    (18304, 2048, 1024, "torch.bfloat16"),  # S31  ~1.27x  (P5 C2)
+    (20352, 2048, 1024, "torch.bfloat16"),  # S32  ~1.25x  (P5 C2; K-1109 carve-out)
+    (22400, 2048, 1024, "torch.bfloat16"),  # S33  ~1.21x  (P5 C2)
+    (24448, 2048, 1024, "torch.bfloat16"),  # S34  ~1.19x  (P5 C2)
+    (26496, 2048, 1024, "torch.bfloat16"),  # S35  ~1.24x  (P5 C2)
+    (25600, 2048,  256, "torch.bfloat16"),  # S37  ~1.30x  (P5 C2; K-1109 carve-out)
+    (49152, 2048,  256, "torch.bfloat16"),  # S39  ~1.37x  (P5 C2)
+})
+
+# K-1131 held-out neighbors (12 cells perturbed +/-1 power-of-2 from 4
+# representative anchors: S32 peak, S39 extreme-M / shallow-K, S18 only-
+# non-2K-N, S24 only-N=3072).  Per-cell mean speedup (hbl/tb) annotated
+# from K-1131's paired n=30 + 10k-resample paired bootstrap on rad-mi300x-1;
+# range 1.15x-1.657x; cohort geomean 1.367x; envelope-edge cells N04/N06.
+_K1131_P8_NEIGHBORS_12 = frozenset({
+    # ----- S32 (20352, 2048, 1024) family — full 6-axis coverage -----
+    (20352, 2048,  512, "torch.bfloat16"),  # N01 S32 K/2  IN_COHORT
+    (20352, 2048, 2048, "torch.bfloat16"),  # N02 S32 K*2  IN_COHORT
+    (40704, 2048, 1024, "torch.bfloat16"),  # N03 S32 M*2  IN_COHORT
+    (10176, 2048, 1024, "torch.bfloat16"),  # N04 S32 M/2  ratio 1.604x (envelope edge)
+    (20352, 4096, 1024, "torch.bfloat16"),  # N05 S32 N*2  IN_COHORT
+    (20352, 1024, 1024, "torch.bfloat16"),  # N06 S32 N/2  ratio 1.657x (cohort MAX)
+    # ----- S39 (49152, 2048, 256) family — K-axis only (extreme-M) -----
+    (49152, 2048,  128, "torch.bfloat16"),  # N07 S39 K/2  IN_COHORT
+    (49152, 2048,  512, "torch.bfloat16"),  # N08 S39 K*2  IN_COHORT
+    # ----- S18 (5972, 1792, 768) family — N-axis only (only non-2K N) -----
+    ( 5972,  896,  768, "torch.bfloat16"),  # N09 S18 N/2  IN_COHORT
+    ( 5972, 3584,  768, "torch.bfloat16"),  # N10 S18 N*2  IN_COHORT
+    # ----- S24 (4480, 3072, 768) family — M/2 + K*2 (only N=3072) -----
+    ( 2240, 3072,  768, "torch.bfloat16"),  # N11 S24 M/2  IN_COHORT (P6 Env-B overlap)
+    ( 4480, 3072, 1536, "torch.bfloat16"),  # N12 S24 K*2  IN_COHORT
+})
+
+# K-1175 / K-1161 E2 axis extension admits.  K-1161 paired n=30 HIP-graph
+# hot-cache validation of the K-axis extension envelope
+#   E2 := N in {1792, 2048, 3072} AND K in {96, 128, 192, 256, 512, 768, 1024}
+# returned a **NEGATIVE_AXIS_PIVOT** verdict overall (3/8 = 37.5% admit,
+# below the 50% pivot threshold; well below the 80% landing threshold).
+# In particular:
+#   - K-floor relaxation (K < 256: E2_K1=512x2048x96, E2_K2=512x2048x192):
+#       0/2 admit -- both are TB-favoured (small-M Triton-win tail).
+#   - K=512 interior fill (E2_I1=192x2048x512, E2_I2=156x1792x512,
+#       E2_I3=160x3072x512): 0/3 admit -- all TB-favoured (small-M tail).
+#   - K=736 interior fill (E2_I4=736x1792x736): 1/1 admits at hbl/tb=1.315x
+#       CI95=[1.313, 1.317].  Sole K-interior route-OUT-safe cell.
+#   - M-axis extension at K=1024 (E2_M1=10112x2048x1024,
+#       E2_M2=12160x2048x1024, both at K-1121 anchor K-set): 2/2 admit at
+#       hbl/tb 1.759x and 1.499x respectively.  Orthogonal axis, not in
+#       K-floor=128 / K=512 scope but K-1161 uncovered.
+#
+# Per K-1161 R-1161.K-FLOOR-RELAXATION-SURFACES-TB-FAVOURED-SMALL-M-TAIL:
+# the K-1121 MFMA-issue-stall cohort's small-M corner (M <= 512) of the
+# (M, K) plane is a Triton win region; K-1142's (M >= 4480) carve-out
+# already excluded these cells by M-floor regardless of K-floor strictness.
+# K-floor=128 is NOT hipBLASLt-favourable for this regime; only the M-axis
+# extension and the K=736 single-cell pin are landed here.  The K-floor
+# of any future structural extension MUST remain at K >= 256 unless paired
+# with a strict M-floor strictly above the small-M Triton-favoured tail.
+#
+# Strict-equality only (R-1131): no parametric envelope -- each cell was
+# directly measured at paired n=30 with hbl/tb >= 1.315x and CI95-lo > 1.05x.
+_K1161_E2_ADMITS_3 = frozenset({
+    # ----- K-interior single-cell admit (only K-axis cell that survived) -----
+    (  736, 1792,  736, "torch.bfloat16"),  # E2_I4 hbl/tb=1.315x CI95=[1.313, 1.317] (K=736 upper edge)
+    # ----- M-axis extension at K-1121 anchor K=1024 (orthogonal axis) -----
+    (10112, 2048, 1024, "torch.bfloat16"),  # E2_M1 hbl/tb=1.759x CI95=[1.753, 1.770]
+    (12160, 2048, 1024, "torch.bfloat16"),  # E2_M2 hbl/tb=1.499x CI95=[1.496, 1.504]
+})
+
+# K-1231 / K-1205 E_N3 N-axis extension admits.  Productionised on top of
+# K-1216's stacked dispatch chain (fix/K-1209-stacked @ fb9461f).  Paired
+# n=30 HIP-graph hot-cache validation on rad-mi300x-1 fallback (c42 SSH
+# plane outage continued through K-1216's 10th recurrence and was still
+# refused on the K-1231 verification window) of the N-floor relaxation:
+#   E_N3 := N = 128 (one power-of-2 tier below the natural sub-1024 N floor)
+#           AND K in {256, 768, 1024} (K-1144 K-set held fixed -- NOT a
+#               K-axis relaxation; K-1161/K-1176 already established
+#               K-floor < 256 is NEGATIVE on this cohort)
+#           AND M in K-1121 anchor M-set (mirrored projection per K-1131)
+#           AND bf16
+# returned a clean POSITIVE landing verdict: 8/9 = 88.9% admit, well above
+# the 75% landing threshold, and decisively diverging from K-1161's K-axis
+# NEGATIVE (1/6 = 16.7%) on adjacent cells / same hardware / same protocol
+# -- empirically REFUTING K-1199's analytical (M<->N) symmetry prediction.
+#
+# Mechanistic reading: at extreme aspect ratios with M >> N=128, hipBLASLt's
+# Tensile schedule (wide unroll + many waves) hides the same MFMA-issue-
+# stall bottleneck more aggressively than at K-1121 mid-square N=2048 tiles
+# -- per-cell speedups widen 1.14x-3.25x at N=128 vs 1.16x-1.27x at N=2048.
+# The single rejection EN_K768_S24 (M=4480 K=768 N=128 bf16 hbl/tb=0.967x
+# CI95=[0.94, 1.00]) sits exactly at the K-1142 M-floor; the same small-M
+# Triton-favoured tail surfaced by K-1161 along the K-axis is active here
+# at the M-floor of the K-1121 anchor M-set (R-1205.SMALL-M-TRITON-
+# FAVOURED-TAIL-IS-AXIS-AGNOSTIC-AT-COHORT-M-FLOOR).  The strict-equality
+# posture EXCLUDES this false positive by construction (carve-out by
+# omission); see K1205_EN3_REJECTED_1_LIST in the pin tests for an
+# explicit no-leak regression trap.
+#
+# Strict-equality only (R-1131 / R-1175): no parametric envelope -- each
+# cell was directly measured at paired n=30 with hbl/tb >= 1.144x and
+# CI95-lo > 1.05x.  N=128 keeps the four sub-frozensets pairwise disjoint
+# by construction (no prior P8 cell has N < 896).
+_K1205_EN3_ADMITS_8 = frozenset({
+    # ----- N=128 K=1024 cluster (5 admits; speedups 1.37x-3.25x) -----
+    ( 6016,  128, 1024, "torch.bfloat16"),  # EN_K1024_S25 hbl/tb=1.370x CI95=[1.362, 1.374]
+    ( 8064,  128, 1024, "torch.bfloat16"),  # EN_K1024_S26 hbl/tb=1.402x CI95=[1.396, 1.415]
+    (14208,  128, 1024, "torch.bfloat16"),  # EN_K1024_S29 hbl/tb=3.254x CI95=[3.234, 3.267] (cohort MAX)
+    (16256,  128, 1024, "torch.bfloat16"),  # EN_K1024_S30 hbl/tb=3.024x CI95=[3.011, 3.056]
+    (22400,  128, 1024, "torch.bfloat16"),  # EN_K1024_S33 hbl/tb=2.258x CI95=[2.234, 2.269]
+    # ----- N=128 K=256 cluster (2 admits; extreme-M; speedups 1.14x-1.78x) -----
+    (25600,  128,  256, "torch.bfloat16"),  # EN_K256_S37  hbl/tb=1.144x CI95=[1.140, 1.149] (cohort MIN admit)
+    (49152,  128,  256, "torch.bfloat16"),  # EN_K256_S39  hbl/tb=1.781x CI95=[1.768, 1.803]
+    # ----- N=128 K=768 cluster (1 admit; M=4480 carve-out via omission) -----
+    ( 5972,  128,  768, "torch.bfloat16"),  # EN_K768_S18  hbl/tb=1.227x CI95=[1.226, 1.227]
+    # NOTE: EN_K768_S24 (M=4480 N=128 K=768 bf16 hbl/tb=0.967x) is
+    # DELIBERATELY OMITTED -- this is the K-1205 N-axis false-positive
+    # carve-out at the K-1142 M-floor.  See K1205_EN3_REJECTED_1_LIST
+    # in tests/test_k971_route_predicate.py for the no-leak pin.
+})
+
+# ---------------------------------------------------------------------------
+# K-1219 / K-1240 -- E3 N-floor=256 anchor-projected admits (7 cells).
+# K-1131-style +/-1-power-of-2 N-axis projection of K-1121 PMC anchors
+# {S18, S24, S25, S30, S37, S39} + K-1175 E2_M1 admit, projected to
+# N=256 (one tier below the K-1131 N09 N=896 natural floor).  Per K-1142
+# carve-out, M >= 4480 on every cell.  Validated independently in K-1219
+# (commit f110d64 on fix/K-1219-n256, branch productionised pre-K-1282)
+# at paired n=30 HIP-graph hot-cache MI300X with cohort geomean
+# tb-over-hbl 1.505x; admitted to the unified K-1282 P8 envelope.
+#
+# K-1303 (S-002) layers this set onto the K-1275 baseline (K-1216 stacked
+# dispatch chain @ fb9461f extended by K-1227's _K1205_EN3_ADMITS_8 to
+# 36 cells).  N=256 sits on a disjoint N-axis tier below the K-1131
+# N09 N=896 natural floor and above K-1227's N=128 tier, so the union
+# is pairwise-disjoint with all four prior provenance frozensets by
+# construction (asserted below).
+# ---------------------------------------------------------------------------
+_K1219_E3_NFLOOR256_ADMITS_7 = frozenset({
+    # ----- E3 N=256 anchor-projected admits (M >= 4480 per K-1142) -----
+    ( 5972,  256,  768, "torch.bfloat16"),  # E3_S18_N256
+    ( 4480,  256,  768, "torch.bfloat16"),  # E3_S24_N256
+    ( 6016,  256, 1024, "torch.bfloat16"),  # E3_S25_N256  MI300X tb/hbl 1.215 CI95=[1.206,1.224]
+    (16256,  256, 1024, "torch.bfloat16"),  # E3_S30_N256  MI300X tb/hbl 2.274 CI95=[2.260,2.291]
+    (25600,  256,  256, "torch.bfloat16"),  # E3_S37_N256
+    (49152,  256,  256, "torch.bfloat16"),  # E3_S39_N256
+    (10112,  256, 1024, "torch.bfloat16"),  # E3_E2M1_N256 MI300X tb/hbl 2.926 CI95=[2.911,2.942]
+})
+
+# ---------------------------------------------------------------------------
+# K-1283 / K-1297 (S-002) -- A1 sub-cohort targeted P8 admit-cell extension
+# (8 cells).  K-1283 classified the K-1132 wpeu=1 13-cell residual into A1
+# (LDS-wait-starvation, MFMA-issue-stall dominated) and A2 (occupancy-bound,
+# paired waves ratio >= 1.7) sub-cohorts.  All five A1 *parent* cells (S18,
+# S24, S25, S29 in `_K1121_P8_ANCHORS_13`; N11 in `_K1131_P8_NEIGHBORS_12`)
+# are already routed.  K-1131 only perturbed S32 (A2), S39 (A2), S18 (A1),
+# and S24 (A1) -- leaving S25 and S29 (A1 anchors) with **zero**
+# +/-1-power-of-2 perturbation coverage, plus several un-covered axes on
+# S18 / S24.
+#
+# K-1297 closes the A1-only perturbation gap with a strict-equality
+# extension validated under paired n=30 HIP-graph hot-cache (V2 protocol;
+# see K-1297 PR / fix/K-1283-A1 @ f4cc5cf for the V1-vs-V2 audit).  V2
+# admits 8 cells at CI95-lo > 1.0x on rad-mi300x-1; cohort geomean =
+# 1.389x.  All admits respect the K-1142 M-floor (M >= 4480) and the
+# K-1161 K-floor (K >= 256).
+#
+# K-1322 (S-002) layers this set onto the K-1303 unified envelope (which
+# already contains K-1121 + K-1131 + K-1161 E2 + K-1205 N=128 + K-1219
+# N=256 = 43 cells), growing the unified envelope to 51 cells.  K-1283
+# A1 perturbations are K-1131-style perturbations of A1 anchors that
+# K-1131 itself did NOT enumerate (S25, S29, plus un-covered M/K axes of
+# S18 / S24).  Disjointness with all five prior sub-frozensets is by
+# construction (asserted at module load).
+# ---------------------------------------------------------------------------
+_K1283_A1_PERTURBATIONS_8 = frozenset({
+    # ----- S25 (6016, 2048, 1024) family -- A1 anchor, 5/5 axes admit -----
+    (12032, 2048, 1024, "torch.bfloat16"),  # A1_S25_Mx2
+    ( 6016, 4096, 1024, "torch.bfloat16"),  # A1_S25_Nx2
+    ( 6016, 1024, 1024, "torch.bfloat16"),  # A1_S25_N/2
+    ( 6016, 2048, 2048, "torch.bfloat16"),  # A1_S25_Kx2
+    ( 6016, 2048,  512, "torch.bfloat16"),  # A1_S25_K/2
+    # ----- S29 (14208, 2048, 1024) family -- A1 anchor, 3/6 axes admit -----
+    (28416, 2048, 1024, "torch.bfloat16"),  # A1_S29_Mx2
+    (14208, 4096, 1024, "torch.bfloat16"),  # A1_S29_Nx2
+    (14208, 2048,  512, "torch.bfloat16"),  # A1_S29_K/2
+    # NOTE: 7 K-1297 candidates were rejected (CI95-lo <= 1.0x) under V2
+    # and are DELIBERATELY OMITTED here (S29 boundary rejects, S18_Mx2
+    # noise-floor straddler, S18/S24 K-axis rejects).  See K-1297 PR
+    # body and tests/test_k971_route_predicate.py K-1283 no-leak pins.
+})
+
+# Composed 51-cell P8 envelope (K-1322 unified).  Six named provenance
+# frozensets (K-1121 anchors, K-1131 neighbors, K-1175/K-1161 E2 admits,
+# K-1231/K-1205 E_N3 N=128 admits, K-1219 E3 N=256 admits, K-1283/K-1297
+# A1 perturbations) -- the dispatch path consults the union.  Per
+# R-1144.DUAL-FROZENSET-PROVENANCE and its K-1175 / K-1205 / K-1219 /
+# K-1297 extensions, source-ticket lineage is load-bearing for future
+# reviewers (precedence-inversion debugging, PMC re-classifier work, ADR
+# audits) so each measurement campaign keeps its own named set with a
+# runtime size + pairwise-disjointness check.
+_P8_MFMA_ISSUE_STALL_ROUTEOUT = (
+    _K1121_P8_ANCHORS_13
+    | _K1131_P8_NEIGHBORS_12
+    | _K1161_E2_ADMITS_3
+    | _K1205_EN3_ADMITS_8
+    | _K1219_E3_NFLOOR256_ADMITS_7
+    | _K1283_A1_PERTURBATIONS_8
+)
+assert len(_P8_MFMA_ISSUE_STALL_ROUTEOUT) == 51, (
+    "K-1322 unified P8 envelope must be exactly 51 cells (13 K-1121 "
+    "anchors + 12 K-1131 neighbors + 3 K-1161 E2 admits + 8 K-1205 E_N3 "
+    "N=128 admits + 7 K-1219 E3 N=256 admits + 8 K-1283/K-1297 A1 "
+    "perturbations); a duplicate or stray entry has crept in.")
+# Cross-check: the five sub-sets must be pairwise disjoint by construction.
+# K-1131 perturbed AWAY from K-1121 anchors; K-1161 E2 admits were
+# selected from the K-931 always-uncovered top-40 catalog minus all
+# K-1121 anchors and minus all K-1131 neighbors; K-1205 E_N3 admits use
+# N=128 (no prior P8 cell has N < 896 -- disjointness by N-axis projection);
+# K-1219 E3 admits use N=256 (disjoint from N=128 K-1205 by construction
+# and below the K-1131 N09 N=896 natural floor).
+assert _K1121_P8_ANCHORS_13.isdisjoint(_K1131_P8_NEIGHBORS_12), (
+    "K-1144 P8 anchors and neighbors overlap; K-1131 neighbor generation "
+    "rules require strict disjointness from the 13 K-1121 anchors.")
+assert _K1121_P8_ANCHORS_13.isdisjoint(_K1161_E2_ADMITS_3), (
+    "K-1175 K-1161 E2 admits overlap with K-1121 anchors; the K-1161 "
+    "candidate generator excluded all K-1121 anchors by construction.")
+assert _K1131_P8_NEIGHBORS_12.isdisjoint(_K1161_E2_ADMITS_3), (
+    "K-1175 K-1161 E2 admits overlap with K-1131 neighbors; the K-1161 "
+    "candidate generator excluded all K-1131 neighbors by construction.")
+assert _K1205_EN3_ADMITS_8.isdisjoint(_K1121_P8_ANCHORS_13), (
+    "K-1205 E_N3 admits overlap with K-1121 anchors; E_N3 candidates "
+    "have N=128 by construction and no K-1121 anchor has N=128.")
+assert _K1205_EN3_ADMITS_8.isdisjoint(_K1131_P8_NEIGHBORS_12), (
+    "K-1205 E_N3 admits overlap with K-1131 neighbors; E_N3 candidates "
+    "have N=128 by construction and no K-1131 neighbor has N=128.")
+assert _K1205_EN3_ADMITS_8.isdisjoint(_K1161_E2_ADMITS_3), (
+    "K-1205 E_N3 admits overlap with K-1161 E2 admits; E_N3 candidates "
+    "have N=128 by construction and no K-1161 E2 admit has N=128.")
+# K-1219 (N=256) cross-disjointness with the prior 36-cell envelope.
+assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1121_P8_ANCHORS_13), (
+    "K-1219 E3 N=256 admit overlaps a K-1121 anchor; the K-1131-style "
+    "anchor projection excluded all K-1121 anchors by construction.")
+assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1131_P8_NEIGHBORS_12), (
+    "K-1219 E3 N=256 admit overlaps a K-1131 neighbor; the K-1131 "
+    "perturbation set's smallest N is 896, well above the N=256 tier.")
+assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1161_E2_ADMITS_3), (
+    "K-1219 E3 N=256 admit overlaps a K-1161 E2 admit; the K-1161 "
+    "K-axis admits all sit at N in {1792, 2048}, not N=256.")
+# K-1303 cross-band disjointness: K-1227 N=128 vs K-1219 N=256.
+assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1205_EN3_ADMITS_8), (
+    "K-1303 composition error: K-1219 N=256 admits overlap K-1205 E_N3 "
+    "N=128 admits.  The two campaigns operate on disjoint N axes by "
+    "construction; an overlap indicates an authoring typo in one of "
+    "the two frozensets.")
+# K-1322 / K-1297 A1 cross-disjointness with the prior five sub-frozensets.
+# K-1283 A1 perturbations are perturbations of A1 anchors that K-1131 did
+# not enumerate; their N values are in {1024, 2048, 4096} (S25/S29 family),
+# overlapping the K-1131 / K-1121 N axis (N in {896, 1024, 2048}) on the N
+# coordinate but always differing on (M, K) by construction.  N=128 / N=256
+# tiers (K-1205 / K-1219) are trivially disjoint.
+assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1121_P8_ANCHORS_13), (
+    "K-1283 A1 perturbation overlaps a K-1121 anchor; the K-1131-style "
+    "+/-1-power-of-2 perturbation generator excludes the parent anchor "
+    "by construction.")
+assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1131_P8_NEIGHBORS_12), (
+    "K-1283 A1 perturbation overlaps a K-1131 neighbor; K-1297 selected "
+    "only A1-anchor perturbations on axes K-1131 did NOT enumerate (S25, "
+    "S29, plus un-covered M/K axes of S18/S24).")
+assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1161_E2_ADMITS_3), (
+    "K-1283 A1 perturbation overlaps a K-1161 E2 admit; the three E2 "
+    "admits ({(736,1792,736), (10112,2048,1024), (12160,2048,1024)}) are "
+    "structurally distinct from the K-1297 A1 perturbation cells.")
+assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1205_EN3_ADMITS_8), (
+    "K-1283 A1 perturbation overlaps a K-1205 E_N3 admit; K-1297 cells "
+    "all have N >= 1024; K-1205 cells all have N=128.")
+assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1219_E3_NFLOOR256_ADMITS_7), (
+    "K-1283 A1 perturbation overlaps a K-1219 E3 N=256 admit; K-1297 "
+    "cells all have N >= 1024; K-1219 cells all have N=256.")
+# K-1335 cross-predicate disjointness: K-1335 longK_smallSquare admits live
+# on the LDS-BC `K971_ROUTE_TABLE` (5th-position dispatch predicate) and
+# MUST NOT collide with any K-1322 P8 sub-frozenset.  K-1335 cells have
+# M=N∈{1024,2048} and K∈{4096,8192}; every K-1322 P8 sub-frozenset's M-axis
+# floor or N-axis selector excludes this region by construction (K-1121 /
+# K-1131 / K-1161 / K-1283 use M >= 4480 with shape constraints; K-1205
+# uses N=128; K-1219 uses N=256).  Disjointness is asserted on the
+# (M,N,K,dtype) tuple after stripping the dtype back to a 4-tuple
+# representation since both frozensets share the same key shape.
+_K1335_VS_P8_DISJOINT = _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4.isdisjoint(
+    _P8_MFMA_ISSUE_STALL_ROUTEOUT)
+assert _K1335_VS_P8_DISJOINT, (
+    "K-1335 longK_smallSquare admit overlaps the K-1322 51-cell P8 "
+    "MFMA-issue-stall envelope; the two predicates target distinct "
+    "hardware bottlenecks (LDS-BC vs MFMA-issue-stall per K-913 / "
+    "K-1326 / R-1329) and must remain disjoint by construction.")
+
+
+# ---------------------------------------------------------------------------
+# K-1209-stacked / K-1216 (S-002): E1 axis-aligned envelope productionised
+# from K-1151 / K-1142 stacked AFTER the P8 28-cell strict-equality route.
+# K-1209 ablation on K-931 always-uncovered top-40 confirmed E1 is fully
+# dominated by P8+K-1175 on this cohort (0 marginal cells, 0 marginal FPs);
+# E1 is retained as defense-in-depth for cohorts beyond K-931 where the
+# audit chain has not yet enumerated every K-1142-envelope-admittable cell.
+# E1 ships with the K-1142 (M >= 4480) ∧ (K >= 256) carve-out which holds
+# at 0 FPs across all 4 stacked configurations on K-931 top-40 (K-1209).
+# E2 K-floor=128 is EXCLUDED per K-1176 cross-arch failure (0/8 cells on
+# MI325X/MI355X) — no K-axis relaxation past K=256.
+# ---------------------------------------------------------------------------
+K1142_E1_NS = frozenset({1792, 2048, 3072})
+K1142_E1_KS = frozenset({256, 768, 1024})
+K1142_E1_M_FLOOR = 4480  # K-1121 anchor S24's M (margin 0; excludes FP1=256x2048x256)
+K1142_E1_K_FLOOR = 256   # K-1161 NEGATIVE_AXIS_PIVOT pin; do NOT relax to 128
+
+
+def R_K1142_E1_route_to_hbl(M: int, N: int, K: int, dtype) -> bool:
+    """K-1151 E1 envelope route-OUT — bf16 ∧ N∈{1792,2048,3072} ∧
+    K∈{256,768,1024} ∧ M≥4480 ∧ K≥256. Stacked AFTER P8 in K-1209-stacked
+    so P8 wins on overlap (no double-routing); E1 only fires on cells P8
+    does not already enumerate. K-1209 confirmed 0 marginal coverage on
+    K-931 top-40 beyond P8+K-1175 — E1 is defense-in-depth for non-K-931
+    catalogs where the audit chain has not converged.
+    """
+    if not _dtype_is_bf16(dtype):
+        return False
+    if N not in K1142_E1_NS or K not in K1142_E1_KS:
+        return False
+    if M < K1142_E1_M_FLOOR or K < K1142_E1_K_FLOOR:
+        return False
+    return True
+
+
+def _p8_mfma_issue_stall_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1144 P8 (extended by K-1175 / K-1231-K-1205 / K-1219 / K-1297 --
+    unified in K-1303 then K-1322) — direct hipBLASLt route-OUT for the
+    sextuply-validated MFMA-issue-stall cohort (K-1121 anchors + K-1131
+    neighbors + K-1175/K-1161 E2 admits + K-1231/K-1205 E_N3 N=128 admits +
+    K-1219 E3 N=256 admits + K-1283/K-1297 A1 perturbations).
+
+    Returns True iff (M, N, K, dtype) matches one of the 51 strict-equality
+    keys in :data:`_P8_MFMA_ISSUE_STALL_ROUTEOUT`.  bf16-only by design
+    (the entire K-1121 / K-1131 source measurement scope is bf16; fp16
+    parity is tracked separately on the K-1093 / K-1125 line).
+
+    This predicate is consulted **before** the K-1089 P6 admit-back-to-
+    kernel check inside ``_k971_route_to_hbl`` so K-1121's measurement
+    evidence (hipBLASLt wins on S24, S29 at ~1.20x, ~1.22x respectively)
+    overrides the K-1089 envelope admit for the small subset of cells
+    where the two envelopes overlap (S24 and S29 inside P6 Env-B and
+    Env-A; K-1131 N11 inside P6 Env-B).  K-1074's paired n=30 LAND audit
+    plus K-1098's clause-by-clause backtest established that the K-1089
+    admit was falsified for these cells -- P8 codifies the correction.
+
+    For cells that are NOT in any P6 envelope, P8's strict-equality match
+    is functionally identical to the existing P5 Clause-2 route-OUT
+    decision (both return True -> route to hipBLASLt).  The dispatch
+    outcome is unchanged for those cells; P8 just makes the routing
+    rationale source-of-truth attributable to the K-1121 + K-1131
+    measurement campaign rather than P5's structural pathology heuristic.
+    """
+    if not _dtype_is_bf16(dtype):
+        return False
+    return (int(M), int(N), int(K), str(dtype)) in _P8_MFMA_ISSUE_STALL_ROUTEOUT
+
+
+# ---------------------------------------------------------------------------
+# K-1361 (S-002) — P12 `square_mid` PMC-driven route-OUT (6th-position envelope).
+#
+# K-1361 productionises K-1345's Predicate-Q (square_mid 2048³) and Predicate-R
+# (square_mid 4096³) as a 4-cell strict-equality frozenset
+# `_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4`, layered as the 6th-position envelope
+# in the dispatch precedence chain ABOVE the K971 LDS-BC table (5th-position)
+# and BELOW the new K-1367 P13 skinny_N128 K-COMPLEMENT (7th-position).
+#
+# Source measurement chain:
+#   * S1 (2048³ bf16): K-1295 paired n=30 + K-877 S1b direct PMC anchor
+#                      (LDS_BC 0.889 cyc/inst, MFMA% gap 1.25 pp).
+#   * S2 (4096³ bf16): K-1295 paired n=30 + K-913 §3 5-anchor PMC triangulation
+#                      (K-655 / K-818 C2 / K-837 N1a / N1b / K-879).
+#   * S1f (2048³ fp16): K-877 S1a direct fp16 PMC anchor (LDS_BC 0.889,
+#                       MFMA% gap 1.27 pp) + K-1295 inheritance via K-913 §3
+#                       dtype invariance.
+#   * S2f (4096³ fp16): K-913 §3 dtype invariance from S1f extended to 4096³
+#                       (INFERRED-DTYPE-PAIR; no direct 4096³ fp16 anchor).
+# 8192³ bf16 is DROP'd (K-1308 F4 HBM-bound, K-879 N2a confirms zero LDS_BC
+# on both engines; out of route-OUT scope per
+# R-1345.HBM-ASYMPTOTE-BOUND-IS-NOT-PREDICATE-ADDRESSABLE).
+#
+# Bucket-rule scoping (per K-1345 RANKED_BUCKETS_v2 authoritative diagonal-only
+# rule, NOT the PRD textual 4-combo enumeration): square_mid = M==N==K diagonal
+# in {2048,4096}; off-diagonal combos (e.g. M=N=2048, K=4096) belong to K-1313
+# WIDE bucket already P10-covered — admitting them would violate A4
+# no-double-admit.  RETRY iteration=2 corrected the PRD ambiguity per
+# R-1361.PRD-TEXTUAL-ENUMERATION-MUST-RESOLVE-AGAINST-AUTHORITATIVE-BUCKET-RULE.
+#
+# Verification (paired n=30 inherited from K-1295; PMC anchors direct + 5-anchor
+# triangulation; B=10000 paired bootstrap CI95):
+#   S1  bf16 paired tb/hbl med 0.258 [0.257, 0.260]  inv 3.87×  ROUTE-OUT
+#   S2  bf16 paired tb/hbl med 0.550 [0.544, 0.552]  inv 1.82×  ROUTE-OUT
+#   S1f fp16 paired tb/hbl med 0.258 (n/a-INFERRED)  inv 3.87×  ROUTE-OUT-INFERRED
+#   S2f fp16 paired tb/hbl med 0.550 (n/a-INFERRED)  inv 1.82×  ROUTE-OUT-INFERRED
+#
+# Disjointness: P12 cells (M=N=K∈{2048,4096}, both dtypes) are pairwise disjoint
+# with all P8 sub-frozensets (P8 uses M≥4480 for K-1121/K-1131/K-1161/K-1283 or
+# fixed N∈{128,256} for K-1205/K-1219), with K971_ROUTE_TABLE (which uses
+# K∈{16384,32768}, while P12 uses K∈{2048,4096}), and with K-1335 (K-1335 uses
+# K∈{4096,8192} with M=N∈{1024,2048}; the only shape-collision candidate is
+# (2048,2048,4096,bf16) which IS in K-1335 — by construction P12 omits this
+# diagonal anchor since it is already route-OUT'd at the 5th position).
+# ---------------------------------------------------------------------------
+_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4 = frozenset({
+    # S1: 2048³ bf16 — K-877 S1b direct PMC anchor + K-1295 paired n=30
+    (2048, 2048, 2048, "torch.bfloat16"),
+    # S2: 4096³ bf16 — K-913 §3 5-anchor triangulation + K-1295 paired n=30
+    (4096, 4096, 4096, "torch.bfloat16"),
+    # S1f: 2048³ fp16 — K-877 S1a direct fp16 anchor + K-913 §3 inheritance
+    (2048, 2048, 2048, "torch.float16"),
+    # S2f: 4096³ fp16 — INFERRED-DTYPE-PAIR (K-913 §3 from S1f, no 4096³ fp16 anchor)
+    (4096, 4096, 4096, "torch.float16"),
+})
+assert len(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4) == 4, (
+    "K-1361 P12 square_mid frozenset must be exactly 4 cells (S1, S2, S1f, S2f); "
+    "any deviation indicates an authoring typo against the K-1345 "
+    "RANKED_BUCKETS_v2 diagonal-only authoritative bucket rule.")
+# Cross-frozenset disjointness — P12 vs prior envelopes.
+_K1361_P12_VS_P8_DISJOINT = (
+    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+assert _K1361_P12_VS_P8_DISJOINT, (
+    "K-1361 P12 square_mid cell overlaps the K-1322 51-cell P8 envelope; "
+    "P8 sub-frozensets gate on M >= 4480 (K-1121/K-1131/K-1161/K-1283) or "
+    "fixed N ∈ {128, 256} (K-1205/K-1219), neither of which can match "
+    "M=N=K ∈ {2048, 4096}. Investigate before relaxing this assert.")
+_K1361_P12_VS_K971_DISJOINT = (
+    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4.isdisjoint(K971_ROUTE_TABLE))
+assert _K1361_P12_VS_K971_DISJOINT, (
+    "K-1361 P12 square_mid cell overlaps K971_ROUTE_TABLE; K971 (K-905/K-971 "
+    "anchors + K-1335 longK_smallSquare) covers K ∈ {4096, 8192, 16384, 32768} "
+    "with M=N ∈ {1024, 2048}; P12's M=N=K ∈ {2048, 4096} diagonal does not "
+    "intersect that K-axis range with M=N=4096 and excludes the K-1335 "
+    "(2048,2048,4096) cell by construction (already 5th-position route-OUT).")
+
+
+def _k1361_p12_square_mid_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1361 P12 — direct hipBLASLt route-OUT for the 4-cell square_mid
+    PMC-driven cohort (`_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 4 strict-equality
+    keys: M=N=K ∈ {2048, 4096} × dtype ∈ {bf16, fp16}.
+
+    Source measurement quality varies per cell (MEASURED-DIRECT for S1 + S1f
+    via K-877; MEASURED-VIA-TRIANGULATION for S2 via K-913 §3 5-anchor;
+    INFERRED-DTYPE-PAIR for S2f via K-913 §3 dtype invariance from S1f).
+    The runtime predicate behaviour is identical for all 4 cells; the
+    quality grading is preserved as comments + the K-1361-FOLLOW-A0 fresh
+    capture remediation.
+
+    Stacked AFTER K971_ROUTE_TABLE (5th-position) and BEFORE K-1367 P13
+    skinny_N128 K-COMPLEMENT (7th-position) per K-1175 stacked-predicate
+    convention.  Disjoint by construction with all P1–P11 sub-frozensets
+    via the cross-frozenset asserts above.
+    """
+    return (int(M), int(N), int(K), str(dtype)) in _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
+
+
+# ---------------------------------------------------------------------------
+# K-1367 (S-002) — P13 `skinny_N128` K-COMPLEMENT route-OUT (7th-position).
+#
+# K-1379 productionises the K-1367 RETRY-winning 18-cell cohort as
+# `_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18`, layered as the
+# 7th-position envelope in the dispatch precedence chain on top of the
+# K-1361 P12 55-cell baseline (envelope grows 55 → 73 cells; +18 admits).
+#
+# Bucket scope: K-1308's 4-bucket residual decomposition surfaced
+# `skinny_N128` (raw aggregate gap 3.294) as the rank-#1 predicate-addressable
+# residual; K-1345 demoted it to "wrapper-bound, already covered by K-1227's
+# N=128 envelope".  K-1367 then proved that the demotion is K-bounded: at
+# K ≥ 4096, TB compute time dominates the ~30 µs `triton_op` wrapper-overhead
+# ceiling and the wrapper-bound argument no longer applies (codified as
+# R-1367.WRAPPER-OVERHEAD-CEILING-DISAPPEARS-AT-LARGE-K-WHERE-TB-TIME-DOMINATES-30US-TRITONOP).
+# The 18-cell K-COMPLEMENT region is exactly that K ≥ 4096 sub-region of the
+# `skinny_N128` bucket K-1227 does NOT already cover.
+#
+# K-COMPLEMENT region:
+#   M ∈ {2048, 4096, 8192}  (3 anchors)
+#   N = 128                  (column-narrow regime)
+#   K ∈ {4096, 8192, 16384}  (above the 30 µs wrapper-overhead ceiling)
+#   dtype ∈ {bf16, fp16}     (K-913 §3 dtype invariance for both)
+# = 3 × 1 × 3 × 2 = 18 cells.
+#
+# PMC mechanism (rocprofv3 4-pass capture on 7 representative cells):
+#   TB persistent_matmul SQ_LDS_BANK_CONFLICT/inst ≈ 1.45
+#   HBL Cijk_*           SQ_LDS_BANK_CONFLICT/inst = 0     (sharp discriminator)
+#   n_dispatches = 22 per (cell, engine)  (positive-filter-check passed; the
+#                                          HBL LDS_BC=0 is real measurement,
+#                                          not a silent kernel-name-filter miss)
+# This is the SAME K-913 §3 LDS-bank-conflict mechanism that anchored K-1335
+# / K-1338 / K-1361, specialised to the N=128 column-narrow regime.  The
+# persistent_matmul tile pattern systematically conflicts on bf16/fp16 N=128
+# LDS layouts; hipBLASLt's tile selection avoids the bank-conflict geometry
+# entirely.  Codified as
+# R-1367.K913-LDS-BC-MECHANISM-IS-SHARPLY-DISCRIMINATING-FOR-SKINNY-N128.
+#
+# Verification (paired n=30 HIP-graph hot-cache, B=10000 vectorised paired
+# bootstrap CI95 — vectorised per R-1367.VECTORIZED-BOOTSTRAP-IS-DEFAULT-VALIDATION-GATE):
+#   18/18 ROUTE-OUT  (every cell CI95-lo > 1.0)
+#   cohort geomean tb/hbl = 1.678×        (HBL is 1.678× faster ⇒ route-OUT win)
+#   min CI95-lo            = 1.124         (worst cell still strictly route-OUT)
+#   no regressions on the 55-cell K-1361 P12 envelope (paired-arm stable)
+#
+# Projected K-1247 cohort lift: the 18-cell K-COMPLEMENT cohort is fully
+# inside the K-1247 61-cell backtest corpus; cohort geomean 1.678× contributes
+# directly to the realisable cohort lift; measurement deferred to
+# K-1367-FOLLOW-B once the productionised branch is on dedicated MI300X.
+#
+# Why N=128 is hipBLASLt-favoured (mechanistic — answers task brief Q3):
+#   The MFMA tile efficiency threshold for the persistent_matmul kernel sits
+#   at N >= 256 for waves_per_CU >= 2; at N=128 the column-narrow tile under-
+#   utilises the MFMA throughput and incurs systematic LDS-bank-conflicts on
+#   the persistent tile schedule (TB SQ_LDS_BC/inst ≈ 1.45 vs HBL = 0).  At
+#   K >= 4096 the compute time amortises the wrapper-overhead floor, so the
+#   raw HBL win (1.678× cohort geomean) is realisable end-to-end.
+#
+# Disjointness: P13 cells use N=128, M ∈ {2048, 4096, 8192}, K ∈ {4096, 8192,
+# 16384}.  Disjoint with:
+#   * P8 sub-frozensets — K-1121/K-1131/K-1161/K-1283 use M ≥ 4480 (P13
+#     allows M ≥ 2048; would collide on M ∈ {4096, 8192} but those P8 cohorts
+#     never use N=128); K-1205 uses N=128 BUT K ∈ {2048, 8192} with M ≥ 4480;
+#     the only on-paper collision candidates are M=8192,N=128,K=8192 cells;
+#     verified disjoint by frozenset.isdisjoint at module load.
+#   * K971_ROUTE_TABLE — K-905/K-971 anchors use M=N ∈ {1024, 2048};
+#     K-1335 uses M=N ∈ {1024, 2048} with K ∈ {4096, 8192}; neither has
+#     N=128, so no collision.
+#   * K-1361 P12 — uses M=N=K ∈ {2048, 4096} with N != 128; no collision.
+# All asserted at module load.
+# ---------------------------------------------------------------------------
+_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 = frozenset({
+    # M=2048 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (2048, 128,  4096, "torch.bfloat16"),
+    (2048, 128,  4096, "torch.float16"),
+    (2048, 128,  8192, "torch.bfloat16"),
+    (2048, 128,  8192, "torch.float16"),
+    (2048, 128, 16384, "torch.bfloat16"),
+    (2048, 128, 16384, "torch.float16"),
+    # M=4096 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (4096, 128,  4096, "torch.bfloat16"),
+    (4096, 128,  4096, "torch.float16"),
+    (4096, 128,  8192, "torch.bfloat16"),
+    (4096, 128,  8192, "torch.float16"),
+    (4096, 128, 16384, "torch.bfloat16"),
+    (4096, 128, 16384, "torch.float16"),
+    # M=8192 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (8192, 128,  4096, "torch.bfloat16"),
+    (8192, 128,  4096, "torch.float16"),
+    (8192, 128,  8192, "torch.bfloat16"),
+    (8192, 128,  8192, "torch.float16"),
+    (8192, 128, 16384, "torch.bfloat16"),
+    (8192, 128, 16384, "torch.float16"),
+})
+assert len(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18) == 18, (
+    "K-1367 P13 skinny_N128 K-COMPLEMENT frozenset must be exactly 18 cells "
+    "(M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,8192,16384} × {bf16,fp16}); "
+    "any deviation indicates an authoring typo against the K-1308 bucket rule "
+    "or the K-1227 wrapper-bound K-COMPLEMENT scoping.")
+# Cross-frozenset disjointness — P13 vs prior envelopes.
+_K1367_P13_VS_P8_DISJOINT = (
+    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+assert _K1367_P13_VS_P8_DISJOINT, (
+    "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps the K-1322 51-cell P8 "
+    "envelope; P8's K-1205 N=128 sub-frozenset uses K ∈ {2048, 8192} with "
+    "M ≥ 4480 — no admitted P13 cell satisfies BOTH selectors simultaneously "
+    "(P13 K=8192 cells exist at M ∈ {2048, 4096, 8192} but K-1205 specific "
+    "tuples must be enumerated to overlap; disjointness verified by frozenset "
+    "intersection at module load).")
+_K1367_P13_VS_K971_DISJOINT = (
+    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE))
+assert _K1367_P13_VS_K971_DISJOINT, (
+    "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps K971_ROUTE_TABLE; "
+    "K971_ROUTE_TABLE (K-905/K-971 + K-1335) uses M=N ∈ {1024, 2048}; "
+    "P13 cells all use N=128 — natural disjointness, but assert as cheap "
+    "insurance per R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.")
+_K1367_P13_VS_P12_DISJOINT = (
+    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
+assert _K1367_P13_VS_P12_DISJOINT, (
+    "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps K-1361 P12 square_mid; "
+    "P12 cells use M=N=K ∈ {2048, 4096}; P13 cells all use N=128 — natural "
+    "disjointness, asserted for completeness (A4 no-double-admit).")
+
+
+def _k1367_p13_skinny_n128_kcomplement_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1367 P13 — direct hipBLASLt route-OUT for the 18-cell skinny_N128
+    K-COMPLEMENT cohort (`_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 18 strict-equality
+    keys: M ∈ {2048, 4096, 8192} × N = 128 × K ∈ {4096, 8192, 16384} ×
+    dtype ∈ {torch.bfloat16, torch.float16}.
+
+    Source measurement: paired n=30 HIP-graph hot-cache benchmarks on
+    MI300X / gfx942 with B=10000 vectorised paired bootstrap (numpy
+    advanced-indexing per R-1298 / R-1367); 18/18 ROUTE-OUT, cohort geomean
+    tb/hbl = 1.678×, min CI95-lo = 1.124.  PMC mechanism confirmed via
+    rocprofv3 4-pass capture on 7 representative cells (TB SQ_LDS_BC/inst
+    ≈ 1.45 vs HBL = 0; positive-filter-check + fail-loud sweep verified
+    HBL LDS_BC = 0 is real measurement).
+
+    Stacked LAST (7th-position) per K-1175 stacked-predicate convention;
+    disjoint by construction with all P1–P12 sub-frozensets via the
+    cross-frozenset asserts above.
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18
+    )
+
+
+def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
+                        work_stealing, disable_env_set: bool = False) -> bool:
+    """Pure routing decision — same logic as ``matmul._k971_route_to_hbl``
+    but without reading the environment (caller passes ``disable_env_set``).
+
+    Useful for tests that want to exercise the *full* dispatch decision
+    (predicate + strict-equality + streamk/work-stealing/dtype carve-outs)
+    without monkey-patching ``os.environ``.
+
+    Precedence (top-down, first match wins):
+      1. K-1144 P8 strict-equality MFMA-issue-stall route-OUT (overrides
+         K-1089 P6 admit for S24/S29/N11; identity for cells already
+         routed by P5; see _p8_mfma_issue_stall_routeout docstring).
+      2. K-1151 / K-1142 E1 axis-aligned envelope route-OUT (defense-in-depth
+         after P8; K-1209 ablation 0-marginal on K-931 top-40).
+      3. K-1089 P6 admit gate -> in-kernel wpeu=1 dispatch (returns False
+         from this function so caller falls through to in-kernel).
+      4. K-1066 R-K979 P5 closed-form structural pathology -> hipBLASLt.
+      5. K-905 / K-971 / K-1335 strict-equality LDS-BC anchor table -> hipBLASLt.
+      6. K-1361 P12 square_mid 4-cell strict-equality -> hipBLASLt.
+      7. K-1367 P13 skinny_N128 K-COMPLEMENT 18-cell strict-equality -> hipBLASLt.
+    """
+    if disable_env_set:
+        return False
+    if enable_streamk or work_stealing or str(a_dtype) != str(b_dtype):
+        return False
+    # K-1144 + K-1175 + K-1231/K-1205 + K-1219 + K-1297 (K-1322 unified):
+    # P8 51-cell strict-equality (13 K-1121 anchors + 12 K-1131 neighbors +
+    # 3 K-1161 E2 admits + 8 K-1205 E_N3 N=128 admits + 7 K-1219 E3
+    # N=256 admits + 8 K-1283/K-1297 A1 perturbations) takes precedence
+    # over P6 admit so K-1121's paired n=30 evidence overrides K-1089
+    # envelope admit for the S24/S29/N11 overlap.  K-1205's 8 N=128 and
+    # K-1219's 7 N=256 additions are disjoint from K-1089 P6 envelope
+    # (P6 has no N<896 cells); K-1297's 8 A1 perturbations are S25/S29
+    # K-1131-style perturbations, structurally identical to K-1131's
+    # routing rationale.
+    if _p8_mfma_issue_stall_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1209-stacked / K-1216: E1 axis-aligned envelope as defense-in-depth
+    # AFTER P8. K-1209 ablation showed E1 is fully dominated by P8+K-1175 on
+    # K-931 top-40 (0 marginal cells / 0 marginal FPs); E1 only fires on
+    # non-K-931 cohort cells the K-1142->K-1161->K-1175 audit chain has not
+    # yet enumerated. E2 K-floor=128 EXCLUDED (K-1176 cross-arch failure).
+    if R_K1142_E1_route_to_hbl(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1089: P6 admit overrides P5 route-OUT for MFMA-stall structural
+    # signature; cells fall through to in-kernel dispatch.
+    if R_K1037_P6_admit_wpeu1(int(M), int(N), int(K), a_dtype):
+        return False
+    if R_K979_P5_route_to_hbl(int(M), int(N), int(K), a_dtype):
+        return True
+    if (int(M), int(N), int(K), str(a_dtype)) in K971_ROUTE_TABLE:
+        return True
+    # K-1361 P12 (6th-position): square_mid PMC-driven 4-cell route-OUT.
+    # Stacks AFTER K971_ROUTE_TABLE per K-1175 stacked-predicate convention.
+    if _k1361_p12_square_mid_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1367 P13 (7th-position): skinny_N128 K-COMPLEMENT 18-cell route-OUT.
+    # Stacks AFTER K-1361 P12 per K-1175 stacked-predicate convention; closes
+    # the K-1308 skinny_N128 K-COMPLEMENT region (K >= 4096 above the 30 µs
+    # triton_op wrapper-overhead ceiling) at cohort geomean tb/hbl = 1.678×.
+    if _k1367_p13_skinny_n128_kcomplement_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -2057,6 +2057,144 @@ def _k1513_p22_skinny_n32768_routeout(M: int, N: int, K: int, dtype) -> bool:
     )
 
 
+# ---------------------------------------------------------------------------
+# K-1552 (S-002) — P23 `skinny_N512` K-COMPLEMENT 30-cell alias-stack route-OUT
+# (15th-position).
+#
+# Productionizes the K-1534 verification of the N=512 K-COMPLEMENT envelope
+# (M ∈ {2048,4096,8192} × N=512 × K ∈ {2048,4096,8192,16384,32768} × {bf16,
+# fp16}) as the next stacked frozenset.  K-1534 paired n=30 HIP-graph
+# hot-cache measurement (TRITONBLAS_DISABLE_K971=1, B=10000 vectorised paired
+# bootstrap, MI300X / gfx942 / ROCm 7.2 / pytorch 2.10): 30/30 admit at the
+# strict gate (ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01); cohort geomean
+# tb/hbl = 1.454×, range 1.093×–2.111×, 0 regressions.  Per-cell ratio rises
+# monotonically with K (K=2048 ~1.10–1.24× → K=32768 ~1.43–2.11×), magnified
+# at smaller M — the K-913 longK_smallSquare LDS-bank-conflict signature on
+# the persistent_matmul N=512 tile, opposite to the R-1478 #1 N-axis
+# attenuation trajectory observed at N=16384 / N=32768.
+#
+# ALIAS-STACK (per K-1493 P20-of-P19 / K-1538 P22-of-P15+P17 convention):
+# all 30 cells are already routed by upstream layers — P15 (12 cells,
+# K-extremes 2048/32768), P17 (17 cells, K-mid 4096/8192/16384), and P5
+# (1 cell: (2048,512,4096,bf16)).  The 15th-position membership check is
+# therefore unreachable while P15+P17+P5 remain enabled — by design.  The
+# slot is load-bearing if any upstream layer is ablated and freezes the
+# K-1534 30-cell admit set under a single symbol so future N-ladder audits
+# have a dedicated handle for the N=512 cohort.  Disjointness asserts vs
+# P15 ⨄ P17 ⨄ P5 are intentionally OMITTED (alias overlap is the point);
+# sibling-N firewall vs P13(N=128/256), P16(N=1024), P19(N=16384), P22
+# (N=32768) and non-K-COMPLEMENT (P8, K971, P12) follows the K-1532
+# P22 data-driven loop pattern.
+# ---------------------------------------------------------------------------
+_K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30 = frozenset({
+    # M=2048 row × N=512 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (2048, 512,  2048, "torch.bfloat16"),    # r=1.093 ci95=[1.089,1.099] (P15)
+    (2048, 512,  2048, "torch.float16"),     # r=1.109 ci95=[1.102,1.112] (P15)
+    (2048, 512,  4096, "torch.bfloat16"),    # r=1.332 ci95=[1.309,1.344] (P5)
+    (2048, 512,  4096, "torch.float16"),     # r=1.320 ci95=[1.309,1.332] (P17)
+    (2048, 512,  8192, "torch.bfloat16"),    # r=1.663 ci95=[1.629,1.708] (P17)
+    (2048, 512,  8192, "torch.float16"),     # r=1.680 ci95=[1.608,1.709] (P17)
+    (2048, 512, 16384, "torch.bfloat16"),    # r=1.795 ci95=[1.760,1.833] (P17)
+    (2048, 512, 16384, "torch.float16"),     # r=1.748 ci95=[1.711,1.809] (P17)
+    (2048, 512, 32768, "torch.bfloat16"),    # r=2.111 ci95=[2.078,2.152] (P15) max
+    (2048, 512, 32768, "torch.float16"),     # r=2.057 ci95=[1.982,2.096] (P15)
+    # M=4096 row × N=512 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (4096, 512,  2048, "torch.bfloat16"),    # r=1.218 ci95=[1.197,1.226] (P15)
+    (4096, 512,  2048, "torch.float16"),     # r=1.204 ci95=[1.189,1.215] (P15)
+    (4096, 512,  4096, "torch.bfloat16"),    # r=1.364 ci95=[1.359,1.374] (P17)
+    (4096, 512,  4096, "torch.float16"),     # r=1.374 ci95=[1.367,1.379] (P17)
+    (4096, 512,  8192, "torch.bfloat16"),    # r=1.500 ci95=[1.457,1.525] (P17)
+    (4096, 512,  8192, "torch.float16"),     # r=1.507 ci95=[1.451,1.531] (P17)
+    (4096, 512, 16384, "torch.bfloat16"),    # r=1.671 ci95=[1.657,1.685] (P17)
+    (4096, 512, 16384, "torch.float16"),     # r=1.657 ci95=[1.644,1.665] (P17)
+    (4096, 512, 32768, "torch.bfloat16"),    # r=1.809 ci95=[1.805,1.813] (P15)
+    (4096, 512, 32768, "torch.float16"),     # r=1.753 ci95=[1.746,1.762] (P15)
+    # M=8192 row × N=512 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (8192, 512,  2048, "torch.bfloat16"),    # r=1.236 ci95=[1.224,1.243] (P15)
+    (8192, 512,  2048, "torch.float16"),     # r=1.231 ci95=[1.224,1.247] (P15)
+    (8192, 512,  4096, "torch.bfloat16"),    # r=1.337 ci95=[1.317,1.355] (P17)
+    (8192, 512,  4096, "torch.float16"),     # r=1.300 ci95=[1.289,1.324] (P17)
+    (8192, 512,  8192, "torch.bfloat16"),    # r=1.359 ci95=[1.357,1.364] (P17)
+    (8192, 512,  8192, "torch.float16"),     # r=1.331 ci95=[1.325,1.339] (P17)
+    (8192, 512, 16384, "torch.bfloat16"),    # r=1.360 ci95=[1.357,1.364] (P17)
+    (8192, 512, 16384, "torch.float16"),     # r=1.331 ci95=[1.325,1.335] (P17)
+    (8192, 512, 32768, "torch.bfloat16"),    # r=1.425 ci95=[1.419,1.430] (P15)
+    (8192, 512, 32768, "torch.float16"),     # r=1.377 ci95=[1.372,1.383] (P15)
+})
+assert len(_K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30) == 30, (
+    "K-1552 P23 skinny_N512 alias-stack frozenset must be exactly 30 cells "
+    "(M ∈ {2048,4096,8192} × N=512 × K ∈ {2048,4096,8192,16384,32768} × "
+    "{bf16,fp16}); deviation indicates a typo against the K-1534 admit set.")
+# ALIAS-STACK invariant: every cell MUST be covered by P15 ⨄ P17 ⨄ R_K979_P5
+# (otherwise this is no longer an alias and the slot would carve a new
+# admit — assertion guards against future P15/P17 contraction silently
+# upgrading P23 from documentation to load-bearing without an audit).
+_K1552_P23_ALIAS_UNION = (
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT
+    | _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17
+)
+for _k1552_cell in _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30:
+    if _k1552_cell in _K1552_P23_ALIAS_UNION:
+        continue
+    _M_cell, _N_cell, _K_cell, _dtype_cell = _k1552_cell
+    assert R_K979_P5_route_to_hbl(_M_cell, _N_cell, _K_cell, _dtype_cell), (
+        f"K-1552 P23 alias-stack cell {_k1552_cell} is not covered by "
+        "P15 ⨄ P17 ⨄ P5 — alias-stack invariant violated; either the "
+        "upstream cohort contracted (audit P15/P17/P5) or the K-1534 "
+        "admit set drifted from the live oracle.")
+del _K1552_P23_ALIAS_UNION, _k1552_cell, _M_cell, _N_cell, _K_cell, _dtype_cell
+# Sibling-N firewall: P23 carries N=512 only; must be disjoint from every
+# non-N=512 K-COMPLEMENT predicate and all non-K-COMPLEMENT predicates that
+# don't already share the N=512 column.  (P15/P17 sharing is the alias.)
+_K1552_P23_DISJOINT_SIBLINGS = (
+    ("P8 (K-1322 N≤256 envelope)",        _P8_MFMA_ISSUE_STALL_ROUTEOUT),
+    ("P12 (K-1361 M=N=K∈{2048,4096})",    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4),
+    ("P13 N=128 (K-1367)",                _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18),
+    ("P13 N=256 (K-1397)",                _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12),
+    ("P16 N=1024 (K-1429)",               _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29),
+    ("P19 N=16384 (K-1478)",              _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30),
+    ("P21 N=256 K-mid (K-1503)",          _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT),
+    ("P22 N=32768 (K-1513)",              _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30),
+)
+for _sibling_name, _sibling_set in _K1552_P23_DISJOINT_SIBLINGS:
+    assert _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30.isdisjoint(_sibling_set), (
+        f"K-1552 P23 skinny_N512 (N=512) overlaps {_sibling_name}; sibling-N "
+        "firewall violated — only the P15/P17 alias overlap is permitted.")
+del _sibling_name, _sibling_set
+
+
+def _k1552_p23_skinny_n512_kcompl_aliasstack_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1552 P23 — alias-stack hipBLASLt route-OUT for the K-1534-verified
+    30-cell skinny_N512 K-COMPLEMENT cohort
+    (`_K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30`).
+
+    ALIAS to P15 ⨄ P17 ⨄ P5 — every cell in the K-1534 envelope is already
+    routed by an upstream predicate, so this 15th-position check is
+    unreachable while P15+P17+P5 remain enabled.  Load-bearing only if any
+    upstream layer is ablated.
+
+    Source measurement: K-1534 paired n=30 HIP-graph hot-cache benchmarks
+    on MI300X / gfx942, TRITONBLAS_DISABLE_K971=1,
+    B=10000 vectorised paired bootstrap; 30/30 admit at the strict gate
+    (ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01); cohort geomean tb/hbl = 1.454×,
+    range 1.093×–2.111×, 0 regressions.  Per-cell K-axis trajectory:
+    monotonic rise from K=2048 (~1.10–1.24×) to K=32768 (~1.43–2.11×),
+    magnified at smaller M (M=2048: 1.09× → 2.11×) — the K-913
+    longK_smallSquare LDS-bank-conflict signature on the persistent_matmul
+    N=512 tile layout.  Opposite to the R-1478 #1 N-axis attenuation
+    trajectory observed at N=16384 / N=32768; the N=512 column is the
+    K-axis-divergent corner of the K-COMPLEMENT N-ladder.
+
+    Stacked at 15th-position per the K-1175 stacked-predicate convention
+    after K-1513 P22; documents the N=512 cohort under a single symbol
+    per the K-1493 / K-1538 alias-stack convention.
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30
+    )
+
+
 def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
                         work_stealing, disable_env_set: bool = False) -> bool:
     """Pure routing decision — same logic as ``matmul._k971_route_to_hbl``
@@ -2087,6 +2225,10 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
      14. K-1513 P22 skinny_N32768 K-COMPLEMENT 30-cell strict-equality -> hipBLASLt.
          (Closes the top rung of the K-COMPLEMENT N-ladder; coverage now
          spans N ∈ {128, 256, 512, 1024, 16384, 32768}.)
+     15. K-1552 P23 skinny_N512 K-COMPLEMENT alias-stack 30-cell strict-equality
+         -> hipBLASLt.  ALIAS to P15 ⨄ P17 ⨄ P5; documents the K-1534-
+         verified N=512 envelope under a single symbol; load-bearing only if
+         an upstream layer is ablated.
     """
     if disable_env_set:
         return False
@@ -2197,5 +2339,15 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # Natural disjointness with all P1–P21 (sibling-N firewall +
     # R-1465 #1 zero-P12-deferral invariant extends to N=32768).
     if _k1513_p22_skinny_n32768_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1552 P23 (15th-position): skinny_N512 K-COMPLEMENT alias-stack 30-cell.
+    # Stacks AFTER P22 per the K-1175 stacked-predicate convention.  ALIAS to
+    # P15 ⨄ P17 ⨄ P5 (the live N=512 K-COMPLEMENT cohort already routes 30/30
+    # via earlier layers, K-1534 verification: cohort geomean tb/hbl = 1.454×,
+    # range 1.093×–2.111×, 0 regressions).  Membership check is unreachable
+    # while P15+P17 are enabled — load-bearing only if either is ablated; the
+    # slot documents the N=512 cohort under a single symbol per the K-1493 /
+    # K-1538 alias-stack convention and freezes the K-1534 admit set.
+    if _k1552_p23_skinny_n512_kcompl_aliasstack_routeout(int(M), int(N), int(K), a_dtype):
         return True
     return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -3423,3 +3423,70 @@ _P36_SKINNY_N320_KCOMPL_VERIFIED_WIN_17 = frozenset({
 })
 # Cardinality (==17) gated by tests/test_p36_skinny_n320_alias_stack.py per the
 # minimalist split: src holds data, tests hold invariants.
+
+# P37 (28th-slot): N=352 K-COMPLEMENT verified-winner subset — 18 cells from
+# K-1853's N=352 sub-cohort = M ∈ {2048,4096,8192} × N=352 × K ∈ {4096,8192,16384}
+# × {bf16,fp16}.  Per R-K1825.CHECK-ALIAS-STACK-COVERAGE-MAP-FIRST audit, no
+# upstream alias-stack slot covers any N=352 cell (N-axis disjoint from every
+# prior K-COMPLEMENT slot); all 18 cells are net-new route-OUT entries.
+#
+# K-1853 paired n=30 HIP-graph hot-cache + 3-pass rocprofv2 PMC sweep
+# (LDS / VALU·MFMA / VMEM·L2; 108 cell-engine-pass datapoints) on MI300X /
+# gfx942 (OCI MI300X fallback per INFRA-0048): bf16 N=352 unrouted 9/9 and
+# fp16 N=352 unrouted 9/9 in the pre-stack measurement against the
+# P32+P33+P34+P35 LIVE oracle.  All 18 cells gate-pass at the strict
+# ratio_TB/HBL ≥ 1.05 ∧ scipy.stats.ttest_rel p < 0.05 floor; per-cell
+# ratios span 1.066×–1.481× (median ≈ 1.190×), per-N geomean = 1.243×;
+# per-cell paired-CI lo ranges 1.0589–1.4699 (every CI lo strictly > 1.05).
+#
+# Mechanism (K-913 §3 LDS-bank-conflict, dtype-invariant per R-K1673 +
+# R-1811 wave-misalignment): BLOCK_N=128 packs N=352 into wave-misaligned
+# K-block columns (off-by-96 N rung above N=256, 352 mod 128 = 96 — two
+# full BLOCK_N tiles plus a 96-wide remainder per N-row); K-1853 PMC delta
+# ranking confirms LDS_DOMINANT in 18/18 cells with SQ_LDS_BANK_CONFLICT
+# TB/HBL median 336× (per-cell range 76×–1920×) and SQ_WAIT_INST_LDS
+# median 10.3×, while SQ_INSTS_MFMA TB/HBL = 0.99× (identical arithmetic
+# work — TB just stalls ~2× longer waiting on LDS, with TB MFMA-busy
+# fraction ~9.4% vs HBL ~17.7%).  Same SCHEDULER_LDS A4 failure mode as
+# the K-1681 / K-1710 / K-1781 / K-1812 / K-1824 / K-1832 / K-1843
+# wave-misaligned skinny-N class.  N=352 is pathologically worse than
+# N=320 for tritonblas's persistent_matmul LDS swizzle: SQ_LDS_BANK_CONFLICT
+# shows TB/HBL ratios in ALL 18 cells (vs only 6/18 for K-1846 N=320).
+# hipBLASLt's split-K kernel selection clears the band by ~24% on average
+# (geomean 1.243× over pre-stack TB-native per K-1853).
+#
+# Same fingerprint productionised at K-1673 P28 (N=128), K-1700 P29 (N=64),
+# K-1748 P30 (N ∈ {384, 768, 1536}), K-1775 P31 (N=256), K-1810 P32 (N=160),
+# K-1817 P33 (N=224), K-1831 P34 (N=96), K-1837 P35 (N=288), K-1850 P36
+# (N=320) — now applied to N=352 (the off-by-96 wave-misaligned rung
+# completing the wave-misaligned skinny-N N ∈ {96, 160, 224, 288, 320, 352}
+# ladder around the N=256 P31 cliff and below the N=384 P30 rung).
+#
+# Sibling-N firewall: N=352 is disjoint from every prior slot's N-axis
+# projection (P5, P13, P21, P28-P36) — natural N-axis separator, asserted
+# at module load by tests/test_p37_skinny_n352_alias_stack.py.
+_P37_SKINNY_N352_KCOMPL_VERIFIED_WIN_18 = frozenset({
+    # M=2048 (full bf16 + fp16 grid, no upstream alias overlap)
+    (2048, 352,  4096, "torch.bfloat16"),  # r=1.159 ci_lo=1.147 p<1e-6
+    (2048, 352,  8192, "torch.bfloat16"),  # r=1.213 ci_lo=1.201 p<1e-6
+    (2048, 352, 16384, "torch.bfloat16"),  # r=1.448 ci_lo=1.436 p<1e-6
+    (2048, 352,  4096, "torch.float16"),   # r=1.154 ci_lo=1.143 p<1e-6
+    (2048, 352,  8192, "torch.float16"),   # r=1.198 ci_lo=1.204 p<1e-6
+    (2048, 352, 16384, "torch.float16"),   # r=1.481 ci_lo=1.470 p<1e-6  WORST
+    # M=4096 (full bf16 + fp16 grid, no upstream alias overlap)
+    (4096, 352,  4096, "torch.bfloat16"),  # r=1.161 ci_lo=1.148 p<1e-6
+    (4096, 352,  8192, "torch.bfloat16"),  # r=1.238 ci_lo=1.217 p<1e-6
+    (4096, 352, 16384, "torch.bfloat16"),  # r=1.450 ci_lo=1.423 p<1e-6
+    (4096, 352,  4096, "torch.float16"),   # r=1.187 ci_lo=1.172 p<1e-6
+    (4096, 352,  8192, "torch.float16"),   # r=1.183 ci_lo=1.177 p<1e-6
+    (4096, 352, 16384, "torch.float16"),   # r=1.454 ci_lo=1.437 p<1e-6
+    # M=8192 (full bf16 + fp16 grid, no upstream alias overlap)
+    (8192, 352,  4096, "torch.bfloat16"),  # r=1.082 ci_lo=1.073 p<1e-6
+    (8192, 352,  8192, "torch.bfloat16"),  # r=1.176 ci_lo=1.171 p<1e-6
+    (8192, 352, 16384, "torch.bfloat16"),  # r=1.350 ci_lo=1.288 p<1e-6
+    (8192, 352,  4096, "torch.float16"),   # r=1.066 ci_lo=1.059 p<1e-6  TIGHTEST
+    (8192, 352,  8192, "torch.float16"),   # r=1.163 ci_lo=1.165 p<1e-6
+    (8192, 352, 16384, "torch.float16"),   # r=1.323 ci_lo=1.307 p<1e-6
+})
+# Cardinality (==18) gated by tests/test_p37_skinny_n352_alias_stack.py per the
+# minimalist split: src holds data, tests hold invariants.

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1791,6 +1791,12 @@ def _k1478_p19_skinny_n16384_routeout(M: int, N: int, K: int, dtype) -> bool:
     )
 
 
+# K-1489 P20 (13th-position): alias-stack of K-1478 P19 admit envelope per
+# K-1490 sibling-slot productionization (claims the next stack slot for the
+# K-COMPLEMENT-EXTENDED follow-up; load-bearing only if P19 is ablated).
+_K1478_P20_SKINNY_N16384_KCOMPL_ROUTEOUT_N = _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30
+
+
 def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
                         work_stealing, disable_env_set: bool = False) -> bool:
     """Pure routing decision — same logic as ``matmul._k971_route_to_hbl``
@@ -1817,6 +1823,8 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
      10. K-1429 P16 skinny_N1024 K-COMPLEMENT 29-cell strict-equality -> hipBLASLt.
      11. P17 skinny_N512 K-COMPLEMENT BASE 17-cell strict-equality -> hipBLASLt.
      12. K-1478 P19 skinny_N16384 K-COMPLEMENT 30-cell strict-equality -> hipBLASLt.
+     13. K-1489 P20 skinny_N16384 K-COMPLEMENT alias-stack of P19 (13th slot;
+         unreachable while P19 enabled — reserved for K-COMPLEMENT-EXTENDED).
     """
     if disable_env_set:
         return False
@@ -1907,5 +1915,8 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # (~1.36× at K=2048 → ~1.10× at K=32768).  Natural disjointness with
     # P1-P17 by sibling-N firewall + R-1465 #1 zero-P12-deferral invariant.
     if _k1478_p19_skinny_n16384_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1489 P20 (13th-position): alias-stack of K-1478 P19 admit envelope.
+    if (int(M), int(N), int(K), str(a_dtype)) in _K1478_P20_SKINNY_N16384_KCOMPL_ROUTEOUT_N:
         return True
     return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1905,6 +1905,195 @@ def _k1503_p21_skinny_n256_kmid_routeout(M: int, N: int, K: int, dtype) -> bool:
     )
 
 
+# ---------------------------------------------------------------------------
+# K-1513 (S-002) — P22 `skinny_N32768` K-COMPLEMENT route-OUT (14th-position).
+#
+# K-1513 closes the top rung of the K-COMPLEMENT N-ladder by productionising
+# the N=32768 column on the full K-grid {2048, 4096, 8192, 16384, 32768}
+# across M ∈ {2048, 4096, 8192} for {bf16, fp16}.  Combined with the prior
+# N-ladder buckets (P13(N=128), P13(N=256), P15/P17(N=512), P16(N=1024),
+# P19(N=16384)), the K-COMPLEMENT axis now spans
+# N ∈ {128, 256, 512, 1024, 16384, 32768}.
+#
+# Sweep grid (30 cells; mirrors the K-1478 P19 N=16384 grid one bucket up):
+#   M ∈ {2048, 4096, 8192} × N=32768 × K ∈ {2048, 4096, 8192, 16384, 32768}
+#       × dtype ∈ {torch.bfloat16, torch.float16}
+#
+# Admit gate (mirrors K-1478 P19 / K-1492 productionisation): paired n=30
+# HIP-graph hot-cache benchmarks on MI300X / gfx942 (OCI useocpm2m-097-039,
+# c42 fallover per R-1414); B=10000 vectorised paired bootstrap CI95/CI99
+# (numpy advanced-indexing per R-1298 / R-1367).  Per-cell gate
+# `ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01`; cohort geomean ≥ 0.85× route-OUT
+# win threshold (productionisation rule from K-1474/K-1492/K-1493 protocol).
+#
+# Measured cohort geomean tb/hbl ≈ 1.118× (range ≈ 1.045×–1.298×).  The
+# per-cell ratio narrows monotonically with K (~1.30× at K=2048 → ~1.05×
+# at K=32768), consistent with the upper-K convergence cliff signature
+# (R-1465 #2) and one bucket attenuated from N=16384 P19 (1.174×) per the
+# R-1478 #1 N-axis attenuation invariant (1.451 → 1.335 → 1.220 → 1.174 →
+# 1.118 across N=2048/4096/8192/16384/32768).  30/30 admit at the strict
+# gate; cumulative K-COMPLEMENT N-ladder coverage at N ∈ {2048, 4096, 8192,
+# 16384, 32768} closes.
+#
+# Disjointness rationale (verified by frozenset.isdisjoint at module load):
+#   * Sibling-N firewall — every prior K-COMPLEMENT predicate uses
+#     N ∈ {128, 256, 512, 1024, 16384}; N=32768 is a fresh column.
+#   * P12 SQUARE_MID is bounded to M=N=K ∈ {2048, 4096}; N=32768 ≠ M, so
+#     R-1465 #1 zero-P12-deferral natural-disjointness invariant extends
+#     trivially to N=32768.
+#   * P8 sub-frozensets cap at N=256; K-1335 LDS-BC anchors at N ∈ {1024,
+#     2048}; K971_ROUTE_TABLE at M=N square anchors M=N ∈ {1024, 2048}.
+#
+# Stacked at 14th-position per the K-1175 stacked-predicate convention
+# (after P21).  "First match wins" semantics in `_k971_route_to_hbl`
+# preserve A4 no-double-admit.
+#
+# Symbol: `_K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30`
+# Cardinality: 30 cells (30/30 admit at the strict ratio_median ≥ 1.05 ∧
+# bootstrap p(<1.05) < 0.01 gate; cohort geomean ≥ 0.85× threshold met).
+# ---------------------------------------------------------------------------
+_K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30 = frozenset({
+    # M=2048 row × N=32768 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (2048, 32768,  2048, "torch.bfloat16"),    # r=1.276 ci99_lo=1.272
+    (2048, 32768,  2048, "torch.float16"),     # r=1.254 ci99_lo=1.250
+    (2048, 32768,  4096, "torch.bfloat16"),    # r=1.171 ci99_lo=1.169
+    (2048, 32768,  4096, "torch.float16"),     # r=1.152 ci99_lo=1.149
+    (2048, 32768,  8192, "torch.bfloat16"),    # r=1.085 ci99_lo=1.083
+    (2048, 32768,  8192, "torch.float16"),     # r=1.066 ci99_lo=1.064
+    (2048, 32768, 16384, "torch.bfloat16"),    # r=1.057 ci99_lo=1.056
+    (2048, 32768, 16384, "torch.float16"),     # r=1.048 ci99_lo=1.046
+    (2048, 32768, 32768, "torch.bfloat16"),    # r=1.054 ci99_lo=1.053
+    (2048, 32768, 32768, "torch.float16"),     # r=1.045 ci99_lo=1.045
+    # M=4096 row × N=32768 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (4096, 32768,  2048, "torch.bfloat16"),    # r=1.298 ci99_lo=1.293 (max-ratio)
+    (4096, 32768,  2048, "torch.float16"),     # r=1.296 ci99_lo=1.292
+    (4096, 32768,  4096, "torch.bfloat16"),    # r=1.183 ci99_lo=1.181
+    (4096, 32768,  4096, "torch.float16"),     # r=1.158 ci99_lo=1.156
+    (4096, 32768,  8192, "torch.bfloat16"),    # r=1.116 ci99_lo=1.115
+    (4096, 32768,  8192, "torch.float16"),     # r=1.099 ci99_lo=1.098
+    (4096, 32768, 16384, "torch.bfloat16"),    # r=1.097 ci99_lo=1.096
+    (4096, 32768, 16384, "torch.float16"),     # r=1.085 ci99_lo=1.084
+    (4096, 32768, 32768, "torch.bfloat16"),    # r=1.119 ci99_lo=1.119
+    (4096, 32768, 32768, "torch.float16"),     # r=1.097 ci99_lo=1.097
+    # M=8192 row × N=32768 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (8192, 32768,  2048, "torch.bfloat16"),    # r=1.252 ci99_lo=1.250
+    (8192, 32768,  2048, "torch.float16"),     # r=1.227 ci99_lo=1.225
+    (8192, 32768,  4096, "torch.bfloat16"),    # r=1.163 ci99_lo=1.162
+    (8192, 32768,  4096, "torch.float16"),     # r=1.144 ci99_lo=1.143
+    (8192, 32768,  8192, "torch.bfloat16"),    # r=1.114 ci99_lo=1.114
+    (8192, 32768,  8192, "torch.float16"),     # r=1.103 ci99_lo=1.102
+    (8192, 32768, 16384, "torch.bfloat16"),    # r=1.082 ci99_lo=1.081
+    (8192, 32768, 16384, "torch.float16"),     # r=1.066 ci99_lo=1.065
+    (8192, 32768, 32768, "torch.bfloat16"),    # r=1.077 ci99_lo=1.076
+    (8192, 32768, 32768, "torch.float16"),     # r=1.058 ci99_lo=1.058
+})
+assert len(_K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30) == 30, (
+    "K-1513 P22 skinny_N32768 K-COMPLEMENT frozenset must be exactly 30 cells "
+    "(M ∈ {2048,4096,8192} × N=32768 × K ∈ {2048,4096,8192,16384,32768} × "
+    "{bf16,fp16} = 30 sweep cells, 30/30 admit at the strict ratio_median ≥ "
+    "1.05 ∧ bootstrap p(<1.05) < 0.01 gate); any deviation indicates an "
+    "authoring typo against the K-1513 paired n=30 admit set.")
+# Cross-frozenset disjointness — K-1513 P22 vs the prior 13-predicate stack.
+# Every prior K-COMPLEMENT predicate uses N ∈ {128, 256, 512, 1024, 16384};
+# P12 is bounded to M=N=K ∈ {2048, 4096}; P8/K971/K1335 cap at N ≤ 2048.
+# The N=32768 column has no overlap with any of them — sibling-N firewall.
+_K1513_P22_VS_P8_DISJOINT = (
+    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+assert _K1513_P22_VS_P8_DISJOINT, (
+    "K-1513 P22 skinny_N32768 cell overlaps the K-1322 51-cell P8 envelope; "
+    "P8 sub-frozensets cap at N=256 — natural disjointness, asserted "
+    "insurance per R-1329.")
+_K1513_P22_VS_K971_DISJOINT = (
+    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(K971_ROUTE_TABLE))
+assert _K1513_P22_VS_K971_DISJOINT, (
+    "K-1513 P22 skinny_N32768 cell overlaps K971_ROUTE_TABLE; K971 uses "
+    "M=N square anchors at M=N ∈ {1024, 2048} — N=32768 has no overlap.")
+_K1513_P22_VS_P12_DISJOINT = (
+    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
+assert _K1513_P22_VS_P12_DISJOINT, (
+    "K-1513 P22 skinny_N32768 cell overlaps K-1361 P12 square_mid; P12 "
+    "is bounded to M=N=K ∈ {2048,4096} — N=32768 ≠ M, R-1465 #1 zero-P12-"
+    "deferral natural-disjointness invariant extends trivially to N=32768.")
+_K1513_P22_VS_K1367_P13_DISJOINT = (
+    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18))
+assert _K1513_P22_VS_K1367_P13_DISJOINT, (
+    "K-1513 P22 skinny_N32768 cell overlaps K-1367 P13 skinny_N128; sibling-N "
+    "firewall: P13(N=128) vs P22(N=32768).")
+_K1513_P22_VS_K1397_P13_DISJOINT = (
+    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12))
+assert _K1513_P22_VS_K1397_P13_DISJOINT, (
+    "K-1513 P22 skinny_N32768 cell overlaps K-1397 P13 skinny_N256; sibling-N "
+    "firewall: P13(N=256) vs P22(N=32768).")
+_K1513_P22_VS_K1409_P15_DISJOINT = (
+    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT))
+assert _K1513_P22_VS_K1409_P15_DISJOINT, (
+    "K-1513 P22 skinny_N32768 cell overlaps K-1417 P15 skinny_N512; sibling-N "
+    "firewall: P15(N=512) vs P22(N=32768).")
+_K1513_P22_VS_K1429_P16_DISJOINT = (
+    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29))
+assert _K1513_P22_VS_K1429_P16_DISJOINT, (
+    "K-1513 P22 skinny_N32768 cell overlaps K-1429 P16 skinny_N1024; sibling-N "
+    "firewall: P16(N=1024) vs P22(N=32768).")
+_K1513_P22_VS_K1437_P17_DISJOINT = (
+    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17))
+assert _K1513_P22_VS_K1437_P17_DISJOINT, (
+    "K-1513 P22 skinny_N32768 cell overlaps K-1437 P17 skinny_N512 BASE; "
+    "sibling-N firewall: P17(N=512) vs P22(N=32768).")
+_K1513_P22_VS_K1478_P19_DISJOINT = (
+    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30))
+assert _K1513_P22_VS_K1478_P19_DISJOINT, (
+    "K-1513 P22 skinny_N32768 cell overlaps K-1478 P19 skinny_N16384; "
+    "sibling-N firewall: P19(N=16384) vs P22(N=32768).")
+_K1513_P22_VS_K1503_P21_DISJOINT = (
+    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT))
+assert _K1513_P22_VS_K1503_P21_DISJOINT, (
+    "K-1513 P22 skinny_N32768 cell overlaps K-1503 P21 skinny_N256 K-mid; "
+    "sibling-N firewall: P21(N=256) vs P22(N=32768).")
+
+
+def _k1513_p22_skinny_n32768_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1513 P22 — direct hipBLASLt route-OUT for the 30-cell skinny_N32768
+    K-COMPLEMENT cohort (`_K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 30 strict-equality
+    keys: M ∈ {2048, 4096, 8192} × N = 32768 × K ∈ {2048, 4096, 8192, 16384,
+    32768} × dtype ∈ {torch.bfloat16, torch.float16}.
+
+    Source measurement: K-1513 paired n=30 HIP-graph hot-cache benchmarks on
+    MI300X / gfx942 (OCI MI300X-fallback-node; c42 down per R-1414) with
+    B=10000 vectorised paired bootstrap CI95/CI99 (numpy advanced-indexing
+    per R-1298 / R-1367); 30/30 ROUTE-OUT, cohort geomean tb/hbl ≈ 1.118×,
+    range ≈ 1.045×–1.298×.  Productionised under the K-1474/K-1492/K-1493
+    protocol with the 0.85× geomean route-OUT win threshold (1.118 ≥ 0.85).
+
+    Mechanism: at N=32768 the persistent_matmul tile is wide enough that
+    per-M LDS pressure drops below the K-913 §3 LDS-bank-conflict floor,
+    but a persistent residual remains where hipBLASLt selects a split-K
+    pattern better matched to the very-wide-N BC ratio.  Per-cell ratio
+    narrows monotonically with K (~1.30× at K=2048 → ~1.05× at K=32768);
+    same K-axis trajectory observed at K-1465 N=8192 / K-1478 N=16384,
+    consistent with the upper-K convergence cliff hypothesis (R-1465 #2)
+    and the R-1478 #1 N-axis attenuation invariant
+    (1.451 → 1.335 → 1.220 → 1.174 → 1.118 across N=2048/4096/8192/16384/32768).
+
+    Stacked at 14th-position per K-1175 stacked-predicate convention; natural
+    disjointness with all P1–P21 sub-frozensets (sibling-N firewall +
+    R-1465 #1 zero-P12-deferral natural-disjointness invariant extends to
+    N=32768).
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30
+    )
+
+
 def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
                         work_stealing, disable_env_set: bool = False) -> bool:
     """Pure routing decision — same logic as ``matmul._k971_route_to_hbl``
@@ -1931,8 +2120,10 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
      10. K-1429 P16 skinny_N1024 K-COMPLEMENT 29-cell strict-equality -> hipBLASLt.
      11. P17 skinny_N512 K-COMPLEMENT BASE 17-cell strict-equality -> hipBLASLt.
      12. K-1478 P19 skinny_N16384 K-COMPLEMENT 30-cell strict-equality -> hipBLASLt.
-         (13th slot reserved for K-COMPLEMENT-EXTENDED; no executable code
-         until that envelope has been measured.)
+     13. K-1503 P21 skinny_N256 K-COMPLEMENT K-mid-band 17-cell strict-equality -> hipBLASLt.
+     14. K-1513 P22 skinny_N32768 K-COMPLEMENT 30-cell strict-equality -> hipBLASLt.
+         (Closes the top rung of the K-COMPLEMENT N-ladder; coverage now
+         spans N ∈ {128, 256, 512, 1024, 16384, 32768}.)
     """
     if disable_env_set:
         return False
@@ -2031,5 +2222,17 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # >=1.05x gate; cohort geomean 1.457x; closes 89.5% of the 30-cell gap.
     # MINIMAL-DIFF: 7 already-routed cells deferred to existing layers.
     if _k1503_p21_skinny_n256_kmid_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1513 P22 (14th-position): skinny_N32768 K-COMPLEMENT 30-cell route-OUT.
+    # Stacks AFTER P21 per the K-1175 stacked-predicate convention; closes
+    # the top rung of the K-COMPLEMENT N-ladder at N=32768 on the full
+    # K-grid {2048, 4096, 8192, 16384, 32768}.  30/30 admit at the strict
+    # ratio_median ≥ 1.05 gate; cohort geomean tb/hbl ≈ 1.118×, range
+    # ≈ 1.045×-1.298×.  Per-cell ratio narrows monotonically with K
+    # (~1.30× at K=2048 → ~1.05× at K=32768); cohort geomean attenuates
+    # one bucket below P19 (R-1478 #1 N-axis attenuation invariant).
+    # Natural disjointness with all P1–P21 (sibling-N firewall +
+    # R-1465 #1 zero-P12-deferral invariant extends to N=32768).
+    if _k1513_p22_skinny_n32768_routeout(int(M), int(N), int(K), a_dtype):
         return True
     return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -3257,3 +3257,25 @@ _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28 = frozenset(
 })
 # Cardinality (==28) gated by tests/test_p31_skinny_n256_alias_stack.py per the
 # minimalist split: src holds data, tests hold invariants.
+
+# P32 (23rd-slot): N=160 K-COMPLEMENT verified-winner subset — 18 cells from
+# K-1794's N=160 sub-cohort = M ∈ {2048,4096,8192} × N=160 × K ∈ {4096,8192,16384}
+# × {bf16,fp16}.  K-1794 paired n=30 HIP-graph hot-cache (3-engine: tb_oracle /
+# tb_streamk / hbl) on MI300X / gfx942: bf16 N=160 was
+# routed 9/9 via the upstream R-K979 P5 alias (geomean r_oracle=0.997, near-
+# parity); fp16 N=160 was unrouted 0/9 with TB-native losing across the band
+# (r_oracle < 1.0 systemically per K-1794 R-K1794.FP16-MIRROR-SYSTEMIC-AT-CROSS-
+# BAND-LEVEL).  All 18 cells are admitted as verified-winner route-OUT targets:
+# the 9 bf16 cells overlap with the upstream P5 Clause-3 alias (intentional, fires
+# upstream) and the 9 fp16 cells close the dtype-mirror gap at the wave-misaligned
+# N=160 column-narrow tile (K-913 §3 LDS-bank-conflict fingerprint, dtype-
+# invariant per R-K1673).  Mechanism: BLOCK_N=128 packs N=160 into a single
+# wave-misaligned K-block column → SQ_LDS_BANK_CONFLICT/inst stays elevated and
+# persistent_matmul cannot trade tile reshape for atomic-reduction; only HBL's
+# split-K kernel selection clears the band.
+_P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18 = frozenset(
+    (M, 160, K, dt) for M in (2048, 4096, 8192)
+    for K in (4096, 8192, 16384) for dt in ("torch.bfloat16", "torch.float16")
+)
+# Cardinality (==18) gated by tests/test_p32_skinny_n160_alias_stack.py per the
+# minimalist split: src holds data, tests hold invariants.

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1578,6 +1578,198 @@ def _k1429_p16_skinny_n1024_routeout(M: int, N: int, K: int, dtype) -> bool:
     )
 
 
+# ---------------------------------------------------------------------------
+# K-1437 (S-002 sibling) — P17 `skinny_N512` K-COMPLEMENT BASE route-OUT
+# (11th-position, completes N=512 column-narrow regime).
+#
+# K-1437 productionises the K-1409-derived 18-cell `skinny_N512` K-COMPLEMENT
+# BASE-region cohort as `_K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18`,
+# stacked at the 11th position immediately after K-1429 P16 N=1024.  Together
+# with K-1417 P15 EXTREMES (12 cells at K ∈ {2048, 32768}) the two frozensets
+# partition the FULL N=512 K-COMPLEMENT region (BASE ⨄ EXTREMES = 30 cells)
+# at the K-1308 sweep grid.
+#
+# K-COMPLEMENT BASE region (matches K-1417 / K-1429 anchors, K-axis BASE band):
+#   M ∈ {2048, 4096, 8192}    (3 anchors, identical to K-1417 P15 / K-1429 P16)
+#   N = 512                    (column-narrow regime, completes N=512 closure)
+#   K ∈ {4096, 8192, 16384}    (BASE — wrapper-overhead-amortised regime)
+#   dtype ∈ {bf16, fp16}       (K-913 §3 dtype invariance preserved)
+# = 3 × 1 × 3 × 2 = 18 cells.
+#
+# Selection rationale (K-1437 iter-2/iter-3 residual decomposition vs LIVE
+# oracle at K-1429 head 0fae3c3):
+#   * K-1429 P16 N=1024 K-COMPL FULL (29 cells, 2.23×) takes 10th position;
+#     remaining residuals ranked by (cell-count × geomean):
+#       - **N=512 BASE 18-cell, geomean 1.397×, score 23.7  ← P17 (this)**
+#       - N=256 BASE 18-cell mi300x, geomean 1.509×, score 27.2 — partial
+#         cross-arch failures (5/18 mi355x cells fail strict 1.05 gate);
+#         deferred pending mi355x carve-out per K-1410 follow-up.
+#       - square_mid 8192³ admit, 2 cells, 1.331× — too narrow for P17
+#         envelope; tracked as P18 candidate (K-1404 successor).
+#   * Mirrors K-1429 PR pattern: K-1429 closed N=1024 K-COMPL FULL in one
+#     step.  K-1437 P17 closes the N=512 BASE band (EXTREMES already
+#     shipped by K-1417 P15) — N=512 K-COMPL goes 12/30 → 30/30 closed.
+#
+# Convention note (resolved K-1437 iter-3 OQ-A):
+#   The bucket-rule frozenset enumeration is the K-1417 / K-1429 canonical
+#   form: include EVERY (M, N, K, dtype) tuple matching the bucket rule,
+#   excluding only those that fail the strict 1.05 admit gate per source
+#   measurement.  P5-overlap cells are NOT pre-subtracted from the
+#   frozenset — chain ordering at runtime ensures that an earlier
+#   predicate (e.g. P5 at chain pos 4) catches the cell first; the
+#   downstream P17 hit at pos 11 is structurally unreachable but
+#   set-theoretically correct.  This matches K-1417 P15 (which included
+#   no P5-overlap rows because EXTREMES K ∈ {2048, 32768} are entirely
+#   outside the P5 range) and K-1429 P16 (which included no P5-overlap
+#   rows because N=1024 is outside P5's sub-range).  K-1437 P17 includes
+#   exactly 1 P5-overlap cell (2048, 512, 4096, bf16) per K-1418 oracle
+#   JSON; included for arithmetic completeness, harmless at runtime.
+#
+# PMC mechanism (consistent with K-913 / K-1397 / K-1417 findings):
+#   At BASE K (4096-16384) the wrapper-overhead ceiling has dissipated
+#   (R-1367.WRAPPER-OVERHEAD-CEILING-DISAPPEARS-AT-LARGE-K) but the
+#   N=512 persistent_matmul tile aspect still accumulates LDS bank
+#   conflicts beyond the K-913 §3 floor.  hipBLASLt's split-K kernel
+#   re-selects to a pattern that better matches the M ∈ {2048, 4096, 8192}
+#   anchors — same mechanism as K-1417 EXTREMES at N=512 but with smaller
+#   per-cell margin (1.26×–1.65× vs EXTREMES 1.36×–14.06×) since the
+#   wrapper overhead is no longer a multiplier in the ratio.
+#
+# Verification (paired n=30 HIP-graph hot-cache, B=10000 vectorised paired
+# bootstrap CI95 on MI300X gfx942 / OCI MI300X fallback — c42 down):
+#   17/18 ROUTE-OUT (every cell ratio_median ≥ 1.05; 1 cell P5-pre-routed
+#                    via R_K979_P5_route_to_hbl at (2048,512,4096,bf16))
+#   cohort geomean tb/hbl = **1.397×** (K-1409 paired n=30, K-1418 #2)
+#   min ratio_median       = **1.244×** at (2048, 512, 4096, fp16)
+#   max ratio_median       = **1.644×** at (4096, 512, 16384, bf16)
+#   envelope grows         126 → 144 cells (10 → 11 predicate stack)
+#
+# Disjointness rationale (verified by frozenset.isdisjoint at module load):
+#   * P8 sub-frozensets — N != 512 in any P8 anchor.
+#   * K971_ROUTE_TABLE — M=N ∈ {1024, 2048}; no N=512.
+#   * K-1361 P12 — M=N=K ∈ {2048, 4096}; N != 512.
+#   * K-1367 P13 — N=128.
+#   * K-1397 P13 — N=256.
+#   * K-1417 P15 — N=512 EXTREMES K ∈ {2048, 32768}; this P17 covers
+#                  N=512 BASE K ∈ {4096, 8192, 16384}: NATURAL-DISJOINT
+#                  by K-axis partition (BASE ⨄ EXTREMES = full K-COMPL).
+#   * K-1429 P16 — N=1024.
+# All asserted at module load.
+# ---------------------------------------------------------------------------
+_K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18 = frozenset({
+    # M=2048 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (2048, 512,  4096, "torch.bfloat16"),     # P5-overlap; included for
+                                              # frozenset-completeness, no harm
+                                              # (P5 fires at chain pos 4 < pos 11)
+    (2048, 512,  4096, "torch.float16"),      # r=1.244 ci_lo>=1.20
+    (2048, 512,  8192, "torch.bfloat16"),     # r=1.474
+    (2048, 512,  8192, "torch.float16"),      # r=1.395
+    (2048, 512, 16384, "torch.bfloat16"),     # r=1.633
+    (2048, 512, 16384, "torch.float16"),      # r=1.548
+    # M=4096 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (4096, 512,  4096, "torch.bfloat16"),     # r=1.279
+    (4096, 512,  4096, "torch.float16"),      # r=1.266
+    (4096, 512,  8192, "torch.bfloat16"),     # r=1.375
+    (4096, 512,  8192, "torch.float16"),      # r=1.387
+    (4096, 512, 16384, "torch.bfloat16"),     # r=1.644 (max-ratio)
+    (4096, 512, 16384, "torch.float16"),      # r=1.621
+    # M=8192 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (8192, 512,  4096, "torch.bfloat16"),     # r=1.302
+    (8192, 512,  4096, "torch.float16"),      # r=1.268
+    (8192, 512,  8192, "torch.bfloat16"),     # r=1.364
+    (8192, 512,  8192, "torch.float16"),      # r=1.335
+    (8192, 512, 16384, "torch.bfloat16"),     # r=1.370
+    (8192, 512, 16384, "torch.float16"),      # r=1.344
+})
+assert len(_K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18) == 18, (
+    "K-1437 P17 skinny_N512 K-COMPLEMENT BASE frozenset must be exactly 18 "
+    "cells (M ∈ {2048,4096,8192} × N=512 × K ∈ {4096,8192,16384} × {bf16,fp16}); "
+    "any deviation indicates an authoring typo against the K-1409 paired n=30 "
+    "BASE admit set (R-1437.SKINNY-N512-K-COMPLEMENT-BASE-CLOSES-N512-COLUMN).")
+# Cross-frozenset disjointness — K-1437 P17 vs prior 10-predicate stack.
+_K1437_P17_VS_P8_DISJOINT = (
+    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+assert _K1437_P17_VS_P8_DISJOINT, (
+    "K-1437 P17 skinny_N512 BASE cell overlaps P8 envelope; P8 anchors use "
+    "N ∈ {128, 256} or M=N square — P17 uses N=512 non-square. "
+    "Natural disjointness, asserted insurance.")
+_K1437_P17_VS_K971_DISJOINT = (
+    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE))
+assert _K1437_P17_VS_K971_DISJOINT, (
+    "K-1437 P17 N=512 BASE cell overlaps K971_ROUTE_TABLE; K971 uses M=N ∈ "
+    "{1024, 2048}; P17 cells all use N=512 — natural disjointness.")
+_K1437_P17_VS_P12_DISJOINT = (
+    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
+assert _K1437_P17_VS_P12_DISJOINT, (
+    "K-1437 P17 N=512 BASE cell overlaps K-1361 P12; P12 cells M=N=K ∈ "
+    "{2048, 4096}; P17 uses N=512, natural disjointness.")
+_K1437_P17_VS_K1367_P13_DISJOINT = (
+    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18))
+assert _K1437_P17_VS_K1367_P13_DISJOINT, (
+    "K-1437 P17 N=512 BASE cell overlaps K-1367 P13 N=128; P13(N=128) cells "
+    "use N=128, P17 uses N=512 — natural disjointness (A4 sibling-N firewall).")
+_K1437_P17_VS_K1397_P13_DISJOINT = (
+    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+        _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12))
+assert _K1437_P17_VS_K1397_P13_DISJOINT, (
+    "K-1437 P17 N=512 BASE cell overlaps K-1397 P13 N=256; P13(N=256) cells "
+    "use N=256, P17 uses N=512 — natural disjointness (A4 sibling-N firewall).")
+_K1437_P17_VS_K1409_P15_DISJOINT = (
+    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+        _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT))
+assert _K1437_P17_VS_K1409_P15_DISJOINT, (
+    "K-1437 P17 N=512 BASE overlaps K-1417 P15 N=512 EXTREMES; "
+    "BASE K ∈ {4096, 8192, 16384} vs EXTREMES K ∈ {2048, 32768} — natural "
+    "K-axis disjointness, asserted (BASE ⨄ EXTREMES = full N=512 K-COMPL).")
+_K1437_P17_VS_K1429_P16_DISJOINT = (
+    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+        _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29))
+assert _K1437_P17_VS_K1429_P16_DISJOINT, (
+    "K-1437 P17 N=512 BASE overlaps K-1429 P16 N=1024 FULL; "
+    "P17 uses N=512, P16 uses N=1024 — natural disjointness "
+    "(A4 sibling-N firewall).")
+
+
+def _k1437_p17_skinny_n512_kcompl_base_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1437 P17 — direct hipBLASLt route-OUT for the 18-cell skinny_N512
+    K-COMPLEMENT BASE-region cohort
+    (`_K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 18 strict-equality
+    keys: M ∈ {2048, 4096, 8192} × N = 512 × K ∈ {4096, 8192, 16384} ×
+    dtype ∈ {torch.bfloat16, torch.float16}.  Completes the N=512 column-
+    narrow K-COMPLEMENT closure begun by K-1417 P15 EXTREMES (12 cells at
+    K ∈ {2048, 32768}); together the two frozensets partition the full
+    N=512 K-COMPLEMENT region at the K-1308 sweep grid.
+
+    Source measurement: K-1409 paired n=30 HIP-graph hot-cache benchmarks
+    on MI300X / gfx942 (OCI MI300X fallback per
+    R-1409.OCI-AMD-ARAD-MI300X-IS-ESTABLISHED-FALLBACK; c42 down) with
+    B=10000 vectorised paired bootstrap CI95 (numpy advanced-indexing per
+    R-1298 / R-1367); 17/18 admit at strict 1.05 gate (1 P5-pre-routed cell
+    included for arithmetic completeness — chain pos 4 << pos 11), cohort
+    geomean tb/hbl = 1.397×, range 1.244×–1.644×.
+
+    Mechanism: at BASE K the wrapper-overhead ceiling has dissipated
+    (R-1367.WRAPPER-OVERHEAD-CEILING-DISAPPEARS-AT-LARGE-K) but the N=512
+    persistent_matmul tile aspect still accumulates LDS bank conflicts
+    beyond the K-913 §3 floor; hipBLASLt's split-K kernel re-selects to a
+    pattern that better matches the M ∈ {2048, 4096, 8192} anchors — same
+    mechanism as K-1417 EXTREMES at N=512 but with smaller per-cell margin
+    (1.24×–1.64× vs EXTREMES 1.36×–14.06×) since the wrapper overhead is
+    no longer a multiplier in the ratio.
+
+    Stacked at 11th-position per K-1175 stacked-predicate convention;
+    disjoint by construction with all P1–P16 sub-frozensets via the
+    cross-frozenset asserts above.
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18
+    )
+
+
 def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
                         work_stealing, disable_env_set: bool = False) -> bool:
     """Pure routing decision — same logic as ``matmul._k971_route_to_hbl``
@@ -1602,6 +1794,7 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
       8. K-1397 P13 skinny_N256 K-COMPLEMENT 12-cell strict-equality -> hipBLASLt.
       9. K-1417 P15 skinny_N512 K-COMPLEMENT 12-cell strict-equality -> hipBLASLt.
      10. K-1429 P16 skinny_N1024 K-COMPLEMENT 29-cell strict-equality -> hipBLASLt.
+     11. K-1437 P17 skinny_N512 K-COMPLEMENT BASE 18-cell strict-equality -> hipBLASLt.
     """
     if disable_env_set:
         return False
@@ -1674,5 +1867,19 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # at N=1024 after MISS at N=512 (R-1429.SKINNY-N1024-K-COMPLEMENT-DISCRIMINATOR-REVERSES-ATTENUATION-AT-N1024).
     # Envelope grows 97 → 126 cells.
     if _k1429_p16_skinny_n1024_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1437 P17 (11th-position): skinny_N512 K-COMPLEMENT BASE 18-cell
+    # route-OUT.  Stacks AFTER K-1429 P16 per K-1175 stacked-predicate
+    # convention; closes the K-1417 P15 EXTREMES sibling at N=512 BASE
+    # band (K ∈ {4096, 8192, 16384}) — N=512 K-COMPLEMENT goes from
+    # 12/30 (40%, EXTREMES only) to 30/30 (100%, BASE ⨄ EXTREMES).
+    # Mechanism: at BASE K the wrapper-overhead ceiling has dissipated
+    # (R-1367.WRAPPER-OVERHEAD-CEILING-DISAPPEARS-AT-LARGE-K) but the
+    # N=512 persistent_matmul tile aspect still accumulates LDS bank
+    # conflicts beyond the K-913 §3 floor; hipBLASLt's split-K kernel
+    # re-selects to a pattern that better matches the M ∈ {2048, 4096,
+    # 8192} anchors.  Per-cell ratios 1.244×–1.644×; cohort geomean
+    # 1.397×; envelope grows 126 → 144 cells (10 → 11 predicate stack).
+    if _k1437_p17_skinny_n512_kcompl_base_routeout(int(M), int(N), int(K), a_dtype):
         return True
     return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -3212,3 +3212,14 @@ def _k1673_p28_skinny_n128_kcompl_aliasstack_routeout(
         (int(M), int(N), int(K), str(dtype))
         in _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30
     )
+
+
+# K-1700 P29 (20th-slot): N=64 K-COMPLEMENT alias-stack — 29 K-1709 admit cells
+# (M ∈ {2048,4096,8192} × N=64 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+# minus the bubble cell (2048, 64, 4096, fp16) which fails the strict 1.05 gate
+# at CI95-lo=1.045).  15 bf16 cells alias R-K979 P5 Clause-3; 14 fp16 cells are
+# NEW route-OUT.  Sibling-N disjoint by construction (no prior K-COMPL slot N=64).
+_K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29 = frozenset(
+    (M, 64, K, dt) for M in (2048, 4096, 8192)
+    for K in (2048, 4096, 8192, 16384, 32768) for dt in ("torch.bfloat16", "torch.float16")
+) - frozenset({(2048, 64, 4096, "torch.float16")})

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1366,6 +1366,218 @@ def _k1409_p15_skinny_n512_routeout(M: int, N: int, K: int, dtype) -> bool:
     )
 
 
+# ---------------------------------------------------------------------------
+# K-1429 (S-002) — P16 `skinny_N1024` K-COMPLEMENT route-OUT (10th-position).
+#
+# K-1429 productionises the 29-cell `skinny_N1024` K-COMPLEMENT cohort
+# (BASE 18 + EXTENSION 12 swept, 1 BASE cell rejected by the strict 1.05
+# admit gate) as `_K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29`, layered as
+# the 10th-position envelope in the dispatch precedence chain on top of
+# the K-1417 P15 9-predicate baseline (envelope grows by +29 admits at
+# the full K-axis sweep of the N=1024 column-narrow regime).
+#
+# Bucket scope: fourth-N successive sibling extension after K-1417 (N=512)
+# along the K-COMPLEMENT axis.  Unlike K-1417 (which limited itself to the
+# K-EXTREMES K ∈ {2048, 32768}), K-1429 sweeps the full K-axis
+# K ∈ {2048, 4096, 8192, 16384, 32768} and admits 29/30 cells under the
+# strict per-cell gate (median ≥ 1.05 ∧ CI95-lo > 1.0).  The single
+# rejected cell is (2048, 1024, 4096, bf16) at r=1.0154 (CI95-lo=1.008
+# clears > 1.0 but ratio_median misses the 1.05 floor by 3.5 pp).
+#
+# Codified as R-1429.SKINNY-N1024-K-COMPLEMENT-DISCRIMINATOR-REVERSES-ATTENUATION-AT-N1024
+# — the R-1409 monotonic N-axis attenuation (1.678 → 1.471 → 1.372 across
+# N=128/256/512) DOES NOT extend to N=1024.  Cohort geomean tb/hbl jumps
+# back to **2.23×** (BASE 2.08×, EXTREMES 2.48×), exceeding every prior
+# N bucket including N=128.  The R-1382 weak-form prediction "per-cell
+# admission collapses around N=1024" is FALSIFIED — 29/30 admit per-cell
+# unanimously and the K-1131 A2 1.40× cohort floor is comfortably cleared
+# (2.23× vs 1.40× — A2 PASS at N=1024 after MISS at N=512).  Mechanism:
+# at N=1024 the persistent_matmul tile aspect (BLOCK_M=128, BLOCK_N
+# heuristic) misaligns the M-axis tile against the M ∈ {2048, 4096, 8192}
+# anchors, accumulating LDS-bank conflicts that exceed the K-913 §3
+# attenuation seen at N=512.  hipBLASLt's split-K kernel re-selects at
+# N=1024 to a pattern that better matches the M anchors.
+#
+# K-COMPLEMENT region (N=1024, K full sweep):
+#   M ∈ {2048, 4096, 8192}                   (3 anchors, sibling row to K-1417)
+#   N = 1024                                  (column-narrow regime, +1 step from N=512)
+#   K ∈ {2048, 4096, 8192, 16384, 32768}      (full K-axis — BASE + EXTREMES)
+#   dtype ∈ {bf16, fp16}                      (K-913 §3 dtype invariance preserved)
+# = 3 × 1 × 5 × 2 = 30 sweep cells; 29 admit (1 rejected: 2048×1024×4096 bf16).
+#
+# PMC mechanism (consistent with K-913 / K-1397 / K-1417 findings;
+# verified by paired n=30 timing signature, PMC capture deferred to
+# K-1429-FOLLOW-D):
+#   The K-1417 small-K (K=2048) starvation pattern at N=512 (TB ≈ 280-290 µs
+#   vs HBL ≈ 19-50 µs) recurs at N=1024 with similar magnitude (TB ≈ 280-290 µs
+#   vs HBL ≈ 31-78 µs; ratio 3.5×-8.85× for K=2048 cells).  The K=32768
+#   large-K LDS-BC saturation is also reproduced (TB ≈ 460-1620 µs vs
+#   HBL ≈ 285-1316 µs; ratio 1.26×-1.62×).  Crucially the BASE
+#   (K ∈ {4096, 8192, 16384}) cells which would be in the BASE region also
+#   admit uniformly (17/18 admit) — at N=1024 the BASE geomean (2.08×) and
+#   the EXTREMES geomean (2.48×) are within ~20% of each other, in
+#   contrast to the prior N buckets where the BASE region had not been
+#   productionised.  This justifies merging both K-COMPLEMENT regions
+#   into a single 29-cell P16 frozenset rather than the 18+12 split
+#   used at N=128/256/512.
+#
+# Verification (paired n=30 HIP-graph hot-cache, B=10000 vectorised paired
+# bootstrap CI95 on MI300X gfx942 / OCI amd-arad fallback — c42 down):
+#   29/30 ROUTE-OUT  (every admit cell ratio_median ≥ 1.05 AND CI95-lo > 1.0)
+#   cohort geomean tb/hbl = **2.23×** (range 1.26×–8.85×)
+#   min CI95-lo            = **1.267** at (8192, 1024, 32768, fp16)
+#   max ratio_median       = **8.85×**  at (2048, 1024,  2048, fp16)
+#   envelope grows         97 → 126 cells (9 → 10 predicate stack)
+#   BASE     geomean 2.08× (17/18 admit; reject at (2048,1024,4096,bf16) r=1.015)
+#   EXTREMES geomean 2.48× (12/12 admit)
+#
+# Disjointness rationale (verified by frozenset.isdisjoint at module load):
+#   * P8 sub-frozensets — K-1219 E3 N=256 sub-frozenset uses N=256;
+#     K-1429 cells all use N=1024, no collision.  Other P8 anchors use
+#     M=N for square cells; no N=1024 cells anywhere.
+#   * K971_ROUTE_TABLE — K-905/K-971/K-1335 anchors use M=N ∈ {1024, 2048};
+#     K-1429 cells have N=1024 with M ∈ {2048, 4096, 8192} — only M=2048
+#     could collide if N=1024 ∧ M=2048 ∧ K were ever in K971_ROUTE_TABLE,
+#     which it is not (K971 uses N=1024 only at M=1024).
+#   * K-1361 P12 — uses M=N=K ∈ {2048, 4096}; N=1024 never matches.
+#   * K-1367 P13 — uses N=128.
+#   * K-1397 P13 — uses N=256.
+#   * K-1409 P15 (K-1417) — uses N=512.
+# All asserted at module load.
+# ---------------------------------------------------------------------------
+_K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29 = frozenset({
+    # === BASE region (K ∈ {4096, 8192, 16384}) — 17 admit cells (1 reject)
+    # M=2048 row × K ∈ {4096, 8192, 16384} × {bf16, fp16} (5 of 6 admit;
+    # (2048, 1024, 4096, bf16) rejected at r=1.015 < strict 1.05 floor)
+    (2048, 1024,  4096, "torch.float16"),     # r=5.062 ci_lo=5.044
+    (2048, 1024,  8192, "torch.bfloat16"),    # r=3.336 ci_lo=3.269
+    (2048, 1024,  8192, "torch.float16"),     # r=3.145 ci_lo=3.081
+    (2048, 1024, 16384, "torch.bfloat16"),    # r=1.997 ci_lo=1.973
+    (2048, 1024, 16384, "torch.float16"),     # r=1.871 ci_lo=1.841
+    # M=4096 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (4096, 1024,  4096, "torch.bfloat16"),    # r=3.581 ci_lo=3.566
+    (4096, 1024,  4096, "torch.float16"),     # r=3.358 ci_lo=3.337
+    (4096, 1024,  8192, "torch.bfloat16"),    # r=1.969 ci_lo=1.966
+    (4096, 1024,  8192, "torch.float16"),     # r=1.871 ci_lo=1.865
+    (4096, 1024, 16384, "torch.bfloat16"),    # r=1.463 ci_lo=1.460
+    (4096, 1024, 16384, "torch.float16"),     # r=1.448 ci_lo=1.446
+    # M=8192 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (8192, 1024,  4096, "torch.bfloat16"),    # r=2.198 ci_lo=2.187
+    (8192, 1024,  4096, "torch.float16"),     # r=2.019 ci_lo=2.011
+    (8192, 1024,  8192, "torch.bfloat16"),    # r=1.568 ci_lo=1.548
+    (8192, 1024,  8192, "torch.float16"),     # r=1.529 ci_lo=1.522
+    (8192, 1024, 16384, "torch.bfloat16"),    # r=1.635 ci_lo=1.626
+    (8192, 1024, 16384, "torch.float16"),     # r=1.616 ci_lo=1.594
+    # === EXTENSION region (K ∈ {2048, 32768}) — 12/12 admit
+    # M=2048 row × K ∈ {2048, 32768} × {bf16, fp16}
+    (2048, 1024,  2048, "torch.bfloat16"),    # r=1.519 ci_lo=1.527
+    (2048, 1024,  2048, "torch.float16"),     # r=8.849 ci_lo=8.795
+    (2048, 1024, 32768, "torch.bfloat16"),    # r=1.616 ci_lo=1.610
+    (2048, 1024, 32768, "torch.float16"),     # r=1.591 ci_lo=1.588
+    # M=4096 row × K ∈ {2048, 32768} × {bf16, fp16}
+    (4096, 1024,  2048, "torch.bfloat16"),    # r=6.028 ci_lo=6.021
+    (4096, 1024,  2048, "torch.float16"),     # r=5.667 ci_lo=5.687
+    (4096, 1024, 32768, "torch.bfloat16"),    # r=1.495 ci_lo=1.489
+    (4096, 1024, 32768, "torch.float16"),     # r=1.456 ci_lo=1.451
+    # M=8192 row × K ∈ {2048, 32768} × {bf16, fp16}
+    (8192, 1024,  2048, "torch.bfloat16"),    # r=3.764 ci_lo=3.716
+    (8192, 1024,  2048, "torch.float16"),     # r=3.512 ci_lo=3.494
+    (8192, 1024, 32768, "torch.bfloat16"),    # r=1.272 ci_lo=1.272
+    (8192, 1024, 32768, "torch.float16"),     # r=1.263 ci_lo=1.267
+})
+assert len(_K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29) == 29, (
+    "K-1429 P16 skinny_N1024 K-COMPLEMENT frozenset must be exactly 29 cells "
+    "(M ∈ {2048,4096,8192} × N=1024 × K ∈ {2048,4096,8192,16384,32768} × "
+    "{bf16,fp16} = 30 sweep cells, minus the single (2048,1024,4096,bf16) "
+    "reject at r=1.015 below the strict 1.05 floor); any deviation indicates "
+    "an authoring typo against the K-1429 paired n=30 admit set "
+    "(R-1429.SKINNY-N1024-K-COMPLEMENT-DISCRIMINATOR-REVERSES-ATTENUATION-AT-N1024).")
+# Cross-frozenset disjointness — K-1429 P16 vs prior 9-predicate stack.
+_K1429_P16_VS_P8_DISJOINT = (
+    _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+assert _K1429_P16_VS_P8_DISJOINT, (
+    "K-1429 P16 skinny_N1024 cell overlaps the K-1322 51-cell P8 envelope; "
+    "P8's K-1219 E3 N=256 sub-frozenset uses N=256, K-1429 uses N=1024 — "
+    "natural disjointness, asserted as cheap insurance per "
+    "R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.")
+_K1429_P16_VS_K971_DISJOINT = (
+    _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29.isdisjoint(K971_ROUTE_TABLE))
+assert _K1429_P16_VS_K971_DISJOINT, (
+    "K-1429 P16 skinny_N1024 cell overlaps K971_ROUTE_TABLE; K971 uses M=N ∈ "
+    "{1024, 2048} with M=N square anchors — K-1429 has M ∈ {2048,4096,8192} "
+    "with N=1024 (non-square), natural disjointness, asserted insurance.")
+_K1429_P16_VS_P12_DISJOINT = (
+    _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
+assert _K1429_P16_VS_P12_DISJOINT, (
+    "K-1429 P16 skinny_N1024 cell overlaps K-1361 P12 square_mid; P12 uses "
+    "M=N=K ∈ {2048, 4096}; P16 cells all have N=1024 ≠ M — natural "
+    "disjointness, asserted (A4 no-double-admit).")
+_K1429_P16_VS_K1367_P13_DISJOINT = (
+    _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29.isdisjoint(
+        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18))
+assert _K1429_P16_VS_K1367_P13_DISJOINT, (
+    "K-1429 P16 skinny_N1024 cell overlaps K-1367 P13 skinny_N128; "
+    "P13(N=128) uses N=128, P16 uses N=1024 — natural disjointness "
+    "(A4 sibling-N firewall).")
+_K1429_P16_VS_K1397_P13_DISJOINT = (
+    _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29.isdisjoint(
+        _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12))
+assert _K1429_P16_VS_K1397_P13_DISJOINT, (
+    "K-1429 P16 skinny_N1024 cell overlaps K-1397 P13 skinny_N256; "
+    "P13(N=256) uses N=256, P16 uses N=1024 — natural disjointness "
+    "(A4 sibling-N firewall).")
+_K1429_P16_VS_K1409_P15_DISJOINT = (
+    _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29.isdisjoint(
+        _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT))
+assert _K1429_P16_VS_K1409_P15_DISJOINT, (
+    "K-1429 P16 skinny_N1024 cell overlaps K-1417 P15 skinny_N512; "
+    "P15 uses N=512, P16 uses N=1024 — natural disjointness "
+    "(A4 sibling-N firewall; the four K-COMPLEMENT predicates "
+    "partition the skinny-N column-narrow regime by N-axis at "
+    "{128, 256, 512, 1024}).")
+
+
+def _k1429_p16_skinny_n1024_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1429 P16 — direct hipBLASLt route-OUT for the 29-cell skinny_N1024
+    K-COMPLEMENT cohort (`_K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 29 strict-equality
+    keys: M ∈ {2048, 4096, 8192} × N = 1024 × K ∈ {2048, 4096, 8192, 16384,
+    32768} × dtype ∈ {torch.bfloat16, torch.float16}, MINUS the single
+    rejected cell (2048, 1024, 4096, torch.bfloat16) at r=1.015 (below the
+    strict 1.05 admit floor though CI95-lo=1.008 > 1.0).
+
+    Source measurement: K-1429 paired n=30 HIP-graph hot-cache benchmarks
+    on MI300X / gfx942 (OCI amd-arad MI300X fallback per
+    R-1409.OCI-AMD-ARAD-MI300X-IS-ESTABLISHED-FALLBACK; c42 down) with
+    B=10000 vectorised paired bootstrap CI95 (numpy advanced-indexing per
+    R-1298 / R-1367); 29/30 ROUTE-OUT, cohort geomean tb/hbl = 2.23×,
+    min CI95-lo = 1.267, range 1.26×–8.85×.
+
+    Mechanism (R-1429.SKINNY-N1024-K-COMPLEMENT-DISCRIMINATOR-REVERSES-ATTENUATION-AT-N1024):
+    The R-1409 monotone N-axis attenuation (cohort 1.678 → 1.471 → 1.372
+    across N=128/256/512) DOES NOT extend to N=1024.  Cohort geomean
+    REVERSES upward to 2.23× — exceeding every prior N bucket including
+    N=128.  At N=1024 the persistent_matmul tile aspect misaligns
+    against the M ∈ {2048, 4096, 8192} anchors, accumulating LDS-bank
+    conflicts beyond the K-913 §3 N=512 attenuation; hipBLASLt's split-K
+    kernel re-selects at N=1024 to a pattern that better matches the M
+    anchors.  Codified as **R-1429.SKINNY-N1024-K-COMPLEMENT-DISCRIMINATOR-REVERSES-ATTENUATION-AT-N1024**:
+    cohort geomean is non-monotone in N along the K-COMPLEMENT axis
+    (1.678 → 1.471 → 1.372 → **2.23**); R-1382's predicted "null
+    discriminator at N≥512" is FALSIFIED a second time and the K-1131 A2
+    1.40× cohort floor (MISSED by 2.8 pp at N=512) is RECOVERED at N=1024.
+
+    Stacked at 10th-position per K-1175 stacked-predicate convention;
+    disjoint by construction with all P1–P15 sub-frozensets via the
+    cross-frozenset asserts above.
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29
+    )
+
+
 def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
                         work_stealing, disable_env_set: bool = False) -> bool:
     """Pure routing decision — same logic as ``matmul._k971_route_to_hbl``
@@ -1389,6 +1601,7 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
       7. K-1367 P13 skinny_N128 K-COMPLEMENT 18-cell strict-equality -> hipBLASLt.
       8. K-1397 P13 skinny_N256 K-COMPLEMENT 12-cell strict-equality -> hipBLASLt.
       9. K-1417 P15 skinny_N512 K-COMPLEMENT 12-cell strict-equality -> hipBLASLt.
+     10. K-1429 P16 skinny_N1024 K-COMPLEMENT 29-cell strict-equality -> hipBLASLt.
     """
     if disable_env_set:
         return False
@@ -1449,5 +1662,17 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # Per-cell ratios 1.36×–14.06×; cohort geomean 3.43×; envelope grows
     # 85 → 97 cells.
     if _k1409_p15_skinny_n512_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1429 P16 (10th-position): skinny_N1024 K-COMPLEMENT 29-cell route-OUT.
+    # Stacks AFTER K-1417 P15 per K-1175 stacked-predicate convention; closes
+    # the fourth-N successive sibling of the K-COMPLEMENT axis at N=1024
+    # (full K-axis K ∈ {2048, 4096, 8192, 16384, 32768}).  R-1409 monotone
+    # N-axis attenuation (1.678 → 1.471 → 1.372 across N=128/256/512)
+    # REVERSES at N=1024 to cohort geomean 2.23× (BASE 2.08× / EXTREMES 2.48×);
+    # 29/30 admit per-cell strict gate (single reject (2048,1024,4096,bf16)
+    # at r=1.015 below 1.05 floor).  K-1131 A2 1.40× cohort floor RECOVERED
+    # at N=1024 after MISS at N=512 (R-1429.SKINNY-N1024-K-COMPLEMENT-DISCRIMINATOR-REVERSES-ATTENUATION-AT-N1024).
+    # Envelope grows 97 → 126 cells.
+    if _k1429_p16_skinny_n1024_routeout(int(M), int(N), int(K), a_dtype):
         return True
     return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1074,13 +1074,143 @@ def _k1367_p13_skinny_n128_routeout(M: int, N: int, K: int, dtype) -> bool:
     ≈ 1.45 vs HBL = 0; positive-filter-check + fail-loud sweep verified
     HBL LDS_BC = 0 is real measurement).
 
-    Stacked LAST (7th-position) per K-1175 stacked-predicate convention;
+    Stacked at 7th-position per K-1175 stacked-predicate convention;
     disjoint by construction with all P1–P12 sub-frozensets via the
     cross-frozenset asserts above.
     """
     return (
         (int(M), int(N), int(K), str(dtype))
         in _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18
+    )
+
+
+# ---------------------------------------------------------------------------
+# K-1397 (S-002) — P13 `skinny_N256` K-COMPLEMENT route-OUT (8th-position).
+#
+# K-1402 productionises the K-1397-winning 12-cell `skinny_N256` cohort as
+# `_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12`, layered as the 8th-position
+# envelope in the dispatch precedence chain on top of the K-1389 P13 73-cell
+# baseline (envelope grows 73 → 85 cells; +12 admits).
+#
+# Bucket scope: K-1365's post-P12 4-bucket decomposition surfaced
+# `skinny_N256` as the last residual-addressable bucket after P12/P13/N128
+# closed `skinny_N128`.  The K-1397 measurement campaign demonstrated that
+# the same `wrapper-overhead-ceiling-disappears-at-large-K` argument
+# (R-1367.WRAPPER-OVERHEAD-CEILING-DISAPPEARS-AT-LARGE-K-WHERE-TB-TIME-DOMINATES-30US-TRITONOP)
+# generalises to N=256 column-narrow GEMMs, but the K-axis admit set sits
+# at the EXTREMES of the K-1308 sweep grid (K=2048 and K=32768) where the
+# aspect ratio either (a) starves persistent_matmul's tile parallelism with
+# too few K-tiles per CU (K=2048 small-K starvation) or (b) overflows LDS
+# bank-conflict capacity at the persistent N=256 tile width (K=32768 large-K
+# saturation).  The complementary mid-K band (K ∈ {4096, 8192, 16384}) is
+# already routed correctly by tritonblas persistent_matmul; the K-COMPLEMENT
+# is exactly the {K=2048, K=32768} pair (codified as
+# R-1397.SKINNY-N256-K-COMPLEMENT-IS-EXTREMES-NOT-MID-BAND).
+#
+# K-COMPLEMENT region:
+#   M ∈ {2048, 4096, 8192}   (3 anchors, same as K-1367 N=128 row)
+#   N = 256                   (column-narrow regime, +1 column step from N=128)
+#   K ∈ {2048, 32768}         (extremes — small-K starvation + large-K LDS-BC)
+#   dtype ∈ {bf16, fp16}      (K-913 §3 dtype invariance preserved)
+# = 3 × 1 × 2 × 2 = 12 cells.
+#
+# PMC mechanism (consistent with K-913 longK_smallSquare findings):
+#   hipBLASLt's split-K kernel selection wins over tritonblas
+#   persistent_matmul at extreme aspect ratios where LDS bank conflicts
+#   dominate the persistent N=256 tile layout (TB SQ_LDS_BC/inst remains
+#   high at N=256, HBL split-K trades LDS pressure for atomic-reduction).
+#
+# Disjointness rationale (verified by frozenset.isdisjoint at module load):
+#   * P8 sub-frozensets — K-1121/K-1131/K-1161/K-1283 use M >= 4480 (P13
+#     uses M ∈ {2048, 4096} below threshold; M=8192 cells are admitted by
+#     P8 only at specific (N,K) tuples enumerated in K-1121 anchors which
+#     do not include N=256, K ∈ {2048, 32768}).  K-1219 N=256 sub-frozenset
+#     uses K ∈ {1024, 2048} with M ∈ {1024, 2048} — partial overlap candidate
+#     at (2048, 256, 2048, *); verified disjoint by frozenset.isdisjoint at
+#     module load (K-1219 specific tuples must be enumerated to overlap).
+#   * K971_ROUTE_TABLE — K-905/K-971 anchors use M=N ∈ {1024, 2048};
+#     K-1335 uses M=N ∈ {1024, 2048}; neither has N=256, no collision.
+#   * K-1361 P12 — uses M=N=K ∈ {2048, 4096} with N != 256; no collision.
+#   * K-1367 P13 — uses N=128; K-1397 uses N=256; natural disjointness.
+# All asserted at module load.
+# ---------------------------------------------------------------------------
+_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12 = frozenset({
+    # M=2048 row × K ∈ {2048, 32768} × {bf16, fp16}
+    (2048, 256,  2048, "torch.bfloat16"),
+    (2048, 256,  2048, "torch.float16"),
+    (2048, 256, 32768, "torch.bfloat16"),
+    (2048, 256, 32768, "torch.float16"),
+    # M=4096 row × K ∈ {2048, 32768} × {bf16, fp16}
+    (4096, 256,  2048, "torch.bfloat16"),
+    (4096, 256,  2048, "torch.float16"),
+    (4096, 256, 32768, "torch.bfloat16"),
+    (4096, 256, 32768, "torch.float16"),
+    # M=8192 row × K ∈ {2048, 32768} × {bf16, fp16}
+    (8192, 256,  2048, "torch.bfloat16"),
+    (8192, 256,  2048, "torch.float16"),
+    (8192, 256, 32768, "torch.bfloat16"),
+    (8192, 256, 32768, "torch.float16"),
+})
+assert len(_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12) == 12, (
+    "K-1397 P13 skinny_N256 K-COMPLEMENT frozenset must be exactly 12 cells "
+    "(M ∈ {2048,4096,8192} × N=256 × K ∈ {2048,32768} × {bf16,fp16}); "
+    "any deviation indicates an authoring typo against the K-1365 post-P12 "
+    "4-bucket decomposition or the K-1397 K-COMPLEMENT extremes scoping.")
+# Cross-frozenset disjointness — K-1397 P13 vs prior envelopes.
+_K1397_P13_VS_P8_DISJOINT = (
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+assert _K1397_P13_VS_P8_DISJOINT, (
+    "K-1397 P13 skinny_N256 K-COMPLEMENT cell overlaps the K-1322 51-cell P8 "
+    "envelope; K-1219's N=256 sub-frozenset uses K ∈ {1024, 2048} with "
+    "M ∈ {1024, 2048} — only (2048, 256, 2048, *) is an on-paper collision "
+    "candidate; specific K-1219 tuples must be enumerated to overlap.  "
+    "Disjointness verified by frozenset intersection at module load.")
+_K1397_P13_VS_K971_DISJOINT = (
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12.isdisjoint(K971_ROUTE_TABLE))
+assert _K1397_P13_VS_K971_DISJOINT, (
+    "K-1397 P13 skinny_N256 K-COMPLEMENT cell overlaps K971_ROUTE_TABLE; "
+    "K971_ROUTE_TABLE (K-905/K-971 + K-1335) uses M=N ∈ {1024, 2048}; "
+    "K-1397 cells all use N=256 — natural disjointness, but assert as cheap "
+    "insurance per R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.")
+_K1397_P13_VS_P12_DISJOINT = (
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
+assert _K1397_P13_VS_P12_DISJOINT, (
+    "K-1397 P13 skinny_N256 K-COMPLEMENT cell overlaps K-1361 P12 square_mid; "
+    "P12 cells use M=N=K ∈ {2048, 4096}; K-1397 cells all use N=256 — natural "
+    "disjointness, asserted for completeness (A4 no-double-admit).")
+_K1397_P13_VS_K1367_P13_DISJOINT = (
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12.isdisjoint(
+        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18))
+assert _K1397_P13_VS_K1367_P13_DISJOINT, (
+    "K-1397 P13 skinny_N256 cell overlaps K-1367 P13 skinny_N128; "
+    "K-1367 cells use N=128, K-1397 cells use N=256 — natural disjointness, "
+    "asserted for completeness (A4 no-double-admit; the two K-COMPLEMENT "
+    "predicates partition the skinny-N column-narrow regime by N-axis).")
+
+
+def _k1397_p13_skinny_n256_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1397 P13 — direct hipBLASLt route-OUT for the 12-cell skinny_N256
+    K-COMPLEMENT cohort (`_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 12 strict-equality
+    keys: M ∈ {2048, 4096, 8192} × N = 256 × K ∈ {2048, 32768} ×
+    dtype ∈ {torch.bfloat16, torch.float16}.
+
+    Source measurement: K-1397 paired n=30 HIP-graph hot-cache benchmarks
+    on MI300X / gfx942 with B=10000 vectorised paired bootstrap CI95;
+    12/12 ROUTE-OUT, per-cell speedups span 1.04× to 1.12×.  Mechanism is
+    hipBLASLt's split-K kernel selection winning over tritonblas
+    persistent_matmul at extreme aspect ratios where LDS bank conflicts
+    dominate the persistent N=256 tile layout (consistent with K-913
+    longK_smallSquare PMC findings).
+
+    Stacked at 8th-position per K-1175 stacked-predicate convention;
+    disjoint by construction with all P1–P13(N=128) sub-frozensets via the
+    cross-frozenset asserts above.
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12
     )
 
 
@@ -1105,6 +1235,7 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
       5. K-905 / K-971 / K-1335 strict-equality LDS-BC anchor table -> hipBLASLt.
       6. K-1361 P12 square_mid 4-cell strict-equality -> hipBLASLt.
       7. K-1367 P13 skinny_N128 K-COMPLEMENT 18-cell strict-equality -> hipBLASLt.
+      8. K-1397 P13 skinny_N256 K-COMPLEMENT 12-cell strict-equality -> hipBLASLt.
     """
     if disable_env_set:
         return False
@@ -1146,5 +1277,15 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # the K-1308 skinny_N128 K-COMPLEMENT region (K >= 4096 above the 30 µs
     # triton_op wrapper-overhead ceiling) at cohort geomean tb/hbl = 1.678×.
     if _k1367_p13_skinny_n128_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1397 P13 (8th-position): skinny_N256 K-COMPLEMENT 12-cell route-OUT.
+    # Stacks AFTER K-1367 P13 per K-1175 stacked-predicate convention; closes
+    # the last K-1365 post-P12 4-bucket residual (skinny_N256 at K-axis
+    # extremes K ∈ {2048, 32768}) where hipBLASLt's split-K kernel selection
+    # wins over tritonblas persistent_matmul (LDS bank conflicts dominate at
+    # the persistent N=256 tile layout — consistent with K-913
+    # longK_smallSquare PMC findings).  Per-cell speedups 1.04×–1.12×;
+    # envelope grows 73 → 85 cells.
+    if _k1397_p13_skinny_n256_routeout(int(M), int(N), int(K), a_dtype):
         return True
     return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -2234,11 +2234,11 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
          K-COMPLEMENT N-ladder; 28 NEW cells + 2 K-1295 P12 alias cells at
          the (4096, 4096, 4096, {bf16, fp16}) diagonal.  Validates the
          R-1478 #1 N-axis attenuation chain at the new anchor (1.234×).
-     17. K-1553 P25 skinny_N4096 K-COMPLEMENT alias-stack 30-cell
-         strict-equality -> hipBLASLt.  ALIAS to P24 ⨄ P12; documents the
-         K-1553-verified N=4096 envelope under a single K-1553-named symbol
-         per the K-1493 / K-1538 / K-1552 alias-stack convention; load-bearing
-         only if P24 is ablated.
+         (17th-slot K-1553 documentation handle exposed as the
+         module-level alias `_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30`
+         = `_K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30`; no separate
+         predicate, since the admit set is bit-identical and P24 fires
+         first.)
     """
     if disable_env_set:
         return False
@@ -2381,19 +2381,15 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # 1.451 → 1.234 → 1.220 → 1.174 → 1.118).
     if _k1566_p24_skinny_n4096_routeout(int(M), int(N), int(K), a_dtype):
         return True
-    # K-1553 P25 (17th-position): skinny_N4096 K-COMPLEMENT alias-stack 30-cell.
-    # Stacks AFTER P24 per the K-1175 stacked-predicate convention.  ALIAS to
-    # P24 ⨄ P12 (the live N=4096 K-COMPLEMENT cohort already routes 30/30 via
-    # P24, with 2 cells additionally aliased by P12 at the (4096, 4096, 4096,
-    # {bf16, fp16}) diagonal).  Membership check is unreachable while P24 is
-    # enabled — load-bearing only if P24 is ablated; the slot freezes the
-    # K-1553 admit set under a K-1553-named symbol per the K-1493 / K-1538 /
-    # K-1552 alias-stack convention so future N-ladder audits have a dedicated
-    # handle for the K-1553 N=4096 measurement (paired n=30 HIP-graph hot-cache
-    # MI300X gfx942 vs the live post-K-1532 oracle; cohort geomean tb/hbl =
-    # 1.234×, range 1.114×-1.501×; 30/30 admit at strict 1.05 gate).
-    if _k1553_p25_skinny_n4096_kcompl_aliasstack_routeout(int(M), int(N), int(K), a_dtype):
-        return True
+    # K-1553 17th-slot handle: no executable code — `_K1553_P25_SKINNY_
+    # N4096_KCOMPL_ALIASSTACK_30` is a module-level alias of
+    # `_K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30` (bit-identical admit
+    # set; P24 fires first).  Per K-1489 reviewer-consensus precedent,
+    # adding a duplicate frozenset + predicate function for an unreachable
+    # alias is dead code.  The K-1553-named alias preserves audit
+    # traceability for the K-1553 paired n=30 HIP-graph hot-cache
+    # measurement (combined with K-1559 60-cell mid-band confirmation);
+    # see the alias declaration block below for the full provenance.
     return False
 
 
@@ -2572,171 +2568,32 @@ def _k1566_p24_skinny_n4096_routeout(M: int, N: int, K: int, dtype) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# K-1553 (S-002) — P25 `skinny_N4096` K-COMPLEMENT 30-cell alias-stack
-# route-OUT (17th-position).
+# K-1553 (S-002) — P25 `skinny_N4096` K-COMPLEMENT 30-cell alias handle
+# (17th-slot, documentation-only; no executable predicate).
 #
-# Productionizes the K-1553 measurement of the N=4096 K-COMPLEMENT envelope
-# (M ∈ {2048, 4096, 8192} × N=4096 × K ∈ {2048, 4096, 8192, 16384, 32768} ×
-# {bf16, fp16}) as the 17th stacked alias-stack frozenset, freezing the
-# K-1553 admit set under a dedicated K-1553-named symbol per the K-1493
-# P20-of-P19 / K-1538 P22-of-P15+P17 / K-1552 P23-of-P15+P17+P5 alias-stack
-# convention.  K-1553 paired n=30 HIP-graph hot-cache measurement (combined
-# with K-1559's 60-cell mid-band confirmation at N ∈ {4096, 8192}, and
-# B=10000 vectorised paired bootstrap, MI300X / gfx942 / ROCm 7.2 / pytorch
-# 2.10 against the live post-K-1532 routing oracle): 30/30 admit at the
-# strict gate (ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01); cohort geomean
-# tb/hbl = 1.234×, range 1.114×-1.501×, 0 regressions.  Per-row geomean:
-# 1.402× (M=2048) / 1.146× (M=4096) / 1.180× (M=8192) — K-913 LDS-BC band
-# fully live at the M=2048 row because min(M, N) = 2048 keeps the K-913
-# fingerprint live (R-1458 #1).  M=4096/8192 rows attenuate into the K-956
-# wave-occupancy starvation regime.
+# K-1553 measured the N=4096 K-COMPLEMENT envelope (M ∈ {2048, 4096, 8192}
+# × N=4096 × K ∈ {2048, 4096, 8192, 16384, 32768} × {bf16, fp16}) on
+# MI300X / gfx942 with paired n=30 HIP-graph hot-cache + B=10000
+# vectorised paired bootstrap against the live post-K-1532 routing oracle
+# (combined with K-1559 60-cell N ∈ {4096, 8192} mid-band confirmation):
+# 30/30 admit at the strict gate (ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01);
+# cohort geomean tb/hbl = 1.234×, range 1.114×-1.501×, 0 regressions.
+# Per-row geomean: 1.402× (M=2048) / 1.146× (M=4096) / 1.180× (M=8192).
+# K-1566 productionised that envelope as P24 (16th-slot, load-bearing).
 #
-# ALIAS-STACK (per K-1493 / K-1538 / K-1552 convention): all 30 cells are
-# already routed by upstream layers — P24 (K-1566 _K1566_P24_SKINNY_N4096_
-# KCOMPL_ROUTEOUT_30) covers 30/30 of them as direct route-OUT, with 2 of
-# those 30 additionally aliased by P12 (K-1295 _K1295_P12_PMC_SQUARE_MID_
-# ROUTEOUT_4) at the (4096, 4096, 4096, {bf16, fp16}) diagonal.  P24 fires
-# at 16th-position before P25 (17th-position), so the P25 membership check
-# is unreachable while P24 remains enabled — by design.  The slot is
-# load-bearing if P24 is ablated and freezes the K-1553 30-cell admit set
-# under a K-1553-named symbol so future N-ladder audits have a dedicated
-# handle for the K-1553 measurement separate from K-1566's productionization
-# label.  Disjointness asserts vs P24 ⨄ P12 are intentionally OMITTED
-# (alias overlap is the point); sibling-N firewall vs the non-N=4096
-# predicates follows the K-1532 P22 data-driven loop pattern.
-#
-# Sequenced after K-1567 (N=8192 productionization sibling, separate slot)
-# to avoid frozenset-numbering conflicts; P24 (K-1566) and P25 (K-1553)
-# both anchor on the K-1553 envelope but P24 is the load-bearing route-OUT
-# and P25 is the named alias.
+# Per K-1489 reviewer-consensus precedent (REVISE: "delete the alias
+# entirely … if a stable slot number is genuinely needed, leave a one-
+# line comment placeholder instead of executable code"), the K-1553-named
+# 17th-slot handle is exposed as a single module-level alias of the K-1566
+# P24 frozenset rather than as a duplicate frozenset + asserts + predicate
+# (P25's admit set is bit-identical to P24 by definition, and P24 fires
+# first — a duplicate predicate would be unreachable dead code).  The
+# alias preserves the K-1553 audit handle for N-ladder retrospectives
+# without adding routing-decision code; cardinality, sibling-N firewall,
+# alias-coverage, and parent-equality invariants are all transitively
+# inherited from `_K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30` and need no
+# duplicate asserts here.  If P24 is ever ablated, the alias still
+# resolves and any K-1553 audit code that references the alias by name
+# continues to enumerate the K-1553 30-cell admit set.
 # ---------------------------------------------------------------------------
-_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30 = frozenset({
-    # M=2048 row × N=4096 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
-    (2048, 4096,  2048, "torch.bfloat16"),    # r=1.461 ci95=[1.446,1.471] (P24)
-    (2048, 4096,  2048, "torch.float16"),     # r=1.422 ci95=[1.403,1.441] (P24)
-    (2048, 4096,  4096, "torch.bfloat16"),    # r=1.494 ci95=[1.483,1.504] (P24)
-    (2048, 4096,  4096, "torch.float16"),     # r=1.465 ci95=[1.452,1.482] (P24)
-    (2048, 4096,  8192, "torch.bfloat16"),    # r=1.501 ci95=[1.491,1.517] max (P24)
-    (2048, 4096,  8192, "torch.float16"),     # r=1.475 ci95=[1.462,1.487] (P24)
-    (2048, 4096, 16384, "torch.bfloat16"),    # r=1.458 ci95=[1.441,1.465] (P24)
-    (2048, 4096, 16384, "torch.float16"),     # r=1.413 ci95=[1.410,1.416] (P24)
-    (2048, 4096, 32768, "torch.bfloat16"),    # r=1.179 ci95=[1.178,1.181] (P24)
-    (2048, 4096, 32768, "torch.float16"),     # r=1.159 ci95=[1.157,1.160] (P24)
-    # M=4096 row × N=4096 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
-    (4096, 4096,  2048, "torch.bfloat16"),    # r=1.174 ci95=[1.165,1.192] (P24)
-    (4096, 4096,  2048, "torch.float16"),     # r=1.189 ci95=[1.169,1.197] (P24)
-    (4096, 4096,  4096, "torch.bfloat16"),    # r=1.161 ci95=[1.151,1.172] (P12+P24)
-    (4096, 4096,  4096, "torch.float16"),     # r=1.137 ci95=[1.131,1.143] (P12+P24)
-    (4096, 4096,  8192, "torch.bfloat16"),    # r=1.137 ci95=[1.129,1.140] (P24)
-    (4096, 4096,  8192, "torch.float16"),     # r=1.120 ci95=[1.116,1.121] (P24)
-    (4096, 4096, 16384, "torch.bfloat16"),    # r=1.170 ci95=[1.157,1.183] (P24)
-    (4096, 4096, 16384, "torch.float16"),     # r=1.164 ci95=[1.161,1.167] (P24)
-    (4096, 4096, 32768, "torch.bfloat16"),    # r=1.137 ci95=[1.134,1.141] (P24)
-    (4096, 4096, 32768, "torch.float16"),     # r=1.114 ci95=[1.112,1.117] min (P24)
-    # M=8192 row × N=4096 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
-    (8192, 4096,  2048, "torch.bfloat16"),    # r=1.189 ci95=[1.162,1.202] (P24)
-    (8192, 4096,  2048, "torch.float16"),     # r=1.183 ci95=[1.178,1.190] (P24)
-    (8192, 4096,  4096, "torch.bfloat16"),    # r=1.177 ci95=[1.140,1.184] (P24)
-    (8192, 4096,  4096, "torch.float16"),     # r=1.171 ci95=[1.167,1.174] (P24)
-    (8192, 4096,  8192, "torch.bfloat16"),    # r=1.159 ci95=[1.146,1.167] (P24)
-    (8192, 4096,  8192, "torch.float16"),     # r=1.151 ci95=[1.149,1.153] (P24)
-    (8192, 4096, 16384, "torch.bfloat16"),    # r=1.187 ci95=[1.181,1.192] (P24)
-    (8192, 4096, 16384, "torch.float16"),     # r=1.158 ci95=[1.156,1.159] (P24)
-    (8192, 4096, 32768, "torch.bfloat16"),    # r=1.171 ci95=[1.170,1.173] (P24)
-    (8192, 4096, 32768, "torch.float16"),     # r=1.143 ci95=[1.142,1.144] (P24)
-})
-assert len(_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30) == 30, (
-    "K-1553 P25 skinny_N4096 alias-stack frozenset must be exactly 30 cells "
-    "(M ∈ {2048, 4096, 8192} × N=4096 × K ∈ {2048, 4096, 8192, 16384, 32768} "
-    "× {bf16, fp16}); deviation indicates a typo against the K-1553 admit set.")
-# ALIAS-STACK invariant: every cell MUST be covered by P24 ⨄ P12 (otherwise
-# this is no longer an alias and the slot would carve a new admit — assertion
-# guards against future P24/P12 contraction silently upgrading P25 from
-# documentation to load-bearing without an audit re-evaluating whether the
-# affected cells still admit under the post-contraction live oracle).
-_K1553_P25_ALIAS_UNION = (
-    _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
-    | _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
-)
-for _k1553_cell in _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30:
-    assert _k1553_cell in _K1553_P25_ALIAS_UNION, (
-        f"K-1553 P25 alias-stack cell {_k1553_cell} is not covered by "
-        "P24 ⨄ P12 — alias-stack invariant violated; either the upstream "
-        "cohort contracted (audit P24/P12) or the K-1553 admit set "
-        "drifted from the live oracle.")
-del _K1553_P25_ALIAS_UNION, _k1553_cell
-# Equality with K-1566 P24: K-1553 measured the same 30-cell envelope that
-# K-1566 P24 productionised; the two frozensets must be exactly equal.  The
-# assert documents the parent-measurement-vs-productionization-label mapping
-# (K-1553 = source measurement, K-1566 = productionized predicate name).
-assert _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30 == _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30, (
-    "K-1553 P25 alias-stack frozenset must equal K-1566 P24 frozenset "
-    "(P25 is the K-1553-named alias of P24 over the same 30-cell admit set); "
-    "deviation indicates either P24 contracted or P25 was authored against "
-    "a different K-1553 sub-set than the K-1566 productionization.")
-# Sibling-N firewall: P25 carries N=4096 only; must be disjoint from every
-# non-N=4096 K-COMPLEMENT predicate and all non-K-COMPLEMENT predicates that
-# don't already share the N=4096 column.  (P24 / P12 sharing is the alias.)
-_K1553_P25_DISJOINT_SIBLINGS = (
-    ("P8 (K-1322 N≤256 envelope)",        _P8_MFMA_ISSUE_STALL_ROUTEOUT),
-    ("K971_ROUTE_TABLE (M=N≤2048)",       K971_ROUTE_TABLE),
-    ("P13 N=128 (K-1367)",                _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18),
-    ("P13 N=256 (K-1397)",                _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12),
-    ("P15 N=512 (K-1409)",                _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT),
-    ("P16 N=1024 (K-1429)",               _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29),
-    ("P17 N=512 BASE (K-1437)",           _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17),
-    ("P19 N=16384 (K-1478)",              _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30),
-    ("P21 N=256 K-mid (K-1503)",          _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT),
-    ("P22 N=32768 (K-1513)",              _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30),
-    ("P23 N=512 alias (K-1552)",          _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30),
-)
-for _sibling_name, _sibling_set in _K1553_P25_DISJOINT_SIBLINGS:
-    assert _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30.isdisjoint(_sibling_set), (
-        f"K-1553 P25 skinny_N4096 (N=4096) overlaps {_sibling_name}; "
-        "sibling-N firewall violated — every prior K-COMPLEMENT predicate "
-        "uses N ∈ {128, 256, 512, 1024, 16384, 32768} and P8/K971 cap at "
-        "N ≤ 2048, so the N=4096 column must be disjoint by construction "
-        "(P24/P12 alias overlap is the only intentional exception).")
-del _sibling_name, _sibling_set
-
-
-def _k1553_p25_skinny_n4096_kcompl_aliasstack_routeout(M: int, N: int, K: int, dtype) -> bool:
-    """K-1553 P25 — alias-stack hipBLASLt route-OUT for the K-1553-verified
-    30-cell skinny_N4096 K-COMPLEMENT cohort
-    (`_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30`).
-
-    ALIAS to P24 ⨄ P12 — every cell in the K-1553 envelope is already routed
-    by an upstream predicate (P24 covers all 30; P12 additionally aliases 2
-    diagonal cells at (4096, 4096, 4096, {bf16, fp16})), so this 17th-position
-    check is unreachable while P24 remains enabled.  Load-bearing only if
-    P24 is ablated.
-
-    Source measurement: K-1553 paired n=30 HIP-graph hot-cache benchmarks on
-    MI300X / gfx942 (combined with K-1559 60-cell N ∈ {4096, 8192} mid-band
-    confirmation), TRITONBLAS_DISABLE_K971=1, B=10000 vectorised paired
-    bootstrap CI95 against the live post-K-1532 routing oracle (HEAD
-    95e2c47); 30/30 ROUTE-OUT-CANDIDATE at the strict ratio_median ≥ 1.05 ∧
-    p(<1.05) < 0.01 gate; cohort geomean tb/hbl = 1.234×, range
-    1.114×-1.501×, 0 regressions.  Per-row geomean: 1.402× (M=2048) /
-    1.146× (M=4096) / 1.180× (M=8192) — K-913 §3 LDS-BC fingerprint fully
-    live at the M=2048 row because min(M, N) = 2048 satisfies the K-913
-    floor (R-1458 #1); M=4096/8192 attenuate into the K-956 wave-occupancy
-    starvation regime.
-
-    Mechanism (why these cells benefit from hipBLASLt route): at N=4096 the
-    persistent_matmul tile aspect keeps min(M, N) ≤ 2048 for the M=2048 row,
-    saturating LDS bank conflicts on the N=4096 column-narrow LDS layout
-    (K-913 longK_smallSquare signature).  hipBLASLt's split-K kernel selector
-    re-picks at N=4096 to a tile/pipeline pattern that better amortises
-    LDS-BC pressure and wave-occupancy starvation across all three M anchors,
-    yielding the +14-50% per-cell speedups observed in the K-1553 sweep.
-
-    Stacked at 17th-position per the K-1175 stacked-predicate convention
-    after K-1566 P24; documents the K-1553-measured N=4096 cohort under a
-    single K-1553-named symbol per the K-1493 / K-1538 / K-1552 alias-stack
-    convention.
-    """
-    return (
-        (int(M), int(N), int(K), str(dtype))
-        in _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30
-    )
+_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30 = _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1791,10 +1791,16 @@ def _k1478_p19_skinny_n16384_routeout(M: int, N: int, K: int, dtype) -> bool:
     )
 
 
-# K-1489 P20 (13th-position): alias-stack of K-1478 P19 admit envelope per
-# K-1490 sibling-slot productionization (claims the next stack slot for the
-# K-COMPLEMENT-EXTENDED follow-up; load-bearing only if P19 is ablated).
-_K1478_P20_SKINNY_N16384_KCOMPL_ROUTEOUT_N = _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30
+# K-1489 P20 (13th-position) RESERVED — placeholder only, no executable code.
+# Reviewer consensus on the prior K-1489 alias-of-P19 attempt was unanimous
+# REVISE (Minimalist: "delete the P20 alias entirely and reopen the slot only
+# when K-COMPLEMENT-EXTENDED actually has a distinct envelope to land; if a
+# stable slot number is genuinely needed, leave a one-line comment placeholder
+# instead of executable code"; Pragmatist / Skeptic / Testing Zealot all
+# rejected the no-op alias as dead code dressed as productionization).  The
+# slot number is preserved for the future K-COMPLEMENT-EXTENDED admit set;
+# no frozenset, function, or membership check is added until that envelope
+# exists and has been measured under paired n=30 HIP-graph hot-cache.
 
 
 def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
@@ -1823,8 +1829,8 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
      10. K-1429 P16 skinny_N1024 K-COMPLEMENT 29-cell strict-equality -> hipBLASLt.
      11. P17 skinny_N512 K-COMPLEMENT BASE 17-cell strict-equality -> hipBLASLt.
      12. K-1478 P19 skinny_N16384 K-COMPLEMENT 30-cell strict-equality -> hipBLASLt.
-     13. K-1489 P20 skinny_N16384 K-COMPLEMENT alias-stack of P19 (13th slot;
-         unreachable while P19 enabled — reserved for K-COMPLEMENT-EXTENDED).
+         (13th slot reserved for K-COMPLEMENT-EXTENDED; no executable code
+         until that envelope has been measured.)
     """
     if disable_env_set:
         return False
@@ -1916,7 +1922,6 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # P1-P17 by sibling-N firewall + R-1465 #1 zero-P12-deferral invariant.
     if _k1478_p19_skinny_n16384_routeout(int(M), int(N), int(K), a_dtype):
         return True
-    # K-1489 P20 (13th-position): alias-stack of K-1478 P19 admit envelope.
-    if (int(M), int(N), int(K), str(a_dtype)) in _K1478_P20_SKINNY_N16384_KCOMPL_ROUTEOUT_N:
-        return True
+    # K-1489 13th-slot RESERVED — no executable code (see comment block above
+    # the P19 docstring for reviewer rationale).
     return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -2229,6 +2229,11 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
          -> hipBLASLt.  ALIAS to P15 ⨄ P17 ⨄ P5; documents the K-1534-
          verified N=512 envelope under a single symbol; load-bearing only if
          an upstream layer is ablated.
+     16. K-1566 P24 skinny_N4096 K-COMPLEMENT 30-cell strict-equality ->
+         hipBLASLt.  Closes the previously-empty N=4096 rung of the
+         K-COMPLEMENT N-ladder; 28 NEW cells + 2 K-1295 P12 alias cells at
+         the (4096, 4096, 4096, {bf16, fp16}) diagonal.  Validates the
+         R-1478 #1 N-axis attenuation chain at the new anchor (1.234×).
     """
     if disable_env_set:
         return False
@@ -2350,4 +2355,199 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # K-1538 alias-stack convention and freezes the K-1534 admit set.
     if _k1552_p23_skinny_n512_kcompl_aliasstack_routeout(int(M), int(N), int(K), a_dtype):
         return True
+    # K-1566 P24 (16th-position): skinny_N4096 K-COMPLEMENT 30-cell route-OUT.
+    # Stacks AFTER P23 per the K-1175 stacked-predicate convention; closes
+    # the previously-empty N=4096 rung of the K-COMPLEMENT N-ladder
+    # (between P21 N=2048 territory and P19 N=16384) on the full K-grid
+    # {2048, 4096, 8192, 16384, 32768}.  30/30 admit at the strict
+    # ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01 gate (K-1553 paired n=30 +
+    # B=10000 vectorised paired bootstrap on MI300X / gfx942 against the
+    # live post-K-1532 oracle); cohort geomean tb/hbl = 1.234×, range
+    # 1.114×-1.501×.  Per-row geomean: 1.402× (M=2048) / 1.146× (M=4096) /
+    # 1.180× (M=8192) — K-913 LDS-BC band fully live at M=2048 because
+    # min(2048, 4096) ≤ 2048 (R-1458 #1).  Natural disjointness with
+    # P1-P22 by sibling-N firewall (no other frozenset carries an N=4096
+    # cell with M ∈ {2048, 4096, 8192}) plus an explicit P12 alias overlap
+    # for the 2 cells (4096, 4096, 4096, {bf16, fp16}) that K-1295 P12
+    # already routes — those 2 cells are no-op via P24 because P12 fired
+    # first; the remaining 28 cells are NEW route-OUT.  Validates the
+    # R-1478 #1 N-axis attenuation chain anchor at N=4096 (slots between
+    # K-1525 N=2048 1.451× and K-1465/K-1474 N=8192 1.220×; full chain
+    # 1.451 → 1.234 → 1.220 → 1.174 → 1.118).
+    if _k1566_p24_skinny_n4096_routeout(int(M), int(N), int(K), a_dtype):
+        return True
     return False
+
+
+# ---------------------------------------------------------------------------
+# K-1566 (S-002) — P24 `skinny_N4096` K-COMPLEMENT 30-cell route-OUT
+# (16th-position).
+#
+# Productionizes the K-1553 verification of the N=4096 K-COMPLEMENT envelope
+# (M ∈ {2048, 4096, 8192} × N=4096 × K ∈ {2048, 4096, 8192, 16384, 32768} ×
+# {bf16, fp16}) as the 16th stacked frozenset, closing the previously-empty
+# N=4096 rung of the K-COMPLEMENT N-ladder.  K-1553 paired n=30 HIP-graph
+# hot-cache measurement (TRITONBLAS_DISABLE_K971=1, B=10000 vectorised
+# paired bootstrap, MI300X / gfx942 / ROCm 7.2 / pytorch 2.10 against the
+# live post-K-1532 routing oracle): 30/30 admit at the strict gate
+# (ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01); cohort geomean tb/hbl = 1.234×,
+# range 1.114×-1.501×, 0 regressions.  Per-row geomean: 1.402× (M=2048) /
+# 1.146× (M=4096) / 1.180× (M=8192) — K-913 LDS-BC band fully live at the
+# M=2048 row because min(M, N) = 2048 keeps the K-913 fingerprint live
+# (R-1458 #1).  M=4096/8192 rows attenuate into the K-956 wave-occupancy
+# starvation regime.
+#
+# Disjointness: 28 cells are sibling-N-firewall disjoint from every prior
+# frozenset (no P1-P22 frozenset carries an N=4096 cell with M ∈ {2048,
+# 4096, 8192}).  2 cells alias K-1295 P12 — (4096, 4096, 4096,
+# torch.bfloat16) and (4096, 4096, 4096, torch.float16) — P12 fires first
+# in the dispatch chain so the P24 membership check on those 2 cells is
+# unreachable while P12 is enabled.  The 28 NEW cells extend the route-OUT
+# envelope from 156 cells (post-K-1552 stack) to 184 cells (+28).  The
+# alias overlap is intentional and asserted at module load via
+# `_K1566_P24_VS_P12_ALIAS_OVERLAP`; sibling-N firewall vs the other 13
+# frozensets uses the K-1532 P22 data-driven loop pattern.
+#
+# Validates the R-1478 #1 N-axis attenuation chain at the previously-
+# empty N=4096 anchor: chain extends to 1.451 → 1.234 → 1.220 → 1.174 →
+# 1.118 across N ∈ {2048, 4096, 8192, 16384, 32768}, strictly monotone-
+# decreasing throughout (R-1532.N-LADDER-ATTENUATION-PREDICTS-NEXT-RUNG
+# verified by direct measurement at the N=4096 rung).
+# ---------------------------------------------------------------------------
+_K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30 = frozenset({
+    # M=2048 row × N=4096 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (2048, 4096,  2048, "torch.bfloat16"),    # r=1.461 ci95=[1.446,1.471]
+    (2048, 4096,  2048, "torch.float16"),     # r=1.422 ci95=[1.403,1.441]
+    (2048, 4096,  4096, "torch.bfloat16"),    # r=1.494 ci95=[1.483,1.504]
+    (2048, 4096,  4096, "torch.float16"),     # r=1.465 ci95=[1.452,1.482]
+    (2048, 4096,  8192, "torch.bfloat16"),    # r=1.501 ci95=[1.491,1.517] (max)
+    (2048, 4096,  8192, "torch.float16"),     # r=1.475 ci95=[1.462,1.487]
+    (2048, 4096, 16384, "torch.bfloat16"),    # r=1.458 ci95=[1.441,1.465]
+    (2048, 4096, 16384, "torch.float16"),     # r=1.413 ci95=[1.410,1.416]
+    (2048, 4096, 32768, "torch.bfloat16"),    # r=1.179 ci95=[1.178,1.181]
+    (2048, 4096, 32768, "torch.float16"),     # r=1.159 ci95=[1.157,1.160]
+    # M=4096 row × N=4096 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (4096, 4096,  2048, "torch.bfloat16"),    # r=1.174 ci95=[1.165,1.192]
+    (4096, 4096,  2048, "torch.float16"),     # r=1.189 ci95=[1.169,1.197]
+    (4096, 4096,  4096, "torch.bfloat16"),    # r=1.161 ci95=[1.151,1.172] (P12 alias)
+    (4096, 4096,  4096, "torch.float16"),     # r=1.137 ci95=[1.131,1.143] (P12 alias)
+    (4096, 4096,  8192, "torch.bfloat16"),    # r=1.137 ci95=[1.129,1.140]
+    (4096, 4096,  8192, "torch.float16"),     # r=1.120 ci95=[1.116,1.121]
+    (4096, 4096, 16384, "torch.bfloat16"),    # r=1.170 ci95=[1.157,1.183]
+    (4096, 4096, 16384, "torch.float16"),     # r=1.164 ci95=[1.161,1.167]
+    (4096, 4096, 32768, "torch.bfloat16"),    # r=1.137 ci95=[1.134,1.141]
+    (4096, 4096, 32768, "torch.float16"),     # r=1.114 ci95=[1.112,1.117] (min)
+    # M=8192 row × N=4096 × K ∈ {2048,4096,8192,16384,32768} × {bf16, fp16}
+    (8192, 4096,  2048, "torch.bfloat16"),    # r=1.189 ci95=[1.162,1.202]
+    (8192, 4096,  2048, "torch.float16"),     # r=1.183 ci95=[1.178,1.190]
+    (8192, 4096,  4096, "torch.bfloat16"),    # r=1.177 ci95=[1.140,1.184]
+    (8192, 4096,  4096, "torch.float16"),     # r=1.171 ci95=[1.167,1.174]
+    (8192, 4096,  8192, "torch.bfloat16"),    # r=1.159 ci95=[1.146,1.167]
+    (8192, 4096,  8192, "torch.float16"),     # r=1.151 ci95=[1.149,1.153]
+    (8192, 4096, 16384, "torch.bfloat16"),    # r=1.187 ci95=[1.181,1.192]
+    (8192, 4096, 16384, "torch.float16"),     # r=1.158 ci95=[1.156,1.159]
+    (8192, 4096, 32768, "torch.bfloat16"),    # r=1.171 ci95=[1.170,1.173]
+    (8192, 4096, 32768, "torch.float16"),     # r=1.143 ci95=[1.142,1.144]
+})
+assert len(_K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30) == 30, (
+    "K-1566 P24 skinny_N4096 K-COMPLEMENT frozenset must be exactly 30 cells "
+    "(M ∈ {2048, 4096, 8192} × N=4096 × K ∈ {2048, 4096, 8192, 16384, 32768} "
+    "× {bf16, fp16} = 30 sweep cells, 30/30 admit at the strict ratio_median "
+    "≥ 1.05 ∧ bootstrap p(<1.05) < 0.01 gate); any deviation indicates an "
+    "authoring typo against the K-1553 paired n=30 admit set.")
+# Cross-frozenset disjointness — K-1566 P24 vs the prior 14-predicate stack.
+# Every prior K-COMPLEMENT predicate uses N ∈ {128, 256, 512, 1024, 16384,
+# 32768}; P8/K971/K1335 cap at N ≤ 2048; P12 (K-1361) is bounded to
+# M=N=K ∈ {2048, 4096} on the diagonal — only the 2 cells (4096, 4096,
+# 4096, {bf16, fp16}) intersect the K-1566 admit set, codified as an
+# explicit P12 alias overlap below.  The remaining 28 cells are
+# sibling-N-firewall disjoint from every prior frozenset.  Data-driven
+# assert loop (K-1532 minimalist refactor): every sibling listed below
+# must be FULLY disjoint with the K-1566 admit set; P12 is excluded from
+# the firewall list and asserted via `_K1566_P24_VS_P12_ALIAS_OVERLAP`.
+_K1566_P24_DISJOINT_SIBLINGS = (
+    ("P8 (K-1322 N≤256 envelope)",        _P8_MFMA_ISSUE_STALL_ROUTEOUT),
+    ("K971_ROUTE_TABLE (M=N≤2048)",       K971_ROUTE_TABLE),
+    ("P13 N=128 (K-1367)",                _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18),
+    ("P13 N=256 (K-1397)",                _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12),
+    ("P15 N=512 (K-1409)",                _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT),
+    ("P16 N=1024 (K-1429)",               _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29),
+    ("P17 N=512 BASE (K-1437)",           _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17),
+    ("P19 N=16384 (K-1478)",              _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30),
+    ("P21 N=256 K-mid (K-1503)",          _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT),
+    ("P22 N=32768 (K-1513)",              _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30),
+    ("P23 N=512 alias (K-1552)",          _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30),
+)
+for _sibling_name, _sibling_set in _K1566_P24_DISJOINT_SIBLINGS:
+    assert _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30.isdisjoint(_sibling_set), (
+        f"K-1566 P24 skinny_N4096 (N=4096) overlaps {_sibling_name}; "
+        "sibling-N firewall violated — every prior K-COMPLEMENT predicate "
+        "uses N ∈ {128, 256, 512, 1024, 16384, 32768} and P8/K971 cap at "
+        "N ≤ 2048, so the N=4096 column must be disjoint by construction "
+        "(P12 alias overlap is the single intentional exception, asserted "
+        "separately via `_K1566_P24_VS_P12_ALIAS_OVERLAP`).")
+del _sibling_name, _sibling_set
+# Explicit P12 alias overlap: K-1295 P12 already routes the 2 diagonal cells
+# (4096, 4096, 4096, {bf16, fp16}); K-1566 P24's full 30-cell envelope
+# includes those same 2 cells.  P12 fires BEFORE P24 in the dispatch chain
+# so the P24 membership check on those 2 cells is unreachable while P12 is
+# enabled — the 2 cells are alias documentation, the remaining 28 are NEW
+# route-OUT.  The exact-overlap assertion guards against future P12
+# contractions silently upgrading P24 from a 28-NEW-cell stacked predicate
+# to a 30-NEW-cell predicate without an audit (which would re-evaluate
+# whether the two cells still admit under the post-contraction oracle).
+_K1566_P24_VS_P12_ALIAS_OVERLAP = (
+    _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
+    & _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
+assert _K1566_P24_VS_P12_ALIAS_OVERLAP == frozenset({
+    (4096, 4096, 4096, "torch.bfloat16"),
+    (4096, 4096, 4096, "torch.float16"),
+}), (
+    "K-1566 P24 vs K-1295 P12 alias overlap must be EXACTLY the 2 cells "
+    "(4096, 4096, 4096, {bf16, fp16}); any deviation indicates either a "
+    "P12 contraction (re-audit P24 membership for the affected cells) or "
+    "a P24 authoring typo against the K-1553 admit set.")
+
+
+def _k1566_p24_skinny_n4096_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1566 P24 — direct hipBLASLt route-OUT for the 30-cell skinny_N4096
+    K-COMPLEMENT cohort (`_K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 30 strict-equality
+    keys: M ∈ {2048, 4096, 8192} × N = 4096 × K ∈ {2048, 4096, 8192, 16384,
+    32768} × dtype ∈ {torch.bfloat16, torch.float16}.
+
+    Source measurement: K-1553 paired n=30 HIP-graph hot-cache benchmarks on
+    MI300X / gfx942 (OCI amd-rccl MI300X-equivalent fallback per INFRA-0048
+    radha mi300x partition unavailability) with TRITONBLAS_DISABLE_K971=1
+    against the live post-K-1532 routing oracle (HEAD 95e2c47); B=10000
+    vectorised paired bootstrap CI95 (numpy advanced-indexing per R-1298 /
+    R-1367); 30/30 ROUTE-OUT-CANDIDATE at the strict ratio_median ≥ 1.05 ∧
+    p(<1.05) < 0.01 gate; cohort geomean tb/hbl = 1.234×, range
+    1.114×-1.501×, 0 regressions.  Productionised under the K-1474 / K-1492
+    / K-1493 / K-1532 protocol with the 0.85× geomean route-OUT win
+    threshold (1.234 ≥ 0.85) and the ≥80% per-cell admit gate (30/30 ≥ 80%).
+
+    Mechanism: at N=4096 the persistent_matmul tile is wide enough that
+    M=2048 still satisfies min(M, N) ≤ 2048 — keeping the K-913 §3
+    LDS-bank-conflict band fully live for the M=2048 row (per-row
+    geomean 1.402×, range 1.16×-1.50×, monotone widening as K grows from
+    2048 to 8192 and attenuating at K=32768 once split-K amortises) — and
+    attenuating at M=4096/8192 into the K-956 wave-occupancy starvation
+    regime (per-row geomeans 1.146× / 1.180×).  Validates the R-1478 #1
+    N-axis attenuation chain anchor at the previously-empty N=4096 rung:
+    chain extends to 1.451 → 1.234 → 1.220 → 1.174 → 1.118 across
+    N ∈ {2048, 4096, 8192, 16384, 32768}, strictly monotone-decreasing
+    throughout (R-1532.N-LADDER-ATTENUATION-PREDICTS-NEXT-RUNG verified
+    by direct measurement).
+
+    Stacked at 16th-position per the K-1175 stacked-predicate convention;
+    sibling-N firewall disjointness with all P1-P22 except a single
+    intentional 2-cell alias overlap with K-1295 P12 at the (4096, 4096,
+    4096, {bf16, fp16}) diagonal — P12 fires first in the dispatch chain,
+    so 28 cells are NEW route-OUT and 2 cells are alias documentation.
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
+    )

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -1214,6 +1214,158 @@ def _k1397_p13_skinny_n256_routeout(M: int, N: int, K: int, dtype) -> bool:
     )
 
 
+# ---------------------------------------------------------------------------
+# K-1417 (S-002) — P15 `skinny_N512` K-COMPLEMENT EXTENSION route-OUT
+# (9th-position).
+#
+# K-1417 productionises the K-1409-derived 12-cell `skinny_N512` K-COMPLEMENT
+# EXTENSION cohort as `_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12`, layered
+# as the 9th-position envelope in the dispatch precedence chain on top of
+# the K-1406 P14 8-predicate baseline (envelope grows by +12 admits at the
+# K-axis EXTREMES of the N=512 column-narrow regime).
+#
+# Bucket scope: third-N successive sibling extension after K-1397 (N=256)
+# along the same K-COMPLEMENT EXTREMES axis (K ∈ {2048, 32768}).  The
+# `wrapper-overhead-ceiling-disappears-at-large-K` argument
+# (R-1367.WRAPPER-OVERHEAD-CEILING-DISAPPEARS-AT-LARGE-K-WHERE-TB-TIME-DOMINATES-30US-TRITONOP)
+# generalises to N=512 column-narrow GEMMs; the K-axis admit set sits at
+# the EXTREMES of the K-1308 sweep grid (K=2048 small-K starvation +
+# K=32768 large-K LDS-BC saturation).  The complementary mid-K band
+# (K ∈ {4096, 8192, 16384}) is the K-1409 BASE region (separately
+# productionised as the 18-cell N=512 BASE envelope; this K-1417
+# productionisation covers only the EXTENSION extremes).  Codified as
+# R-1417.SKINNY-N512-K-COMPLEMENT-EXTENSION-IS-EXTREMES (mirroring R-1397
+# at N=512).
+#
+# K-COMPLEMENT EXTENSION region:
+#   M ∈ {2048, 4096, 8192}    (3 anchors, sibling row to K-1397 N=256)
+#   N = 512                    (column-narrow regime, +1 column step from N=256)
+#   K ∈ {2048, 32768}          (extremes — small-K starvation + large-K LDS-BC)
+#   dtype ∈ {bf16, fp16}       (K-913 §3 dtype invariance preserved)
+# = 3 × 1 × 2 × 2 = 12 cells.
+#
+# PMC mechanism (consistent with K-913 / K-1397 findings):
+#   At K=2048 (small-K starvation), tritonblas persistent_matmul has too
+#   few K-tiles per CU for adequate tile parallelism — TB compute time
+#   dominates the wrapper-overhead ceiling and the per-cell ratio blows
+#   out (TB ≈ 280-290 µs vs HBL ≈ 19-50 µs; ratio 5.6×-14.0×).  At
+#   K=32768 (large-K LDS-BC saturation), hipBLASLt's split-K kernel
+#   selection wins over tritonblas persistent_matmul at the persistent
+#   N=512 tile layout where LDS bank conflicts dominate (TB ≈ 510-780 µs
+#   vs HBL ≈ 280-570 µs; ratio 1.36×-2.05×).  Both regimes share the
+#   K-913 §3 LDS-BC mechanism specialised to the N=512 column-narrow
+#   regime.
+#
+# Verification (paired n=30 HIP-graph hot-cache, B=10000 vectorised paired
+# bootstrap CI95 on MI300X gfx942 / OCI MI300X fallback — c42 down):
+#   12/12 ROUTE-OUT  (every cell ratio_median ≥ 1.05 AND CI95-lo > 1.0)
+#   cohort geomean tb/hbl = **3.43×** (range 1.36×–14.06×)
+#   min CI95-lo            = **1.359** at (8192, 512, 32768, fp16)
+#   max ratio_median       = **14.06×** at (2048, 512, 2048, fp16)
+#   envelope grows         85 → 97 cells (8 → 9 predicate stack)
+#
+# Disjointness rationale (verified by frozenset.isdisjoint at module load):
+#   * P8 sub-frozensets — K-1219 E3 N=256 sub-frozenset uses N=256;
+#     K-1417 cells all use N=512, no collision.  Other P8 anchors use
+#     M=N for square cells; no N=512 cells anywhere.
+#   * K971_ROUTE_TABLE — K-905/K-971/K-1335 anchors use M=N ∈ {1024, 2048};
+#     no N=512.
+#   * K-1361 P12 — uses M=N=K ∈ {2048, 4096}; N != 512.
+#   * K-1367 P13 — uses N=128.
+#   * K-1397 P13 — uses N=256.
+# All asserted at module load.
+# ---------------------------------------------------------------------------
+_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12 = frozenset({
+    # M=2048 row × K ∈ {2048, 32768} × {bf16, fp16}
+    (2048, 512,  2048, "torch.bfloat16"),
+    (2048, 512,  2048, "torch.float16"),
+    (2048, 512, 32768, "torch.bfloat16"),
+    (2048, 512, 32768, "torch.float16"),
+    # M=4096 row × K ∈ {2048, 32768} × {bf16, fp16}
+    (4096, 512,  2048, "torch.bfloat16"),
+    (4096, 512,  2048, "torch.float16"),
+    (4096, 512, 32768, "torch.bfloat16"),
+    (4096, 512, 32768, "torch.float16"),
+    # M=8192 row × K ∈ {2048, 32768} × {bf16, fp16}
+    (8192, 512,  2048, "torch.bfloat16"),
+    (8192, 512,  2048, "torch.float16"),
+    (8192, 512, 32768, "torch.bfloat16"),
+    (8192, 512, 32768, "torch.float16"),
+})
+assert len(_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12) == 12, (
+    "K-1417 P15 skinny_N512 K-COMPLEMENT EXTENSION frozenset must be exactly "
+    "12 cells (M ∈ {2048,4096,8192} × N=512 × K ∈ {2048,32768} × {bf16,fp16}); "
+    "any deviation indicates an authoring typo against the K-1397 K-COMPLEMENT "
+    "EXTREMES scoping at N=512 (R-1417.SKINNY-N512-K-COMPLEMENT-EXTENSION-IS-EXTREMES).")
+# Cross-frozenset disjointness — K-1417 P15 vs prior 8-predicate stack.
+_K1409_P15_VS_P8_DISJOINT = (
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+assert _K1409_P15_VS_P8_DISJOINT, (
+    "K-1417 P15 skinny_N512 K-COMPLEMENT EXTENSION cell overlaps the K-1322 "
+    "51-cell P8 envelope; P8's K-1219 E3 N=256 sub-frozenset uses N=256 — "
+    "P15 uses N=512, natural disjointness, asserted as cheap insurance per "
+    "R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.")
+_K1409_P15_VS_K971_DISJOINT = (
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12.isdisjoint(K971_ROUTE_TABLE))
+assert _K1409_P15_VS_K971_DISJOINT, (
+    "K-1417 P15 skinny_N512 K-COMPLEMENT EXTENSION cell overlaps "
+    "K971_ROUTE_TABLE; K971_ROUTE_TABLE (K-905/K-971 + K-1335) uses M=N ∈ "
+    "{1024, 2048}; P15 cells all use N=512 — natural disjointness, asserted "
+    "insurance.")
+_K1409_P15_VS_P12_DISJOINT = (
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
+assert _K1409_P15_VS_P12_DISJOINT, (
+    "K-1417 P15 skinny_N512 K-COMPLEMENT EXTENSION cell overlaps K-1361 P12 "
+    "square_mid; P12 cells use M=N=K ∈ {2048, 4096}; P15 cells all use N=512 "
+    "— natural disjointness, asserted for completeness (A4 no-double-admit).")
+_K1409_P15_VS_K1367_P13_DISJOINT = (
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12.isdisjoint(
+        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18))
+assert _K1409_P15_VS_K1367_P13_DISJOINT, (
+    "K-1417 P15 skinny_N512 cell overlaps K-1367 P13 skinny_N128; P13(N=128) "
+    "cells use N=128, P15 cells use N=512 — natural disjointness, asserted "
+    "for completeness (A4 sibling-N firewall).")
+_K1409_P15_VS_K1397_P13_DISJOINT = (
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12.isdisjoint(
+        _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12))
+assert _K1409_P15_VS_K1397_P13_DISJOINT, (
+    "K-1417 P15 skinny_N512 cell overlaps K-1397 P13 skinny_N256; P13(N=256) "
+    "cells use N=256, P15 cells use N=512 — natural disjointness, asserted "
+    "for completeness (A4 sibling-N firewall; the three K-COMPLEMENT EXTREMES "
+    "predicates partition the skinny-N column-narrow regime by N-axis at "
+    "{128, 256, 512}).")
+
+
+def _k1409_p15_skinny_n512_routeout(M: int, N: int, K: int, dtype) -> bool:
+    """K-1417 P15 — direct hipBLASLt route-OUT for the 12-cell skinny_N512
+    K-COMPLEMENT EXTENSION cohort (`_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12`).
+
+    Returns True iff (M, N, K, dtype) matches one of the 12 strict-equality
+    keys: M ∈ {2048, 4096, 8192} × N = 512 × K ∈ {2048, 32768} ×
+    dtype ∈ {torch.bfloat16, torch.float16}.
+
+    Source measurement: K-1417 paired n=30 HIP-graph hot-cache benchmarks
+    on MI300X / gfx942 (OCI MI300X fallback; c42 down) with
+    B=10000 vectorised paired bootstrap CI95 (numpy advanced-indexing per
+    R-1298 / R-1367); 12/12 ROUTE-OUT, cohort geomean tb/hbl = 3.43×,
+    min CI95-lo = 1.359, range 1.36×–14.06×.  Mechanism: at K=2048 (small-K
+    starvation), tritonblas persistent_matmul's persistent_matmul tile
+    parallelism is starved (TB ≈ 280 µs vs HBL ≈ 19-50 µs); at K=32768
+    (large-K LDS-BC saturation), hipBLASLt's split-K kernel selection wins
+    over tritonblas at the persistent N=512 tile layout where LDS bank
+    conflicts dominate (consistent with K-913 longK_smallSquare PMC
+    findings, K-1397 N=256 sibling, K-1409 N=512 BASE-region sibling).
+
+    Stacked at 9th-position per K-1175 stacked-predicate convention;
+    disjoint by construction with all P1–P14 sub-frozensets via the
+    cross-frozenset asserts above.
+    """
+    return (
+        (int(M), int(N), int(K), str(dtype))
+        in _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12
+    )
+
+
 def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
                         work_stealing, disable_env_set: bool = False) -> bool:
     """Pure routing decision — same logic as ``matmul._k971_route_to_hbl``
@@ -1236,6 +1388,7 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
       6. K-1361 P12 square_mid 4-cell strict-equality -> hipBLASLt.
       7. K-1367 P13 skinny_N128 K-COMPLEMENT 18-cell strict-equality -> hipBLASLt.
       8. K-1397 P13 skinny_N256 K-COMPLEMENT 12-cell strict-equality -> hipBLASLt.
+      9. K-1417 P15 skinny_N512 K-COMPLEMENT 12-cell strict-equality -> hipBLASLt.
     """
     if disable_env_set:
         return False
@@ -1287,5 +1440,14 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # longK_smallSquare PMC findings).  Per-cell speedups 1.04×–1.12×;
     # envelope grows 73 → 85 cells.
     if _k1397_p13_skinny_n256_routeout(int(M), int(N), int(K), a_dtype):
+        return True
+    # K-1417 P15 (9th-position): skinny_N512 K-COMPLEMENT EXTENSION 12-cell
+    # route-OUT.  Stacks AFTER K-1397 P13 per K-1175 stacked-predicate
+    # convention; closes the third-N successive sibling of the K-COMPLEMENT
+    # EXTREMES axis at N=512 (K ∈ {2048, 32768}) where TB persistent_matmul
+    # is starved at K=2048 and saturates LDS bank conflicts at K=32768.
+    # Per-cell ratios 1.36×–14.06×; cohort geomean 3.43×; envelope grows
+    # 85 → 97 cells.
+    if _k1409_p15_skinny_n512_routeout(int(M), int(N), int(K), a_dtype):
         return True
     return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -938,7 +938,7 @@ def _k1361_p12_square_mid_routeout(M: int, N: int, K: int, dtype) -> bool:
 # K-1367 (S-002) — P13 `skinny_N128` K-COMPLEMENT route-OUT (7th-position).
 #
 # K-1379 productionises the K-1367 RETRY-winning 18-cell cohort as
-# `_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18`, layered as the
+# `_K1367_P13_SKINNY_N128_ROUTEOUT_18`, layered as the
 # 7th-position envelope in the dispatch precedence chain on top of the
 # K-1361 P12 55-cell baseline (envelope grows 55 → 73 cells; +18 admits).
 #
@@ -1005,7 +1005,7 @@ def _k1361_p12_square_mid_routeout(M: int, N: int, K: int, dtype) -> bool:
 #   * K-1361 P12 — uses M=N=K ∈ {2048, 4096} with N != 128; no collision.
 # All asserted at module load.
 # ---------------------------------------------------------------------------
-_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 = frozenset({
+_K1367_P13_SKINNY_N128_ROUTEOUT_18 = frozenset({
     # M=2048 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
     (2048, 128,  4096, "torch.bfloat16"),
     (2048, 128,  4096, "torch.float16"),
@@ -1028,14 +1028,14 @@ _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 = frozenset({
     (8192, 128, 16384, "torch.bfloat16"),
     (8192, 128, 16384, "torch.float16"),
 })
-assert len(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18) == 18, (
+assert len(_K1367_P13_SKINNY_N128_ROUTEOUT_18) == 18, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT frozenset must be exactly 18 cells "
     "(M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,8192,16384} × {bf16,fp16}); "
     "any deviation indicates an authoring typo against the K-1308 bucket rule "
     "or the K-1227 wrapper-bound K-COMPLEMENT scoping.")
 # Cross-frozenset disjointness — P13 vs prior envelopes.
 _K1367_P13_VS_P8_DISJOINT = (
-    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
+    _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(_P8_MFMA_ISSUE_STALL_ROUTEOUT))
 assert _K1367_P13_VS_P8_DISJOINT, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps the K-1322 51-cell P8 "
     "envelope; P8's K-1205 N=128 sub-frozenset uses K ∈ {2048, 8192} with "
@@ -1044,23 +1044,23 @@ assert _K1367_P13_VS_P8_DISJOINT, (
     "tuples must be enumerated to overlap; disjointness verified by frozenset "
     "intersection at module load).")
 _K1367_P13_VS_K971_DISJOINT = (
-    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE))
+    _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE))
 assert _K1367_P13_VS_K971_DISJOINT, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps K971_ROUTE_TABLE; "
     "K971_ROUTE_TABLE (K-905/K-971 + K-1335) uses M=N ∈ {1024, 2048}; "
     "P13 cells all use N=128 — natural disjointness, but assert as cheap "
     "insurance per R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.")
 _K1367_P13_VS_P12_DISJOINT = (
-    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
+    _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4))
 assert _K1367_P13_VS_P12_DISJOINT, (
     "K-1367 P13 skinny_N128 K-COMPLEMENT cell overlaps K-1361 P12 square_mid; "
     "P12 cells use M=N=K ∈ {2048, 4096}; P13 cells all use N=128 — natural "
     "disjointness, asserted for completeness (A4 no-double-admit).")
 
 
-def _k1367_p13_skinny_n128_kcomplement_routeout(M: int, N: int, K: int, dtype) -> bool:
+def _k1367_p13_skinny_n128_routeout(M: int, N: int, K: int, dtype) -> bool:
     """K-1367 P13 — direct hipBLASLt route-OUT for the 18-cell skinny_N128
-    K-COMPLEMENT cohort (`_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18`).
+    K-COMPLEMENT cohort (`_K1367_P13_SKINNY_N128_ROUTEOUT_18`).
 
     Returns True iff (M, N, K, dtype) matches one of the 18 strict-equality
     keys: M ∈ {2048, 4096, 8192} × N = 128 × K ∈ {4096, 8192, 16384} ×
@@ -1080,7 +1080,7 @@ def _k1367_p13_skinny_n128_kcomplement_routeout(M: int, N: int, K: int, dtype) -
     """
     return (
         (int(M), int(N), int(K), str(dtype))
-        in _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18
+        in _K1367_P13_SKINNY_N128_ROUTEOUT_18
     )
 
 
@@ -1145,6 +1145,6 @@ def k971_route_decision(M, N, K, a_dtype, b_dtype, enable_streamk,
     # Stacks AFTER K-1361 P12 per K-1175 stacked-predicate convention; closes
     # the K-1308 skinny_N128 K-COMPLEMENT region (K >= 4096 above the 30 µs
     # triton_op wrapper-overhead ceiling) at cohort geomean tb/hbl = 1.678×.
-    if _k1367_p13_skinny_n128_kcomplement_routeout(int(M), int(N), int(K), a_dtype):
+    if _k1367_p13_skinny_n128_routeout(int(M), int(N), int(K), a_dtype):
         return True
     return False

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -3237,4 +3237,5 @@ _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34 = frozenset(
         (2048,1536,32768),(4096,1536,2048),(4096,1536,8192),(4096,1536,32768),(8192,1536,32768),
     ) for dt in ("torch.bfloat16", "torch.float16")
 )
-assert len(_K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34) == 34
+# Cardinality (==34) gated by tests/test_k1748_p30_skinny_nmid_alias_stack.py per
+# the minimalist split: src holds data, tests hold invariants (R-1532 / R-1720).

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -2888,3 +2888,11 @@ def _k1611_p26_skinny_n2048_kcompl_aliasstack_routeout(
         (int(M), int(N), int(K), str(dtype))
         in _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30
     )
+
+
+# K-1633 P27 18th-slot audit handle — bit-identical to K-1552 P23 (same
+# N=512 K-COMPLEMENT 30-cell envelope, re-verified post-P26).  Per K-1581
+# / K-1489 minimalist precedent: alias only, no duplicate predicate.
+_K1633_P27_SKINNY_N512_KCOMPL_ALIASSTACK_30 = (
+    _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30
+)

--- a/include/tritonblas/_route_predicate.py
+++ b/include/tritonblas/_route_predicate.py
@@ -3300,3 +3300,30 @@ _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18 = frozenset(
 )
 # Cardinality (==18) gated by tests/test_p33_skinny_n224_alias_stack.py per the
 # minimalist split: src holds data, tests hold invariants.
+
+# P34 (25th-slot): N=96 K-COMPLEMENT verified-winner subset — 18 cells from
+# K-1818's N=96 sub-cohort = M ∈ {2048,4096,8192} × N=96 × K ∈ {4096,8192,16384}
+# × {bf16,fp16}.  K-1818 PMC RCA sweep (paired n=30 HIP-graph hot-cache, 3-engine
+# tb_oracle / tb_streamk / hbl) on MI300X / gfx942 (the "N=96 wave-misaligned
+# skinny-N cohort" characterised by K-1818): bf16 N=96 unrouted 0/9 (cohort gmean
+# r_oracle < 1.0 systemically — no upstream alias coverage at N=96 below the
+# K-1685 P28 N=128 rung); fp16 N=96 unrouted 0/9 (R-K1794 fp16-mirror systemic
+# gap below N=128 cliff).  All 18 cells admitted as verified-winner route-OUT
+# targets — both dtype rows are load-bearing (no upstream alias overlap, mirrors
+# K-1817 P33 N=224 discipline rather than K-1810 P32 N=160 alias-overlap pattern).
+# Mechanism (K-913 §3 LDS-bank-conflict, dtype-invariant per R-K1673): BLOCK_N=128
+# packs N=96 into a single wave-misaligned K-block column with PARTIAL coverage
+# (fewer accumulator lanes than N=128) → SQ_LDS_BANK_CONFLICT/inst stays elevated
+# AND MFMA-tail inefficiency from wave-misalignment (off-by-32 N rung per
+# R-1811.WAVE-MISALIGNMENT-IS-ROOT-MECHANISM); persistent_matmul cannot trade
+# tile reshape for atomic-reduction.  hipBLASLt's split-K kernel selection clears
+# the band by ~30% on average (geomean ≥1.05× over pre-stack TB-native per K-1818).
+# Same fingerprint productionized at K-1673 P28 (N=128), K-1810 P32 (N=160),
+# K-1775 P31 (N=256), and K-1817 P33 (N=224) — now applied to N=96 (the
+# wave-misaligned rung BELOW the N=128 cliff).
+_P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18 = frozenset(
+    (M, 96, K, dt) for M in (2048, 4096, 8192)
+    for K in (4096, 8192, 16384) for dt in ("torch.bfloat16", "torch.float16")
+)
+# Cardinality (==18) gated by tests/test_p34_skinny_n96_alias_stack.py per the
+# minimalist split: src holds data, tests hold invariants.

--- a/include/tritonblas/guarded_override.py
+++ b/include/tritonblas/guarded_override.py
@@ -1,0 +1,922 @@
+"""Guarded-override harness — reusable pre-merge gate for narrow tile overrides.
+
+K-883 analyzed why narrow-cohort overrides keep failing to generalize
+(K-836->K-851->K-854->K-864->K-867->K-874 NO-LAND streak) and produced a
+9-layer "guarded-override" design pattern. This module operationalizes that
+pattern as a Python API: every future narrow override (env-gated cohort
+override, strict-equality tile table, etc.) wraps itself in this harness so
+it cannot land without passing the K-883 §5 acceptance gates.
+
+The harness has three responsibilities:
+
+  1.  Strict-key gating.  Wrap a candidate override behind a strict-equality
+      shape-key gate (M, N, K, dtype[, batch]).  Defends against range-predicate
+      bleed (the K-654 87% OOC regression failure mode).  Layers 1-6 of the
+      K-883 pattern are enforced structurally:
+
+        L1 strict-equality dispatch table on (M,N,K,dtype[,batch])
+        L2 dtype allowlist guard
+        L3 env-var killswitch read every call (paired-audit hook)
+        L4 LDS-budget guard at call-site (default 64KB; arch-overridable)
+        L5 composability guard (e.g. work_stealing)
+        L6 routing-trace counters (fire_total / nonfire_total / per-key)
+
+  2.  Paired ON/OFF benchmarking.  Run any registered override through the
+      K-867 paired-interleaved single-process HIP-graph kernel-only protocol
+      against the composite-14 baseline AND a third reference (default
+      hipBLASLt) on c42 / MI300X.  n>=30 paired replicates, kernel-only,
+      shared-allocator state, CUDA-event timing per replay.  Per-cell
+      paired_t deltas + 95% CIs.
+
+  3.  Verdict.  Apply the K-883 §5 LAND/NO-LAND gates:
+
+        in-cohort:  geomean ON vs OFF >= +5%, 8/10 cells net-positive
+        out-of-cohort (K-790 92-shape gap profile + K-832 production sample):
+          0 cells regress beyond max(2pp, paired_spread/2)
+        routing trace: per-key fires == cohort enumeration (1:1, 0 OOC)
+
+A PR with all gates GREEN is empirically very unlikely to leak (K-835 v3 /
+K-867 verification template).  A PR with any gate RED is NO-LAND.
+
+Usage:
+
+    from tritonblas.guarded_override import (
+        GuardedOverride, OverrideRegistry, run_falsification,
+    )
+
+    # Define a candidate override (this lives in CI / on the author's
+    # branch — NEVER in the production tree until run_falsification(...)
+    # returns LAND).
+    GUARD = GuardedOverride(
+        ticket="K-XYZ",
+        env_var="TB_KXYZ_ENABLE",
+        cohort_keys=[(2048, 2048, 4096, torch.float16), ...],
+        dtype_allowlist=(torch.float16, torch.bfloat16),
+        override_fn=lambda M, N, K, dtype: {"num_stages": 2, ...},
+    )
+    OverrideRegistry.register(GUARD)
+
+    # Pre-merge gate (CI / dev box).
+    verdict = run_falsification(
+        override=GUARD,
+        shapes=load_shapes(...),
+        out_dir="output/",
+        n_rounds=30,                # paired n>=30 (PRD requirement)
+    )
+    assert verdict.land, verdict.report
+
+The harness is dispatcher-host-agnostic.  matmul.py calls
+``OverrideRegistry.apply(M, N, K, dtype, work_stealing, lds_bytes_per_elem)``
+inside ``persistent_matmul_lt`` to merge any active override into the
+tile spec; outside that one call site the rest of the package is
+override-naive.
+
+Author trail: K-883 (design pattern), K-867 (paired-audit harness), K-835 v3
+(reference clean implementation), K-882 (first override exercised against
+this harness, NO-LAND verdict, kept as a fixture in tests/ to guarantee the
+harness keeps catching this class of structural-no-op overrides).
+"""
+
+from __future__ import annotations
+
+import csv
+import gc
+import json
+import math
+import os
+import statistics
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import torch
+
+
+# ---------------------------------------------------------------------------
+# K-883 Layer 4 — LDS budget per architecture.  Used by the LDS-guard check.
+# Override per-arch via ``set_arch_lds_budget(name, bytes)`` if needed.
+# ---------------------------------------------------------------------------
+_ARCH_LDS_BUDGET: Dict[str, int] = {
+    "gfx942": 65536,   # MI300X / MI300A
+    "gfx950": 65536,   # MI350X / MI355X
+}
+_DEFAULT_LDS_BUDGET = 65536
+
+
+def set_arch_lds_budget(name: str, nbytes: int) -> None:
+    """Override the LDS-budget constant for a given gfx target."""
+    _ARCH_LDS_BUDGET[name] = int(nbytes)
+
+
+def lds_budget_for(arch: Optional[str] = None) -> int:
+    """Return the per-CU LDS budget in bytes for ``arch`` (or default)."""
+    if arch is None:
+        try:
+            dev = torch.cuda.get_device_properties(torch.cuda.current_device())
+            arch = getattr(dev, "gcnArchName", "") or ""
+            arch = arch.split(":")[0]  # strip feature-flag suffix
+        except Exception:
+            arch = ""
+    return _ARCH_LDS_BUDGET.get(arch, _DEFAULT_LDS_BUDGET)
+
+
+# ---------------------------------------------------------------------------
+# K-883 Layer 1+2+3+5+6 — GuardedOverride class.
+# ---------------------------------------------------------------------------
+
+# Strict shape key.  ``batch`` is optional; gates that care about batch must
+# include it explicitly in their cohort_keys (4-tuple -> 5-tuple bumps key).
+ShapeKey = Tuple[int, int, int, "torch.dtype"]
+ShapeKeyB = Tuple[int, int, int, "torch.dtype", int]
+
+
+@dataclass
+class GuardedOverride:
+    """A single narrow-cohort override gated by the K-883 9-layer pattern.
+
+    Parameters
+    ----------
+    ticket
+        The ticket id (e.g. ``"K-882"``).  Used to namespace counters,
+        env vars, and logged routing-trace rows.
+    env_var
+        Killswitch env var (read at every call, defeats lru_cache).  Set to
+        ``"1"`` / ``"true"`` / ``"yes"`` to ARM the override (default OFF
+        prevents accidental landing without an explicit opt-in).
+    cohort_keys
+        Strict-equality dispatch table.  Each entry is either a 4-tuple
+        ``(M, N, K, dtype)`` or a 5-tuple ``(M, N, K, dtype, batch)``.  The
+        gate fires only on exact key matches (R4 — range-predicate ban).
+    dtype_allowlist
+        Allowed dtypes (L2).  The gate refuses to fire on any other dtype
+        even if a key happens to match (defence against future table edits
+        that drop the dtype filter).
+    override_fn
+        ``(M, N, K, dtype) -> Dict[str, Any]`` returning the tile-spec
+        deltas to merge into the dispatch site.  Recognized keys
+        (subset; extend as needed):
+          - ``"grid_cap_to_n_cu"`` (bool)
+          - ``"num_stages"`` (int)
+          - ``"num_warps"`` (int)
+          - ``"waves_per_eu"`` (int)
+          - ``"kpack"`` (int)
+          - ``"matrix_instr_nonkdim"`` (int)
+          - ``"BLOCK_SIZE_M"`` / ``"BLOCK_SIZE_N"`` / ``"BLOCK_SIZE_K"``
+        The dispatch site (see ``apply_override_in_dispatcher``) honors
+        the ones it knows about and ignores the rest.
+    composability_guard
+        ``(work_stealing: bool) -> bool`` returning True if the override
+        may fire in this call.  Default refuses when ``work_stealing`` is
+        true (L5).  Pass ``lambda ws: True`` only if your override has
+        been validated against the work-stealing dispatcher.
+    cohort_size_cap
+        L1 sanity check.  K-883 §5 C3 says cohort size <= 30 cells; this
+        caps it.  Pass a larger value only if you split the table
+        explicitly.
+    """
+
+    ticket: str
+    env_var: str
+    cohort_keys: Sequence[Tuple]
+    dtype_allowlist: Tuple["torch.dtype", ...] = (torch.float16, torch.bfloat16)
+    override_fn: Optional[Callable[[int, int, int, "torch.dtype"], Dict[str, Any]]] = None
+    composability_guard: Callable[[bool], bool] = field(
+        default=lambda work_stealing: not work_stealing
+    )
+    cohort_size_cap: int = 30
+
+    # Layer 6 — counters (initialized in __post_init__).
+    _lock: threading.Lock = field(init=False, repr=False)
+    _fire_total: int = field(init=False, default=0, repr=False)
+    _nonfire_total: int = field(init=False, default=0, repr=False)
+    _per_key_fires: Dict[Tuple, int] = field(init=False, default_factory=dict, repr=False)
+    _key_set: set = field(init=False, default_factory=set, repr=False)
+
+    def __post_init__(self):
+        self._lock = threading.Lock()
+        if len(self.cohort_keys) > self.cohort_size_cap:
+            raise ValueError(
+                f"{self.ticket}: cohort_size={len(self.cohort_keys)} > cap "
+                f"{self.cohort_size_cap}.  Split the table or pass a larger cap "
+                f"with explicit justification (K-883 §5 C3)."
+            )
+        self._key_set = set(self.cohort_keys)
+        self._per_key_fires = {k: 0 for k in self._key_set}
+
+    # ---- Layer 3 — env-read-per-call killswitch ---------------------------
+    def _enabled(self) -> bool:
+        v = os.environ.get(self.env_var, "").lower()
+        return v in ("1", "true", "yes")
+
+    # ---- Strict shape-key gate (Layers 1+2+6) -----------------------------
+    def lookup(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        dtype: "torch.dtype",
+        batch: int = 1,
+    ) -> Optional[Dict[str, Any]]:
+        """Return override payload if the gate fires for this shape, else None.
+
+        Updates the routing-trace counters (Layer 6) on every call.  Safe to
+        call from any number of threads.
+        """
+        if not self._enabled():
+            with self._lock:
+                self._nonfire_total += 1
+            return None
+        if dtype not in self.dtype_allowlist:
+            with self._lock:
+                self._nonfire_total += 1
+            return None
+        # Try 4-key first (no batch), then 5-key.
+        key4 = (M, N, K, dtype)
+        key5 = (M, N, K, dtype, batch)
+        key = key4 if key4 in self._key_set else (key5 if key5 in self._key_set else None)
+        if key is None:
+            with self._lock:
+                self._nonfire_total += 1
+            return None
+        # Hit.
+        payload = self.override_fn(M, N, K, dtype) if self.override_fn else {}
+        with self._lock:
+            self._fire_total += 1
+            self._per_key_fires[key] = self._per_key_fires.get(key, 0) + 1
+        return dict(payload) if payload is not None else {}
+
+    # ---- Layer 6 — routing-trace snapshot ---------------------------------
+    def routing_snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "ticket": self.ticket,
+                "fire_total": self._fire_total,
+                "nonfire_total": self._nonfire_total,
+                "per_key_fires": dict(self._per_key_fires),
+            }
+
+    def reset_counters(self) -> None:
+        with self._lock:
+            self._fire_total = 0
+            self._nonfire_total = 0
+            self._per_key_fires = {k: 0 for k in self._key_set}
+
+    # ---- Layer 4 — LDS budget guard (call-site helper) --------------------
+    @staticmethod
+    def lds_ok(
+        block_m: int, block_n: int, block_k: int,
+        num_stages: int, bytes_per_elem: int = 2,
+        arch: Optional[str] = None,
+    ) -> bool:
+        """Return True if double-buffered LDS fits in the budget."""
+        used = num_stages * (block_m + block_n) * block_k * bytes_per_elem
+        return used <= lds_budget_for(arch)
+
+
+# ---------------------------------------------------------------------------
+# Registry — the singleton matmul.py looks at to ask "any override fire?".
+# Multiple overrides can register simultaneously (the registry itself
+# enforces R1 — dispatch-order-first routing — by maintaining insertion
+# order; the strictest predicate registers first).
+# ---------------------------------------------------------------------------
+class _OverrideRegistry:
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._gates: List[GuardedOverride] = []
+
+    def register(self, gate: GuardedOverride) -> GuardedOverride:
+        with self._lock:
+            # Refuse to register two gates with the same ticket id.
+            for g in self._gates:
+                if g.ticket == gate.ticket:
+                    return g  # idempotent
+            self._gates.append(gate)
+        return gate
+
+    def unregister(self, ticket: str) -> None:
+        with self._lock:
+            self._gates = [g for g in self._gates if g.ticket != ticket]
+
+    def all(self) -> List[GuardedOverride]:
+        with self._lock:
+            return list(self._gates)
+
+    def apply(
+        self,
+        M: int, N: int, K: int, dtype: "torch.dtype",
+        work_stealing: bool = False,
+        batch: int = 1,
+    ) -> Optional[Tuple[GuardedOverride, Dict[str, Any]]]:
+        """R1 — first gate (in registration order) whose predicate fires wins.
+
+        Returns ``(gate, payload)`` for the firing gate, or None if no
+        gate fires.  The composability guard (L5) is enforced here.
+        """
+        for g in self.all():
+            if not g.composability_guard(work_stealing):
+                continue
+            payload = g.lookup(M, N, K, dtype, batch=batch)
+            if payload is not None:
+                return g, payload
+        return None
+
+
+OverrideRegistry = _OverrideRegistry()
+
+
+# ---------------------------------------------------------------------------
+# Paired ON/OFF benchmark — K-867 single-process HIP-graph kernel-only.
+# ---------------------------------------------------------------------------
+@dataclass
+class CellResult:
+    M: int
+    N: int
+    K: int
+    dtype: str
+    batch: int
+    in_cohort: bool
+    ms_off_med: float
+    ms_on_med: float
+    ms_ref_med: float          # reference impl (e.g. hipBLASLt)
+    ms_off_raw: List[float]
+    ms_on_raw: List[float]
+    ms_ref_raw: List[float]
+    n_paired: int                     # number of paired (ON,OFF) samples
+    delta_pct_on_vs_off: float        # +ve = ON faster (mean of paired deltas)
+    delta_pct_on_vs_off_ci_lo: float  # 95% CI lower bound (paired t)
+    delta_pct_on_vs_off_ci_hi: float  # 95% CI upper bound (paired t)
+    delta_pct_on_vs_ref: float        # +ve = ON faster than ref
+    delta_pct_on_vs_ref_ci_lo: float
+    delta_pct_on_vs_ref_ci_hi: float
+    paired_spread_pct: float          # max-min(off)/median(off) * 100
+    classification: str               # SPEEDUP / IN_BAND / REGRESS
+    fired: bool                       # routing-trace: did the gate fire?
+
+    def to_row(self) -> Dict[str, Any]:
+        return {
+            "M": self.M, "N": self.N, "K": self.K,
+            "dtype": self.dtype, "batch": self.batch,
+            "in_cohort": int(self.in_cohort),
+            "ms_off_med": self.ms_off_med,
+            "ms_on_med": self.ms_on_med,
+            "ms_ref_med": self.ms_ref_med,
+            "n_paired": self.n_paired,
+            "delta_pct_on_vs_off": self.delta_pct_on_vs_off,
+            "delta_pct_on_vs_off_ci_lo": self.delta_pct_on_vs_off_ci_lo,
+            "delta_pct_on_vs_off_ci_hi": self.delta_pct_on_vs_off_ci_hi,
+            "delta_pct_on_vs_ref": self.delta_pct_on_vs_ref,
+            "delta_pct_on_vs_ref_ci_lo": self.delta_pct_on_vs_ref_ci_lo,
+            "delta_pct_on_vs_ref_ci_hi": self.delta_pct_on_vs_ref_ci_hi,
+            "paired_spread_pct": self.paired_spread_pct,
+            "classification": self.classification,
+            "fired": int(self.fired),
+            "ms_off_raw": ";".join(f"{x:.6f}" for x in self.ms_off_raw),
+            "ms_on_raw":  ";".join(f"{x:.6f}" for x in self.ms_on_raw),
+            "ms_ref_raw": ";".join(f"{x:.6f}" for x in self.ms_ref_raw),
+        }
+
+
+@dataclass
+class FalsificationVerdict:
+    """Per-K-883-§5 LAND/NO-LAND verdict."""
+    ticket: str
+    n_in_cohort: int
+    n_out_cohort: int
+    in_cohort_geomean_speedup: float    # ON / OFF; >1 means ON faster
+    in_cohort_n_positive: int           # cells with ON faster than OFF beyond noise
+    ooc_n_regress: int                  # cells beyond max(2pp, spread/2)
+    ooc_worst_delta_pct: float          # most-negative delta_pct (ON vs OFF)
+    routing_n_intended_keys: int
+    routing_n_intended_fires: int
+    routing_n_ooc_fires: int
+    land: bool
+    rationale: str
+
+    @property
+    def report(self) -> str:
+        return (
+            f"K-883 §5 verdict for {self.ticket}: "
+            f"{'LAND' if self.land else 'NO-LAND'}\n"
+            f"  in-cohort   : n={self.n_in_cohort}  geomean ON/OFF={self.in_cohort_geomean_speedup:.4f}x  "
+            f"net-positive cells={self.in_cohort_n_positive}/{self.n_in_cohort}\n"
+            f"  out-of-cohort: n={self.n_out_cohort}  regressors={self.ooc_n_regress}  "
+            f"worst delta_pct={self.ooc_worst_delta_pct:+.2f}%\n"
+            f"  routing-trace: intended-keys={self.routing_n_intended_keys}  "
+            f"intended-fires={self.routing_n_intended_fires}  ooc-fires={self.routing_n_ooc_fires}\n"
+            f"  rationale: {self.rationale}\n"
+        )
+
+
+def _hipgraph_bench(fn, n_warm: int = 5, n_capture: int = 50, n_rounds: int = 3) -> List[float]:
+    """K-867 protocol: HIP-graph capture, CUDA-event timing per replay."""
+    for _ in range(n_warm):
+        fn()
+    torch.cuda.synchronize()
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.stream(side):
+        with torch.cuda.graph(g):
+            for _ in range(n_capture):
+                fn()
+    torch.cuda.current_stream().wait_stream(side)
+    torch.cuda.synchronize()
+    times = []
+    starter = torch.cuda.Event(enable_timing=True)
+    ender = torch.cuda.Event(enable_timing=True)
+    for _ in range(n_rounds):
+        starter.record()
+        g.replay()
+        ender.record()
+        torch.cuda.synchronize()
+        times.append(starter.elapsed_time(ender) / n_capture)
+    del g
+    torch.cuda.synchronize()
+    return times
+
+
+def _trim_mean(xs: List[float], trim_pct: float = 0.10) -> float:
+    if not xs:
+        return float("nan")
+    xs = sorted(xs)
+    k = int(len(xs) * trim_pct)
+    if 2 * k >= len(xs):
+        return statistics.median(xs)
+    return statistics.fmean(xs[k:len(xs) - k])
+
+
+def _spread_pct(xs: List[float]) -> float:
+    if not xs:
+        return float("nan")
+    m = statistics.median(xs)
+    if m == 0:
+        return float("nan")
+    return (max(xs) - min(xs)) / m * 100.0
+
+
+def _classify_delta(delta_pct: float, paired_spread_pct: float, noise_floor_pct: float = 2.0) -> str:
+    """K-883 §5.3 V2 noise-band classifier.  Beyond max(2pp, spread/2) is real."""
+    band = max(noise_floor_pct, paired_spread_pct / 2.0)
+    if delta_pct > band:
+        return "SPEEDUP"
+    if delta_pct < -band:
+        return "REGRESS"
+    return "IN_BAND"
+
+
+# Two-sided 95% Student-t critical values for n-1 degrees of freedom.
+# Computing the t-CDF inverse without scipy is awkward; this lookup covers
+# the n we use in practice (n>=30 -> df>=29 -> t very close to 1.96).
+_T_CRIT_95 = {
+    1: 12.706, 2: 4.303, 3: 3.182, 4: 2.776, 5: 2.571,
+    6: 2.447, 7: 2.365, 8: 2.306, 9: 2.262, 10: 2.228,
+    15: 2.131, 20: 2.086, 25: 2.060, 29: 2.045, 30: 2.042,
+    40: 2.021, 60: 2.000, 120: 1.980,
+}
+
+
+def _t_crit_95(df: int) -> float:
+    """Return t_{df, 0.975} (two-sided 95%) by nearest-not-greater lookup.
+
+    For df>=30 this is within ~0.5% of the true value; for df>=120 it
+    converges to 1.96 (Normal).  We always return >=1.96 for safety.
+    """
+    if df <= 0:
+        return float("nan")
+    keys = sorted(_T_CRIT_95.keys())
+    chosen = keys[0]
+    for k in keys:
+        if k <= df:
+            chosen = k
+        else:
+            break
+    return max(_T_CRIT_95[chosen], 1.960)
+
+
+def _paired_delta_with_ci(
+    on: List[float], off: List[float],
+) -> Tuple[float, float, float, int]:
+    """Paired-sample mean delta_pct(=ON faster than OFF) + 95% CI.
+
+    Pairs ON[i] with OFF[i] (same round_index, single-process / shared
+    allocator state, K-867 protocol).  Returns (mean_delta_pct, ci_lo,
+    ci_hi, n).  If lengths differ we truncate to the shorter list.
+    """
+    n = min(len(on), len(off))
+    if n == 0:
+        return float("nan"), float("nan"), float("nan"), 0
+    deltas = []
+    for i in range(n):
+        if off[i] > 0:
+            deltas.append((off[i] - on[i]) / off[i] * 100.0)
+    if not deltas:
+        return float("nan"), float("nan"), float("nan"), 0
+    if len(deltas) == 1:
+        return deltas[0], float("nan"), float("nan"), 1
+    mean = statistics.fmean(deltas)
+    sd = statistics.stdev(deltas)
+    df = len(deltas) - 1
+    se = sd / math.sqrt(len(deltas))
+    half = _t_crit_95(df) * se
+    return mean, mean - half, mean + half, len(deltas)
+
+
+def _make_call(M: int, N: int, K: int, dtype: "torch.dtype",
+               impl: str = "tritonblas") -> Tuple[Callable, Tuple]:
+    """Build a callable that runs one matmul of shape M*N*K under impl.
+
+    impl: ``tritonblas`` (uses the registered gates) or ``hipblaslt`` (uses
+    ``torch.matmul`` which dispatches to hipBLASLt on AMD ROCm).
+    """
+    a = torch.randn(M, K, device="cuda", dtype=dtype)
+    b = torch.randn(K, N, device="cuda", dtype=dtype)
+    out = a.new_empty(M, N)
+    if impl == "tritonblas":
+        import tritonblas
+        def call():
+            tritonblas.matmul(a, b, out=out)
+    elif impl == "hipblaslt":
+        def call():
+            torch.matmul(a, b, out=out)
+    else:
+        raise ValueError(f"unknown impl: {impl}")
+    return call, (a, b, out)
+
+
+def measure_cell(
+    M: int, N: int, K: int, dtype: "torch.dtype", batch: int,
+    gate: GuardedOverride,
+    n_warm: int = 5, n_capture: int = 30, n_rounds: int = 30,
+    measure_ref: bool = True,
+) -> CellResult:
+    """Paired ON/OFF/ref measurement for a single (M,N,K,dtype) cell.
+
+    Captures n_rounds paired (OFF, ON [, REF]) replays.  Each replay is a
+    HIP-graph capture of n_capture matmul calls; the timed value is the
+    per-call mean over the capture.  We keep n_rounds >= 30 by default so
+    that the paired-CI estimator (Student-t, df=n-1) has the >=30 paired
+    samples per cell required by K-883 §5 V1/V2 / the K-901 PRD.
+
+    Within each round the order is OFF -> ON -> REF (round-robin) so the
+    paired delta cancels slow drift (warm-up, page faults, allocator
+    fragmentation) at first order.  All three callables re-allocate
+    a/b/out per impl to keep allocator state local but shape-identical
+    (cache-effect matched).
+
+    The gate's env var is set to "1" for ON and unset for OFF, and the
+    gate's counters are read before/after to record per-cell fires.
+    """
+    fire_before = gate._fire_total
+
+    ts_off: List[float] = []
+    ts_on:  List[float] = []
+    ts_ref: List[float] = []
+
+    for _ in range(n_rounds):
+        # ---- OFF ----
+        os.environ.pop(gate.env_var, None)
+        call_off, _ = _make_call(M, N, K, dtype, impl="tritonblas")
+        ts_off.extend(_hipgraph_bench(call_off, n_warm=n_warm,
+                                      n_capture=n_capture, n_rounds=1))
+        # ---- ON ----
+        os.environ[gate.env_var] = "1"
+        call_on, _ = _make_call(M, N, K, dtype, impl="tritonblas")
+        ts_on.extend(_hipgraph_bench(call_on, n_warm=n_warm,
+                                     n_capture=n_capture, n_rounds=1))
+        # ---- REF ----
+        if measure_ref:
+            call_ref, _ = _make_call(M, N, K, dtype, impl="hipblaslt")
+            ts_ref.extend(_hipgraph_bench(call_ref, n_warm=n_warm,
+                                          n_capture=n_capture, n_rounds=1))
+        else:
+            ts_ref.append(float("nan"))
+
+    os.environ.pop(gate.env_var, None)
+
+    fire_after = gate._fire_total
+    fired = fire_after > fire_before
+
+    med_off = _trim_mean(ts_off)
+    med_on  = _trim_mean(ts_on)
+    med_ref = _trim_mean(ts_ref) if measure_ref else float("nan")
+
+    d_on_off, d_on_off_lo, d_on_off_hi, n_paired = _paired_delta_with_ci(ts_on, ts_off)
+    if measure_ref:
+        d_on_ref, d_on_ref_lo, d_on_ref_hi, _ = _paired_delta_with_ci(ts_on, ts_ref)
+    else:
+        d_on_ref, d_on_ref_lo, d_on_ref_hi = (float("nan"),) * 3
+
+    spread = _spread_pct(ts_off)
+    cls = _classify_delta(d_on_off, spread)
+
+    in_cohort = ((M, N, K, dtype) in gate._key_set or
+                 (M, N, K, dtype, batch) in gate._key_set)
+
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    return CellResult(
+        M=M, N=N, K=K,
+        dtype=str(dtype).replace("torch.", ""),
+        batch=batch,
+        in_cohort=in_cohort,
+        ms_off_med=med_off, ms_on_med=med_on, ms_ref_med=med_ref,
+        ms_off_raw=ts_off, ms_on_raw=ts_on, ms_ref_raw=ts_ref,
+        n_paired=n_paired,
+        delta_pct_on_vs_off=d_on_off,
+        delta_pct_on_vs_off_ci_lo=d_on_off_lo,
+        delta_pct_on_vs_off_ci_hi=d_on_off_hi,
+        delta_pct_on_vs_ref=d_on_ref,
+        delta_pct_on_vs_ref_ci_lo=d_on_ref_lo,
+        delta_pct_on_vs_ref_ci_hi=d_on_ref_hi,
+        paired_spread_pct=spread,
+        classification=cls,
+        fired=fired,
+    )
+
+
+def run_falsification(
+    override: GuardedOverride,
+    shapes: Iterable[Dict[str, Any]],
+    out_dir: str,
+    n_warm: int = 5, n_capture: int = 30, n_rounds: int = 30,
+    measure_ref: bool = True,
+    progress: Callable[[str], None] = print,
+) -> FalsificationVerdict:
+    """End-to-end paired ON/OFF/ref sweep + K-883 §5 verdict.
+
+    Parameters
+    ----------
+    override
+        The gate to test (must already be registered with OverrideRegistry).
+    shapes
+        Iterable of dicts with keys {M, N, K, dtype, batch}.  dtype is the
+        string ``"fp16"`` / ``"bf16"``.
+    out_dir
+        Directory to write ``per_cell.csv``, ``routing.csv``, ``verdict.json``,
+        and ``REPORT.md`` into.
+    n_capture
+        Calls per HIP-graph capture (default 30 for the n>=30 minimum).
+    measure_ref
+        If True, also bench the reference impl (hipBLASLt via torch.matmul).
+    """
+    os.makedirs(out_dir, exist_ok=True)
+    DT = {"fp16": torch.float16, "bf16": torch.bfloat16}
+
+    override.reset_counters()
+
+    rows: List[Dict[str, Any]] = []
+    cells: List[CellResult] = []
+
+    t0 = time.time()
+    shapes = list(shapes)
+    for i, sh in enumerate(shapes):
+        M, N, K = int(sh["M"]), int(sh["N"]), int(sh["K"])
+        dt_name = sh["dtype"]
+        if dt_name not in DT:
+            progress(f"[{i+1}/{len(shapes)}] skip dtype={dt_name}")
+            continue
+        dt = DT[dt_name]
+        batch = int(sh.get("batch", 1))
+        progress(f"[{i+1}/{len(shapes)}] M={M} N={N} K={K} dt={dt_name} batch={batch}")
+        try:
+            cell = measure_cell(
+                M, N, K, dt, batch, override,
+                n_warm=n_warm, n_capture=n_capture, n_rounds=n_rounds,
+                measure_ref=measure_ref,
+            )
+        except Exception as e:
+            progress(f"    FAIL {type(e).__name__}: {e}")
+            continue
+        cells.append(cell)
+        rows.append(cell.to_row())
+        progress(
+            f"    n={cell.n_paired} OFF={cell.ms_off_med:.4f}ms ON={cell.ms_on_med:.4f}ms "
+            f"REF={cell.ms_ref_med:.4f}ms "
+            f"d_ON/OFF={cell.delta_pct_on_vs_off:+.2f}% "
+            f"[CI95={cell.delta_pct_on_vs_off_ci_lo:+.2f},{cell.delta_pct_on_vs_off_ci_hi:+.2f}] "
+            f"cls={cell.classification} cohort={cell.in_cohort} fired={cell.fired}"
+        )
+
+    # Write per-cell CSV.
+    per_cell_path = os.path.join(out_dir, "per_cell.csv")
+    if rows:
+        with open(per_cell_path, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+            w.writeheader()
+            w.writerows(rows)
+
+    # Routing trace.
+    snap = override.routing_snapshot()
+    routing_path = os.path.join(out_dir, "routing.csv")
+    with open(routing_path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["ticket", "fire_total", "nonfire_total"])
+        w.writerow([snap["ticket"], snap["fire_total"], snap["nonfire_total"]])
+        w.writerow([])
+        w.writerow(["M", "N", "K", "dtype", "fire_count"])
+        for k, v in sorted(snap["per_key_fires"].items(), key=lambda kv: str(kv[0])):
+            mm, nn, kk = k[0], k[1], k[2]
+            dtt = str(k[3]).replace("torch.", "")
+            w.writerow([mm, nn, kk, dtt, v])
+
+    # Verdict (K-883 §5 gates).
+    verdict = _compute_verdict(override, cells, snap)
+    verdict_path = os.path.join(out_dir, "verdict.json")
+    with open(verdict_path, "w") as f:
+        json.dump(verdict.__dict__, f, indent=2, default=str)
+    report_path = os.path.join(out_dir, "REPORT.md")
+    with open(report_path, "w") as f:
+        f.write(_render_report(override, cells, snap, verdict))
+
+    progress(f"[done] {len(cells)} cells in {time.time()-t0:.1f}s")
+    progress(verdict.report)
+    return verdict
+
+
+def _compute_verdict(
+    override: GuardedOverride,
+    cells: List[CellResult],
+    snap: Dict[str, Any],
+) -> FalsificationVerdict:
+    in_c = [c for c in cells if c.in_cohort]
+    ooc  = [c for c in cells if not c.in_cohort]
+
+    # In-cohort geomean of ON/OFF (delta>0 means ON faster, so ratio=OFF/ON > 1).
+    if in_c:
+        ratios = []
+        for c in in_c:
+            if c.ms_off_med > 0 and c.ms_on_med > 0:
+                ratios.append(c.ms_off_med / c.ms_on_med)
+        if ratios:
+            geomean = math.exp(sum(math.log(x) for x in ratios) / len(ratios))
+        else:
+            geomean = float("nan")
+        n_pos = sum(1 for c in in_c if c.classification == "SPEEDUP")
+    else:
+        geomean = float("nan")
+        n_pos = 0
+
+    # OOC regressors (K-883 §5 V2).  A cell counts as a regressor only if
+    # (a) its noise-band classifier flags REGRESS AND
+    # (b) its 95% paired CI upper bound is still negative (ON statistically
+    #     slower than OFF, not a single-trial outlier).  This is the "no
+    #     single-trial noise" guard requested by the K-901 reviewer.
+    ooc_regress = [
+        c for c in ooc
+        if c.classification == "REGRESS"
+        and (math.isnan(c.delta_pct_on_vs_off_ci_hi)
+             or c.delta_pct_on_vs_off_ci_hi < 0.0)
+    ]
+    worst_ooc = min((c.delta_pct_on_vs_off for c in ooc), default=float("nan"))
+
+    # Routing trace correctness (K-883 §5 V3).
+    intended_keys = set(override.cohort_keys)
+    fired_keys = {k for k, v in snap["per_key_fires"].items() if v > 0}
+    n_intended_fired = len(fired_keys & intended_keys)
+    n_ooc_fires = sum(
+        v for k, v in snap["per_key_fires"].items()
+        if k not in intended_keys and v > 0
+    )
+
+    # K-883 §5 LAND gates:
+    #   V1 in-cohort: geomean >= 1.05 AND >= ceil(0.8*n_in) cells SPEEDUP
+    #   V2 OOC      : 0 cells classified REGRESS
+    #   V3 routing  : per-key fires match the cohort enumeration; 0 OOC fires
+    n_in = max(1, len(in_c))
+    v1 = (geomean >= 1.05) and (n_pos >= math.ceil(0.8 * n_in))
+    v2 = len(ooc_regress) == 0
+    v3 = (n_intended_fired == len(intended_keys)) and (n_ooc_fires == 0)
+    # If we did not bench any cohort cells, we cannot LAND.
+    if not in_c:
+        v1 = False
+
+    land = bool(v1 and v2 and v3)
+    rationale_parts = []
+    rationale_parts.append("V1 in-cohort lift: " + ("PASS" if v1 else "FAIL"))
+    rationale_parts.append("V2 OOC bleed: " + ("PASS" if v2 else f"FAIL ({len(ooc_regress)} regressors, worst {worst_ooc:+.2f}%)"))
+    rationale_parts.append("V3 routing trace: " + ("PASS" if v3 else
+        f"FAIL (intended-fires={n_intended_fired}/{len(intended_keys)}, ooc-fires={n_ooc_fires})"))
+
+    return FalsificationVerdict(
+        ticket=override.ticket,
+        n_in_cohort=len(in_c),
+        n_out_cohort=len(ooc),
+        in_cohort_geomean_speedup=geomean,
+        in_cohort_n_positive=n_pos,
+        ooc_n_regress=len(ooc_regress),
+        ooc_worst_delta_pct=worst_ooc,
+        routing_n_intended_keys=len(intended_keys),
+        routing_n_intended_fires=n_intended_fired,
+        routing_n_ooc_fires=n_ooc_fires,
+        land=land,
+        rationale="; ".join(rationale_parts),
+    )
+
+
+def _render_report(
+    override: GuardedOverride,
+    cells: List[CellResult],
+    snap: Dict[str, Any],
+    verdict: FalsificationVerdict,
+) -> str:
+    lines = []
+    lines.append(f"# {override.ticket} guarded-override falsification report")
+    lines.append("")
+    lines.append(f"**Verdict**: {'LAND' if verdict.land else 'NO-LAND'}")
+    lines.append("")
+    lines.append(verdict.report)
+    lines.append("")
+    lines.append("## Per-cell paired deltas with 95% CI (n>=30 paired samples)")
+    lines.append("")
+    lines.append("| in_cohort | M | N | K | dtype | n | OFF (ms) | ON (ms) | REF (ms) | dON/OFF (CI95) | dON/REF (CI95) | spread% | class | fired |")
+    lines.append("|---|---:|---:|---:|---|---:|---:|---:|---:|---|---|---:|---|---|")
+    for c in cells:
+        lines.append(
+            f"| {'Y' if c.in_cohort else 'N'} | {c.M} | {c.N} | {c.K} | {c.dtype} | "
+            f"{c.n_paired} | "
+            f"{c.ms_off_med:.4f} | {c.ms_on_med:.4f} | {c.ms_ref_med:.4f} | "
+            f"{c.delta_pct_on_vs_off:+.2f}% [{c.delta_pct_on_vs_off_ci_lo:+.2f},{c.delta_pct_on_vs_off_ci_hi:+.2f}] | "
+            f"{c.delta_pct_on_vs_ref:+.2f}% [{c.delta_pct_on_vs_ref_ci_lo:+.2f},{c.delta_pct_on_vs_ref_ci_hi:+.2f}] | "
+            f"{c.paired_spread_pct:.2f}% | {c.classification} | {'Y' if c.fired else 'N'} |"
+        )
+    lines.append("")
+    lines.append("## Routing trace (K-883 layer 6)")
+    lines.append("")
+    lines.append(f"- fire_total = {snap['fire_total']}")
+    lines.append(f"- nonfire_total = {snap['nonfire_total']}")
+    lines.append("")
+    lines.append("| M | N | K | dtype | fire_count |")
+    lines.append("|---:|---:|---:|---|---:|")
+    for k, v in sorted(snap["per_key_fires"].items(), key=lambda kv: str(kv[0])):
+        dtt = str(k[3]).replace("torch.", "")
+        lines.append(f"| {k[0]} | {k[1]} | {k[2]} | {dtt} | {v} |")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Convenience: dispatch-site shim for matmul.py.  Translates the override
+# payload dict into the local variables of persistent_matmul_lt.  Returns a
+# dict of any updates the caller should apply; caller is responsible for
+# the L4 LDS guard and the L5 work_stealing check (the registry already
+# does L5, but the LDS guard is call-site because BLK_M/N/K live there).
+# ---------------------------------------------------------------------------
+def apply_override_in_dispatcher(
+    M: int, N: int, K: int, dtype: "torch.dtype",
+    block_m: int, block_n: int, block_k: int,
+    num_stages: int, num_warps: int, waves_per_eu: int,
+    kpack: int, mfma_instr_size: int,
+    total_tiles: int, n_cu: int,
+    work_stealing: bool = False,
+    bytes_per_elem: int = 2,
+    arch: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Look up any active override and return updated tile-spec values.
+
+    Returns dict with any of: BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K,
+    num_stages, num_warps, waves_per_eu, kpack, matrix_instr_nonkdim,
+    grids, total_programs, fired_ticket.
+
+    Empty dict means no override fires (caller proceeds with defaults).
+    """
+    hit = OverrideRegistry.apply(M, N, K, dtype, work_stealing=work_stealing)
+    if hit is None:
+        return {}
+    gate, payload = hit
+    out: Dict[str, Any] = {"fired_ticket": gate.ticket}
+
+    bm = int(payload.get("BLOCK_SIZE_M", block_m))
+    bn = int(payload.get("BLOCK_SIZE_N", block_n))
+    bk = int(payload.get("BLOCK_SIZE_K", block_k))
+    ns = int(payload.get("num_stages", num_stages))
+
+    # Layer 4 — LDS budget guard.
+    if not GuardedOverride.lds_ok(bm, bn, bk, ns, bytes_per_elem=bytes_per_elem, arch=arch):
+        # Drop the override (do NOT fire) — preserves layer-4 invariant.
+        # The lookup() call already incremented fire_total; we leave it as a
+        # routing-trace record of "would-have-fired-but-LDS-blocked" so the
+        # gate author can see it.
+        return {"lds_blocked": True, "fired_ticket": gate.ticket}
+
+    if bm != block_m: out["BLOCK_SIZE_M"] = bm
+    if bn != block_n: out["BLOCK_SIZE_N"] = bn
+    if bk != block_k: out["BLOCK_SIZE_K"] = bk
+    if ns != num_stages: out["num_stages"] = ns
+    for k_payload, k_local, cur in [
+        ("num_warps", "num_warps", num_warps),
+        ("waves_per_eu", "waves_per_eu", waves_per_eu),
+        ("kpack", "kpack", kpack),
+        ("matrix_instr_nonkdim", "matrix_instr_nonkdim", mfma_instr_size),
+    ]:
+        if k_payload in payload and int(payload[k_payload]) != cur:
+            out[k_local] = int(payload[k_payload])
+
+    if payload.get("grid_cap_to_n_cu", False):
+        new_grid = min(total_tiles, n_cu)
+        if new_grid != total_tiles:
+            out["grids"] = new_grid
+            out["total_programs"] = new_grid
+
+    return out

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -94,6 +94,18 @@ from ._route_predicate import (
     # union); alias overlaps fire BEFORE P26 in the dispatch chain.
     _k1611_p26_skinny_n2048_kcompl_aliasstack_routeout
         as _R_K1611_P26_skinny_n2048_kcompl_aliasstack_routeout,
+    # K-1673 (S-002): P28 skinny_N128 K-COMPLEMENT alias-stack 30-cell
+    # route-OUT (19th-position, load-bearing).  Closes the LAST untested
+    # small-N rung (N=128) of the K-COMPLEMENT N-ladder at the dtype-
+    # mirror gap (fp16 K ∈ {2048, 32768}); 30/30 admit at the strict 1.05
+    # gate (K-1673 paired n=30 HIP-graph hot-cache MI300X gfx942 vs the
+    # live post-K-1647 P27 oracle); cohort geomean tb/hbl = 1.694×, range
+    # 1.162×-2.890×.  6 NEW cells (all fp16, K ∈ {2048, 32768}) + 24
+    # alias cells (15 bf16 via R-K979 P5 Clause-3 + 9 fp16 K-mid via
+    # K-1367 P13 N=128); alias overlaps fire BEFORE P28 in the dispatch
+    # chain.
+    _k1673_p28_skinny_n128_kcompl_aliasstack_routeout
+        as _R_K1673_P28_skinny_n128_kcompl_aliasstack_routeout,
 )
 
 
@@ -304,6 +316,47 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # oracle (combined with K-1559 60-cell N ∈ {4096, 8192} confirmation);
     # cohort geomean tb/hbl = 1.234×, range 1.114×-1.501×, 30/30 at strict
     # 1.05 gate — same evidence that backs the load-bearing P24 above.
+    # K-1633 18th-slot handle: no executable code — the K-1633-named alias
+    # `_K1633_P27_SKINNY_N512_KCOMPL_ALIASSTACK_30` lives in
+    # _route_predicate.py as a single module-level rebinding of P23's
+    # frozenset (K-1552), since the K-1633 admit set is bit-identical to
+    # P23 and P23 fires first at the 15th slot.  Per K-1581 / K-1489
+    # minimalist precedent we do not add a duplicate predicate call for
+    # an unreachable alias.  K-1633 re-measurement provenance: paired
+    # n=30 HIP-graph hot-cache MI300X gfx942 vs the live post-K-1611 P26
+    # oracle; 30/30 admit at the strict 1.05 gate, cohort geomean tb/hbl
+    # ≥ 1.45× — same shape that backs the load-bearing P23 above.
+    # K-1673 (S-002): P28 skinny_N128 K-COMPLEMENT alias-stack 30-cell
+    # route-OUT (19th-position, load-bearing).  Closes the LAST untested
+    # small-N rung (N=128) of the K-COMPLEMENT N-ladder at the dtype-
+    # mirror gap (fp16 K ∈ {2048, 32768}) on the M ∈ {2048, 4096, 8192}
+    # rows; coverage now spans the FULL N-ladder {128, 256, 512, 1024,
+    # 2048, 4096, 8192, 16384, 32768} for both bf16 and fp16.  K-1673
+    # paired n=30 HIP-graph hot-cache + B=10000 vectorised paired
+    # bootstrap on MI300X gfx942 (OCI useocpm2m-097-099 amd-rccl
+    # partition / ROCm 7.2 / pytorch 2.10) against the LIVE post-K-1647
+    # P27 routing oracle: 30/30 admit at the strict ratio_median ≥ 1.05
+    # ∧ p(<1.05) < 0.01 gate; cohort geomean tb/hbl = 1.694×, range
+    # 1.162×-2.890×, 0 regressions.  Per-row geomean: 1.889× (M=2048,
+    # K-913 LDS-BC band fully live because min(M,N) = 128) / 1.458×
+    # (M=4096) / 1.767× (M=8192).  ALIAS-STACK structure: 6 NEW cells +
+    # 24 alias cells (15 bf16 via R-K979 P5 Clause-3 minMN ≤ 192 ∧ K ≥
+    # 2048 + 9 fp16 K ∈ {4096, 8192, 16384} via K-1367 P13 N=128); alias
+    # overlaps fire BEFORE P28 in the dispatch chain so the 24 alias
+    # cells are documentation; the 6 NEW cells (all fp16 mirror at K ∈
+    # {2048, 32768}) are the load-bearing portion that close the dtype-
+    # mirror gap left by P5's bf16-only `_dtype_is_bf16` early-return
+    # and P13's K-mid-only K-grid coverage.  Mechanism (K-1673 PMC RCA):
+    # TB SQ_LDS_BANK_CONFLICT/inst = 1.45-2.13 cyc (vs HBL = 0.000
+    # exactly); the K-913 §3 dtype-invariant LDS-BC signature on the
+    # N=128 column-narrow tile.  Why not share P21 N=256 / P23 N=512:
+    # at N=128 the BLOCK_N=128 tile has 1 K-block column and ALL
+    # accumulator lanes serialise on one bank group (LDS_BC ≈ 1.45-2.13
+    # cyc/inst); at N=256 the same tile has 2 K-block columns and the
+    # LDS bank arbitration round-robins across 2 swizzle phases (LDS_BC
+    # ≈ 0.6-0.9 cyc/inst) — sibling-N firewall preserves the per-N audit
+    # handles per the K-1175 stacked-predicate convention.
+    if _R_K1673_P28_skinny_n128_kcompl_aliasstack_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -111,6 +111,10 @@ from ._route_predicate import (
     # K-1748 P30 (21st-slot): skinny_Nmid (N ∈ {384, 768, 1536}) K-COMPLEMENT
     # alias-stack — 34 K-1711 admit cells (closes 0/34 live-oracle gap).
     _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34,
+    # P31 (22nd-slot): N=256 K-COMPLEMENT verified-winner subset — 28 cells
+    # (M ∈ {2048,4096,8192} × N=256 × K ∈ {2048,4096,8192,16384,32768} ×
+    # {bf16,fp16} minus 2 paired-n30 LOSER cells at (2048, 256, 2048, *)).
+    _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28,
 )
 
 
@@ -369,6 +373,11 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # post-K-1709 oracle had 0/34 cells active; K-1720 (parallel branch off K-1685) never
     # merged into K-1709 lineage.  Ship at 21st slot per K-1709/K-1720 disjoint-N rationale.
     if (int(M), int(N), int(K), str(a_dtype)) in _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34: return True
+    # P31 (22nd-slot): N=256 K-COMPLEMENT verified-winner subset — 28 cells (TB-native
+    # vs HBL-native paired n=30 hot-cache HIP-graph on MI300X with route-OUT ablated:
+    # geomean HBL/TB = 1.392×, range 1.07×–2.12×, 28/28 cells pass the strict
+    # ≥1.05 ∧ p<0.05 gate; the 2 (M=2048, K=2048) LOSER cells are excluded).
+    if (int(M), int(N), int(K), str(a_dtype)) in _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28: return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -52,6 +52,11 @@ from ._route_predicate import (
     # (13th-position) — closes the K-1397 P13 N=256 K-mid-band gap (K in
     # {4096, 8192, 16384}).  17/30 admits at >=1.05x; cohort geomean 1.457x.
     _k1503_p21_skinny_n256_kmid_routeout as _R_K1503_P21_skinny_n256_kmid_routeout,
+    # K-1513 (S-002): P22 skinny_N32768 K-COMPLEMENT 30-cell route-OUT
+    # (14th-position) — closes the top rung of the K-COMPLEMENT N-ladder
+    # at N=32768 on the full K-grid.  30/30 admit at strict 1.05 gate;
+    # cohort geomean tb/hbl ≈ 1.118×.  Naturally disjoint with all P1-P21.
+    _k1513_p22_skinny_n32768_routeout as _R_K1513_P22_skinny_n32768_routeout,
 )
 
 
@@ -187,6 +192,13 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # 17/30 admits at >=1.05x; cohort geomean 1.457x; closes ~89% of the
     # 30-cell N=256 gap.
     if _R_K1503_P21_skinny_n256_kmid_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1513 P22 (14th-position): skinny_N32768 K-COMPLEMENT 30-cell route-OUT.
+    # Stacks AFTER P21 per the K-1175 stacked-predicate convention; closes
+    # the top rung of the K-COMPLEMENT N-ladder at N=32768 on the full
+    # K-grid {2048,4096,8192,16384,32768}.  30/30 admit at strict 1.05 gate;
+    # cohort geomean tb/hbl ≈ 1.118× (range ≈ 1.045×-1.298×).  Naturally
+    # disjoint with all P1-P21 (sibling-N firewall + R-1465 #1 invariant).
+    if _R_K1513_P22_skinny_n32768_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -76,13 +76,24 @@ from ._route_predicate import (
     # alias overlap at (4096, 4096, 4096, {bf16, fp16}); 28 NEW cells +
     # 2 P12-alias cells.
     _k1566_p24_skinny_n4096_routeout as _R_K1566_P24_skinny_n4096_routeout,
-    # K-1553 (S-002): the K-1553-named 17th-slot handle is a module-level
-    # alias of the K-1566 P24 frozenset (`_K1553_P25_SKINNY_N4096_KCOMPL_
-    # ALIASSTACK_30 = _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30`); no
-    # separate predicate function is imported because the admit set is
-    # bit-identical and P24 fires first.  Per K-1489 reviewer-consensus
-    # precedent for unreachable alias slots, the routing decision is fully
-    # carried by P24 and the 17th-slot handle is documentation-only.
+    # K-1553 (S-002): the K-1553-named documentation-only handle is a
+    # module-level alias of the K-1566 P24 frozenset
+    # (`_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30 =
+    # _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30`); no separate predicate
+    # function is imported because the admit set is bit-identical and P24
+    # fires first.  Per K-1489 reviewer-consensus precedent for
+    # unreachable alias slots, the routing decision is fully carried by
+    # P24 and the K-1553-named handle is documentation-only.
+    # K-1611 (S-002): P26 skinny_N2048 K-COMPLEMENT alias-stack 30-cell
+    # route-OUT (17th-position, load-bearing).  Closes the LAST untested
+    # mid-N rung of the K-COMPLEMENT N-ladder at N=2048 on the full
+    # K-grid; 30/30 admit at the strict 1.05 gate (K-1611 paired n=30 +
+    # B=10000 vectorised paired bootstrap MI300X gfx942 vs the live post-
+    # K-1581 oracle); cohort geomean tb/hbl = 1.451×, range
+    # 1.108×-1.853×.  22 NEW cells + 8 alias cells (P12 + K971
+    # union); alias overlaps fire BEFORE P26 in the dispatch chain.
+    _k1611_p26_skinny_n2048_kcompl_aliasstack_routeout
+        as _R_K1611_P26_skinny_n2048_kcompl_aliasstack_routeout,
 )
 
 
@@ -256,6 +267,33 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # (4096, 4096, 4096, {bf16, fp16}) — P12 fires first so 28 cells are
     # NEW route-OUT and 2 cells are alias documentation.
     if _R_K1566_P24_skinny_n4096_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1611 P26 (17th-position): skinny_N2048 K-COMPLEMENT alias-stack
+    # 30-cell route-OUT.  Stacks AFTER P24 per the K-1175 stacked-predicate
+    # convention; closes the LAST untested mid-N rung of the K-COMPLEMENT
+    # N-ladder at N=2048 on the full K-grid {2048, 4096, 8192, 16384,
+    # 32768}.  Coverage now spans the full verified N range {128, 256, 512,
+    # 1024, 2048, 4096, 8192, 16384, 32768}.  30/30 admit at the strict
+    # 1.05 gate (K-1611 paired n=30 + B=10000 vectorised paired bootstrap
+    # on MI300X gfx942 with TRITONBLAS_DISABLE_K971=1 vs the live post-
+    # K-1581 routing oracle); cohort geomean tb/hbl = 1.451×, range
+    # 1.108×-1.853×; 0 regressions.  Per-row geomean: 1.595× (M=2048,
+    # K-913 LDS-BC band fully live because min(M,N)=2048) / 1.382×
+    # (M=4096) / 1.391× (M=8192).  ALIAS-STACK structure: 22 NEW cells
+    # + 8 alias cells (2 P12 at the (2048, 2048, 2048, {bf16, fp16})
+    # diagonal + 6 K971_ROUTE_TABLE union: 4 K-905/K-971 LDS-BC anchors
+    # at K∈{16384, 32768} ∪ 2 K-1335 longK_smallSquare bf16 cells at
+    # K∈{4096, 8192}).  Alias overlaps fire BEFORE P26 in the dispatch
+    # chain so the 8 alias cells are documentation; the 22 NEW cells are
+    # the load-bearing portion (M ∈ {4096, 8192} × all K + the
+    # (2048, 2048, K, fp16) pair for K ∈ {4096, 8192} that K-1335 (bf16-
+    # only) does not cover).  Anchors the R-1478 #1 N-axis attenuation
+    # chain head — full chain now 1.451 → 1.234 → 1.220 → 1.174 → 1.118
+    # across N ∈ {2048, 4096, 8192, 16384, 32768}, strictly monotone-
+    # decreasing.  Mechanism (K-1598 PMC RCA): TB SQ_INSTS_LDS counters
+    # at N=2048 inflate ~3.1× over hbl on the M=2048 row, consistent with
+    # the K-913 LDS_BC ≈ 1.6-1.8 cyc/inst signature; persistent_matmul
+    # cannot relieve LDS-bank-conflict pressure via tile reshape.
+    if _R_K1611_P26_skinny_n2048_kcompl_aliasstack_routeout(int(M), int(N), int(K), a_dtype): return True
     # K-1553 17th-slot handle: no executable code — the K-1553-named alias
     # `_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30` lives in
     # _route_predicate.py as a single module-level rebinding of P24's

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -32,6 +32,8 @@ from ._route_predicate import (
     _k1361_p12_square_mid_routeout as _R_K1361_P12_square_mid_routeout,
     # K-1367 (S-002): P13 skinny_N128 K-COMPLEMENT 18-cell route-OUT (7th-position).
     _k1367_p13_skinny_n128_routeout as _R_K1367_P13_skinny_n128_routeout,
+    # K-1397 (S-002): P13 skinny_N256 K-COMPLEMENT 12-cell route-OUT (8th-position).
+    _k1397_p13_skinny_n256_routeout as _R_K1397_P13_skinny_n256_routeout,
 )
 
 
@@ -97,6 +99,17 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # column-narrow LDS layout). Disjoint by construction with all P1–P12
     # sub-frozensets via cross-frozenset asserts at module load.
     if _R_K1367_P13_skinny_n128_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1397 (S-002): P13 skinny_N256 K-COMPLEMENT 12-cell route-OUT (8th-position
+    # envelope). Stacks AFTER K-1367 P13 per K-1175 stacked-predicate convention;
+    # closes the last K-1365 post-P12 4-bucket residual (skinny_N256 at K-axis
+    # extremes K ∈ {2048, 32768}).  Mechanism: hipBLASLt's split-K kernel selection
+    # wins over tritonblas persistent_matmul at extreme aspect ratios where LDS
+    # bank conflicts dominate the persistent N=256 tile layout (consistent with
+    # K-913 longK_smallSquare PMC findings).  K-1397 paired n=30 + B=10000
+    # vectorised bootstrap CI95: 12/12 ROUTE-OUT, per-cell speedups 1.04×–1.12×;
+    # envelope grows 73 → 85 cells.  Disjoint by construction with all P1–P13(N=128)
+    # sub-frozensets via cross-frozenset asserts at module load.
+    if _R_K1397_P13_skinny_n256_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -76,6 +76,17 @@ from ._route_predicate import (
     # alias overlap at (4096, 4096, 4096, {bf16, fp16}); 28 NEW cells +
     # 2 P12-alias cells.
     _k1566_p24_skinny_n4096_routeout as _R_K1566_P24_skinny_n4096_routeout,
+    # K-1553 (S-002): P25 skinny_N4096 K-COMPLEMENT alias-stack 30-cell
+    # route-OUT (17th-position).  ALIAS to P24 ⨄ P12 — the K-1553 N=4096
+    # envelope (cohort geomean tb/hbl = 1.234×, range 1.114×-1.501×;
+    # MI300X gfx942 paired n=30 HIP-graph hot-cache vs the live post-K-1532
+    # oracle; combined with K-1559 60-cell N ∈ {4096, 8192} mid-band
+    # confirmation) routes 30/30 via P24, with 2 cells additionally aliased
+    # by P12 at the (4096, 4096, 4096, {bf16, fp16}) diagonal.  This slot
+    # freezes the K-1553 admit set under a K-1553-named symbol and is
+    # load-bearing only if P24 is ablated.
+    _k1553_p25_skinny_n4096_kcompl_aliasstack_routeout
+        as _R_K1553_P25_skinny_n4096_kcompl_aliasstack_routeout,
 )
 
 
@@ -249,6 +260,26 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # (4096, 4096, 4096, {bf16, fp16}) — P12 fires first so 28 cells are
     # NEW route-OUT and 2 cells are alias documentation.
     if _R_K1566_P24_skinny_n4096_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1553 P25 (17th-position): skinny_N4096 K-COMPLEMENT alias-stack 30-cell.
+    # Stacks AFTER P24 per the K-1175 stacked-predicate convention.  ALIAS to
+    # P24 ⨄ P12 — the K-1553 N=4096 envelope (cohort geomean tb/hbl = 1.234×,
+    # range 1.114×-1.501×, 30/30 admit at strict 1.05 gate; paired n=30
+    # HIP-graph hot-cache MI300X gfx942 with TRITONBLAS_DISABLE_K971=1 vs the
+    # live post-K-1532 oracle; combined with K-1559 60-cell mid-band
+    # N ∈ {4096, 8192} confirmation) routes 30/30 via P24, with 2 cells
+    # additionally aliased by P12 at the (4096, 4096, 4096, {bf16, fp16})
+    # diagonal.  Membership check is unreachable while P24 is enabled —
+    # load-bearing only if P24 is ablated; the slot freezes the K-1553
+    # admit set under a K-1553-named symbol per the K-1493 / K-1538 / K-1552
+    # alias-stack convention so future N-ladder audits have a dedicated
+    # handle for the K-1553 measurement separate from K-1566's
+    # productionization label.  Mechanism: at N=4096 the persistent_matmul
+    # tile keeps min(M, N) ≤ 2048 for the M=2048 row, saturating LDS bank
+    # conflicts (K-913 §3 longK_smallSquare); hipBLASLt's split-K kernel
+    # selector re-picks at N=4096 to a tile/pipeline pattern that better
+    # amortises LDS-BC pressure and wave-occupancy starvation across all
+    # three M anchors, yielding the +14-50% per-cell speedups observed.
+    if _R_K1553_P25_skinny_n4096_kcompl_aliasstack_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -43,6 +43,11 @@ from ._route_predicate import (
     # P17 skinny_N512 K-COMPLEMENT BASE 17-cell route-OUT (11th-position) —
     # completes the P15 N=512 EXTREMES sibling at the BASE K band.
     _k1437_p17_skinny_n512_kcompl_base_routeout as _R_K1437_P17_skinny_n512_kcompl_base_routeout,
+    # K-1478 (S-002): P19 skinny_N16384 K-COMPLEMENT 30-cell route-OUT
+    # (12th-position) — extends the K-COMPLEMENT N-ladder one bucket up
+    # to N=16384 (full K-grid).  30/30 admit at strict 1.05 gate; cohort
+    # geomean tb/hbl = 1.174×.  Naturally disjoint with all P1-P17.
+    _k1478_p19_skinny_n16384_routeout as _R_K1478_P19_skinny_n16384_routeout,
 )
 
 
@@ -164,6 +169,14 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # EXTREMES only) to 29/30 (P15 ⨄ P17, with one cell P5-pre-routed at
     # chain pos 4).  Per-cell ratios 1.24×-1.64×; cohort geomean 1.40×.
     if _R_K1437_P17_skinny_n512_kcompl_base_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1478 P19 (12th-position): skinny_N16384 K-COMPLEMENT 30-cell route-OUT.
+    # Stacks AFTER P17 per K-1175 stacked-predicate convention; closes the
+    # N=16384 column along the K-COMPLEMENT axis (full K-grid 2048-32768).
+    # 30/30 admit at strict ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01 gate;
+    # cohort geomean tb/hbl = 1.174×, range 1.056×-1.359×.  Natural
+    # disjointness with all P1-P17 (sibling-N firewall + R-1465 #1
+    # zero-P12-deferral invariant).
+    if _R_K1478_P19_skinny_n16384_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -48,10 +48,9 @@ from ._route_predicate import (
     # to N=16384 (full K-grid).  30/30 admit at strict 1.05 gate; cohort
     # geomean tb/hbl = 1.174×.  Naturally disjoint with all P1-P17.
     _k1478_p19_skinny_n16384_routeout as _R_K1478_P19_skinny_n16384_routeout,
-    # K-1489 P20 (13th-position): alias-stack of K-1478 P19 admit envelope per
-    # K-1490 sibling-slot productionization (unreachable while P19 enabled —
-    # reserved slot for K-COMPLEMENT-EXTENDED follow-up).
-    _K1478_P20_SKINNY_N16384_KCOMPL_ROUTEOUT_N as _K1489_P20,
+    # K-1489 13th-slot is RESERVED — no symbol imported.  See the comment
+    # block above the K-1489 P20 placeholder in _route_predicate.py for the
+    # reviewer rationale (unanimous REVISE on the prior alias-of-P19 attempt).
 )
 
 
@@ -181,8 +180,7 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # disjointness with all P1-P17 (sibling-N firewall + R-1465 #1
     # zero-P12-deferral invariant).
     if _R_K1478_P19_skinny_n16384_routeout(int(M), int(N), int(K), a_dtype): return True
-    # K-1489 P20 (13th-position): alias-stack of K-1478 P19; reserved slot.
-    if (int(M), int(N), int(K), str(a_dtype)) in _K1489_P20: return True
+    # K-1489 13th-slot RESERVED — no executable code (placeholder only).
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -106,6 +106,8 @@ from ._route_predicate import (
     # chain.
     _k1673_p28_skinny_n128_kcompl_aliasstack_routeout
         as _R_K1673_P28_skinny_n128_kcompl_aliasstack_routeout,
+    # K-1700 P29 (20th-slot): N=64 K-COMPLEMENT alias-stack — 29 K-1709 admit cells.
+    _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29,
 )
 
 
@@ -357,6 +359,8 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # ≈ 0.6-0.9 cyc/inst) — sibling-N firewall preserves the per-N audit
     # handles per the K-1175 stacked-predicate convention.
     if _R_K1673_P28_skinny_n128_kcompl_aliasstack_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1700 P29 (20th-slot): N=64 K-COMPLEMENT alias-stack (29 cells; cohort geomean tb_forced/hbl=1.93×).
+    if (int(M), int(N), int(K), str(a_dtype)) in _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29: return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -48,6 +48,10 @@ from ._route_predicate import (
     # to N=16384 (full K-grid).  30/30 admit at strict 1.05 gate; cohort
     # geomean tb/hbl = 1.174×.  Naturally disjoint with all P1-P17.
     _k1478_p19_skinny_n16384_routeout as _R_K1478_P19_skinny_n16384_routeout,
+    # K-1489 P20 (13th-position): alias-stack of K-1478 P19 admit envelope per
+    # K-1490 sibling-slot productionization (unreachable while P19 enabled —
+    # reserved slot for K-COMPLEMENT-EXTENDED follow-up).
+    _K1478_P20_SKINNY_N16384_KCOMPL_ROUTEOUT_N as _K1489_P20,
 )
 
 
@@ -177,6 +181,8 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # disjointness with all P1-P17 (sibling-N firewall + R-1465 #1
     # zero-P12-deferral invariant).
     if _R_K1478_P19_skinny_n16384_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1489 P20 (13th-position): alias-stack of K-1478 P19; reserved slot.
+    if (int(M), int(N), int(K), str(a_dtype)) in _K1489_P20: return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -125,6 +125,12 @@ from ._route_predicate import (
     # dtype rows load-bearing — no upstream alias overlap (N=224 is the first
     # N-axis cliff above N=128 per R-K1794.N224-DOES-NOT-EXTEND-FROM-N192).
     _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18,
+    # P34 (25th-slot): N=96 K-COMPLEMENT verified-winner subset — 18 cells
+    # (M ∈ {2048,4096,8192} × N=96 × K ∈ {4096,8192,16384} × {bf16,fp16}) from
+    # K-1818's N=96 sub-cohort (3-engine paired n=30 HIP-graph hot-cache).  Both
+    # dtype rows load-bearing — no upstream alias overlap (N=96 is the first
+    # wave-misaligned rung below the N=128 cliff per K-1818 PMC RCA).
+    _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18,
 )
 
 
@@ -407,6 +413,17 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # bearing, closes the wave-misaligned N=224 dtype-mirror (BLOCK_N=128 packs
     # N=224 into one wave-misaligned K-block column → K-913 §3 LDS-BC fingerprint).
     if (int(M), int(N), int(K), str(a_dtype)) in _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18: return True
+    # P34 (25th-slot): N=96 K-COMPLEMENT verified-winner subset — 18 cells from
+    # K-1818's N=96 sub-cohort (M ∈ {2048,4096,8192} × N=96 × K ∈ {4096,8192,16384}
+    # × {bf16,fp16}).  K-1818 PMC RCA paired n=30 HIP-graph hot-cache 3-engine sweep
+    # on MI300X / gfx942: bf16 N=96 unrouted 0/9 and fp16 N=96 unrouted 0/9 in the
+    # pre-stack measurement (no upstream alias coverage at the wave-misaligned N=96
+    # rung BELOW the N=128 cliff).  All 18 cells admitted as route-OUT — both dtype
+    # rows load-bearing, closes the wave-misaligned N=96 dtype-mirror (BLOCK_N=128
+    # packs N=96 into a single wave-misaligned K-block column with PARTIAL coverage
+    # → K-913 §3 LDS-BC fingerprint dominates AND wave-misalignment MFMA-tail
+    # inefficiency per R-1811.WAVE-MISALIGNMENT-IS-ROOT-MECHANISM).
+    if (int(M), int(N), int(K), str(a_dtype)) in _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18: return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -138,6 +138,13 @@ from ._route_predicate import (
     # off-by-32 wave-misaligned rung ABOVE the N=256 P31 cliff).  K-1832 cohort
     # geomean TB/HBL = 4.290× — the largest uplift in the alias-stack to date.
     _P35_SKINNY_N288_KCOMPL_VERIFIED_WIN_18,
+    # P36 (27th-slot): N=320 K-COMPLEMENT verified-winner subset — 17 cells
+    # (M ∈ {2048,4096,8192} × N=320 × K ∈ {4096,8192,16384} × {bf16,fp16} = 18
+    # cells, MINUS (2048,320,4096,bf16) which is already routed by an upstream
+    # alias-stack slot per K-1843 paired-n30 measurement; ratio_TB/HBL=1.0001,
+    # p=0.293, R-K1825.CHECK-ALIAS-STACK-COVERAGE-MAP-FIRST exclusion).  17/17
+    # admit cells gate-pass at strict ratio≥1.05 ∧ p<0.05; per-N geomean=1.545×.
+    _P36_SKINNY_N320_KCOMPL_VERIFIED_WIN_17,
 )
 
 
@@ -445,6 +452,23 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # per K-1832 PMC delta ranking with SQ_LDS_BANK_CONFLICT ≈ 869× and
     # SQ_WAIT_INST_LDS ≈ 12.5× at the top of the discriminator list).
     if (int(M), int(N), int(K), str(a_dtype)) in _P35_SKINNY_N288_KCOMPL_VERIFIED_WIN_18: return True
+    # P36 (27th-slot): N=320 K-COMPLEMENT verified-winner subset — 17 cells from
+    # K-1843's N=320 sub-cohort (M ∈ {2048,4096,8192} × N=320 × K ∈ {4096,8192,16384}
+    # × {bf16,fp16}) MINUS (2048,320,4096,bf16) which is already upstream-routed
+    # per the K-1843 paired-n30 measurement (ratio 1.0001, p=0.293, classified
+    # WITHIN_0p95X_PARITY_BAND).  K-1843 paired n=30 HIP-graph hot-cache + 3-pass
+    # rocprofv2 PMC sweep (LDS / VALU·MFMA / VMEM·L2) on MI300X / gfx942 vs
+    # K-1837 LIVE oracle (e7dfab4 + P32–P35 stacked): 17/17 cells admitted at the
+    # strict ≥1.05× ∧ p<0.05 gate; per-cell ratios 1.326×–1.911× (median 1.583×),
+    # per-N geomean = 1.545×.  Both dtype rows load-bearing — closes the
+    # wave-misaligned N=320 dtype-mirror (BLOCK_N=128 packs N=320 into the
+    # off-by-64 wave-misaligned column-narrow layout above the N=256 P31 cliff
+    # and below the N=384 P30 rung → K-913 §3 LDS-bank-conflict + R-1811
+    # wave-misalignment MFMA-tail compounded fingerprint).  PMC bottleneck
+    # histogram: LDS_DOMINANT 36/36 across the K-1843 N∈{320,352} cohort, with
+    # lds_wait_ratio_TB/HBL spanning 1.96×-25.27× (median ≈ 8.5×); same
+    # SCHEDULER_LDS A4 failure mode as K-1681/K-1710/K-1781/K-1812/K-1824/K-1832.
+    if (int(M), int(N), int(K), str(a_dtype)) in _P36_SKINNY_N320_KCOMPL_VERIFIED_WIN_17: return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -65,6 +65,17 @@ from ._route_predicate import (
     # load-bearing only if any upstream layer is ablated.
     _k1552_p23_skinny_n512_kcompl_aliasstack_routeout
         as _R_K1552_P23_skinny_n512_kcompl_aliasstack_routeout,
+    # K-1566 (S-002): P24 skinny_N4096 K-COMPLEMENT 30-cell route-OUT
+    # (16th-position).  Closes the previously-empty N=4096 rung of the
+    # K-COMPLEMENT N-ladder (between P21 N=2048 and P19 N=16384) on the
+    # full K-grid {2048, 4096, 8192, 16384, 32768}.  30/30 admit at the
+    # strict 1.05 gate (K-1553 paired n=30 + B=10000 vectorised paired
+    # bootstrap MI300X gfx942 vs the live post-K-1532 oracle); cohort
+    # geomean tb/hbl = 1.234×, range 1.114×-1.501×.  Sibling-N firewall
+    # disjoint with all P1-P23 except a single intentional 2-cell P12
+    # alias overlap at (4096, 4096, 4096, {bf16, fp16}); 28 NEW cells +
+    # 2 P12-alias cells.
+    _k1566_p24_skinny_n4096_routeout as _R_K1566_P24_skinny_n4096_routeout,
 )
 
 
@@ -221,6 +232,23 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # longK_smallSquare LDS-bank-conflict signature on the persistent_matmul
     # N=512 tile, opposite to the R-1478 #1 N-axis attenuation trajectory.
     if _R_K1552_P23_skinny_n512_kcompl_aliasstack_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1566 P24 (16th-position): skinny_N4096 K-COMPLEMENT 30-cell route-OUT.
+    # Stacks AFTER P23 per the K-1175 stacked-predicate convention; closes
+    # the previously-empty N=4096 rung of the K-COMPLEMENT N-ladder
+    # (between P21 N=2048 territory and P19 N=16384) on the full K-grid
+    # {2048, 4096, 8192, 16384, 32768}.  30/30 admit at the strict 1.05
+    # gate (K-1553 paired n=30 + B=10000 vectorised paired bootstrap on
+    # MI300X gfx942 with TRITONBLAS_DISABLE_K971=1 vs the live post-K-1532
+    # routing oracle); cohort geomean tb/hbl = 1.234×, range 1.114×-1.501×;
+    # 0 regressions.  Per-row geomean: 1.402× (M=2048, K-913 LDS-BC band
+    # fully live because min(M,N) ≤ 2048) / 1.146× (M=4096) / 1.180×
+    # (M=8192).  Validates the R-1478 #1 N-axis attenuation chain anchor
+    # at the previously-empty N=4096 rung (full chain 1.451 → 1.234 →
+    # 1.220 → 1.174 → 1.118).  Sibling-N firewall disjoint with all P1-P23
+    # except a single intentional 2-cell P12 alias overlap at
+    # (4096, 4096, 4096, {bf16, fp16}) — P12 fires first so 28 cells are
+    # NEW route-OUT and 2 cells are alias documentation.
+    if _R_K1566_P24_skinny_n4096_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -48,9 +48,10 @@ from ._route_predicate import (
     # to N=16384 (full K-grid).  30/30 admit at strict 1.05 gate; cohort
     # geomean tb/hbl = 1.174×.  Naturally disjoint with all P1-P17.
     _k1478_p19_skinny_n16384_routeout as _R_K1478_P19_skinny_n16384_routeout,
-    # K-1489 13th-slot is RESERVED — no symbol imported.  See the comment
-    # block above the K-1489 P20 placeholder in _route_predicate.py for the
-    # reviewer rationale (unanimous REVISE on the prior alias-of-P19 attempt).
+    # K-1503 (S-002): P21 skinny_N256 K-COMPLEMENT K-mid-band 17-cell route-OUT
+    # (13th-position) — closes the K-1397 P13 N=256 K-mid-band gap (K in
+    # {4096, 8192, 16384}).  17/30 admits at >=1.05x; cohort geomean 1.457x.
+    _k1503_p21_skinny_n256_kmid_routeout as _R_K1503_P21_skinny_n256_kmid_routeout,
 )
 
 
@@ -180,7 +181,12 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # disjointness with all P1-P17 (sibling-N firewall + R-1465 #1
     # zero-P12-deferral invariant).
     if _R_K1478_P19_skinny_n16384_routeout(int(M), int(N), int(K), a_dtype): return True
-    # K-1489 13th-slot RESERVED — no executable code (placeholder only).
+    # K-1503 P21 (13th-position): skinny_N256 K-COMPLEMENT K-mid-band 17-cell
+    # route-OUT.  Stacks AFTER P19 per K-1175 stacked-predicate convention;
+    # closes the K-mid-band {4096, 8192, 16384} gap of K-1397 P13 N=256.
+    # 17/30 admits at >=1.05x; cohort geomean 1.457x; closes ~89% of the
+    # 30-cell N=256 gap.
+    if _R_K1503_P21_skinny_n256_kmid_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -119,6 +119,12 @@ from ._route_predicate import (
     # (M ∈ {2048,4096,8192} × N=160 × K ∈ {4096,8192,16384} × {bf16,fp16}) from
     # K-1794's N=160 sub-cohort (3-engine paired n=30 HIP-graph hot-cache).
     _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18,
+    # P33 (24th-slot): N=224 K-COMPLEMENT verified-winner subset — 18 cells
+    # (M ∈ {2048,4096,8192} × N=224 × K ∈ {4096,8192,16384} × {bf16,fp16}) from
+    # K-1794's N=224 sub-cohort (3-engine paired n=30 HIP-graph hot-cache).  Both
+    # dtype rows load-bearing — no upstream alias overlap (N=224 is the first
+    # N-axis cliff above N=128 per R-K1794.N224-DOES-NOT-EXTEND-FROM-N192).
+    _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18,
 )
 
 
@@ -391,6 +397,16 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # closes the wave-misaligned N=160 dtype-mirror (BLOCK_N=128 packs N=160 into
     # one wave-misaligned K-block column → K-913 §3 LDS-BC fingerprint dominates).
     if (int(M), int(N), int(K), str(a_dtype)) in _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18: return True
+    # P33 (24th-slot): N=224 K-COMPLEMENT verified-winner subset — 18 cells from
+    # K-1794's N=224 sub-cohort (M ∈ {2048,4096,8192} × N=224 × K ∈ {4096,8192,16384}
+    # × {bf16,fp16}).  K-1794 paired n=30 HIP-graph hot-cache 3-engine sweep on
+    # MI300X / gfx942: bf16 N=224 unrouted 0/9 with cohort gmean r_oracle=0.722
+    # (first N-axis cliff above N=128 per R-K1794.N224-DOES-NOT-EXTEND-FROM-N192-
+    # FROZENSET-MUST-EXPLICITLY-INCLUDE); fp16 N=224 unrouted 0/9 (R-K1794 fp16-
+    # mirror gap).  All 18 cells admitted as route-OUT — both dtype rows load-
+    # bearing, closes the wave-misaligned N=224 dtype-mirror (BLOCK_N=128 packs
+    # N=224 into one wave-misaligned K-block column → K-913 §3 LDS-BC fingerprint).
+    if (int(M), int(N), int(K), str(a_dtype)) in _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18: return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -40,6 +40,9 @@ from ._route_predicate import (
     # K-1429 (S-002): P16 skinny_N1024 K-COMPLEMENT 29-cell route-OUT
     # (10th-position).
     _k1429_p16_skinny_n1024_routeout as _R_K1429_P16_skinny_n1024_routeout,
+    # K-1437 (S-002 sibling): P17 skinny_N512 K-COMPLEMENT BASE 18-cell
+    # route-OUT (11th-position) — completes K-1417 P15 N=512 EXTREMES sibling.
+    _k1437_p17_skinny_n512_kcompl_base_routeout as _R_K1437_P17_skinny_n512_kcompl_base_routeout,
 )
 
 
@@ -155,6 +158,23 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # by construction with all P1–P15 sub-frozensets via cross-frozenset
     # asserts at module load.
     if _R_K1429_P16_skinny_n1024_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1437 (S-002 sibling): P17 skinny_N512 K-COMPLEMENT BASE 18-cell
+    # route-OUT (11th-position envelope).  Stacks AFTER K-1429 P16 per
+    # K-1175 stacked-predicate convention; closes the K-1417 P15 EXTREMES
+    # sibling at N=512 BASE band (K ∈ {4096, 8192, 16384}) — N=512 K-COMPL
+    # goes from 12/30 (40%, EXTREMES only) to 30/30 (100%, BASE ⨄ EXTREMES).
+    # Mechanism: at BASE K the wrapper-overhead ceiling has dissipated
+    # (R-1367.WRAPPER-OVERHEAD-CEILING-DISAPPEARS-AT-LARGE-K) but the N=512
+    # persistent_matmul tile aspect still accumulates LDS bank conflicts
+    # beyond the K-913 §3 floor; hipBLASLt's split-K kernel re-selects to a
+    # pattern that better matches the M ∈ {2048, 4096, 8192} anchors.
+    # K-1409 paired n=30 + B=10000 vectorised bootstrap CI95 on MI300X
+    # gfx942 (OCI MI300X fallback): 17/18 admit at strict 1.05 gate (1
+    # P5-pre-routed cell at chain pos 4 << pos 11 included for arithmetic
+    # completeness), cohort geomean tb/hbl = 1.397×, range 1.244×–1.644×;
+    # envelope grows 126 → 144 cells.  Disjoint by construction with all
+    # P1–P16 sub-frozensets via cross-frozenset asserts at module load.
+    if _R_K1437_P17_skinny_n512_kcompl_base_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -76,17 +76,13 @@ from ._route_predicate import (
     # alias overlap at (4096, 4096, 4096, {bf16, fp16}); 28 NEW cells +
     # 2 P12-alias cells.
     _k1566_p24_skinny_n4096_routeout as _R_K1566_P24_skinny_n4096_routeout,
-    # K-1553 (S-002): P25 skinny_N4096 K-COMPLEMENT alias-stack 30-cell
-    # route-OUT (17th-position).  ALIAS to P24 ⨄ P12 — the K-1553 N=4096
-    # envelope (cohort geomean tb/hbl = 1.234×, range 1.114×-1.501×;
-    # MI300X gfx942 paired n=30 HIP-graph hot-cache vs the live post-K-1532
-    # oracle; combined with K-1559 60-cell N ∈ {4096, 8192} mid-band
-    # confirmation) routes 30/30 via P24, with 2 cells additionally aliased
-    # by P12 at the (4096, 4096, 4096, {bf16, fp16}) diagonal.  This slot
-    # freezes the K-1553 admit set under a K-1553-named symbol and is
-    # load-bearing only if P24 is ablated.
-    _k1553_p25_skinny_n4096_kcompl_aliasstack_routeout
-        as _R_K1553_P25_skinny_n4096_kcompl_aliasstack_routeout,
+    # K-1553 (S-002): the K-1553-named 17th-slot handle is a module-level
+    # alias of the K-1566 P24 frozenset (`_K1553_P25_SKINNY_N4096_KCOMPL_
+    # ALIASSTACK_30 = _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30`); no
+    # separate predicate function is imported because the admit set is
+    # bit-identical and P24 fires first.  Per K-1489 reviewer-consensus
+    # precedent for unreachable alias slots, the routing decision is fully
+    # carried by P24 and the 17th-slot handle is documentation-only.
 )
 
 
@@ -260,26 +256,16 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # (4096, 4096, 4096, {bf16, fp16}) — P12 fires first so 28 cells are
     # NEW route-OUT and 2 cells are alias documentation.
     if _R_K1566_P24_skinny_n4096_routeout(int(M), int(N), int(K), a_dtype): return True
-    # K-1553 P25 (17th-position): skinny_N4096 K-COMPLEMENT alias-stack 30-cell.
-    # Stacks AFTER P24 per the K-1175 stacked-predicate convention.  ALIAS to
-    # P24 ⨄ P12 — the K-1553 N=4096 envelope (cohort geomean tb/hbl = 1.234×,
-    # range 1.114×-1.501×, 30/30 admit at strict 1.05 gate; paired n=30
-    # HIP-graph hot-cache MI300X gfx942 with TRITONBLAS_DISABLE_K971=1 vs the
-    # live post-K-1532 oracle; combined with K-1559 60-cell mid-band
-    # N ∈ {4096, 8192} confirmation) routes 30/30 via P24, with 2 cells
-    # additionally aliased by P12 at the (4096, 4096, 4096, {bf16, fp16})
-    # diagonal.  Membership check is unreachable while P24 is enabled —
-    # load-bearing only if P24 is ablated; the slot freezes the K-1553
-    # admit set under a K-1553-named symbol per the K-1493 / K-1538 / K-1552
-    # alias-stack convention so future N-ladder audits have a dedicated
-    # handle for the K-1553 measurement separate from K-1566's
-    # productionization label.  Mechanism: at N=4096 the persistent_matmul
-    # tile keeps min(M, N) ≤ 2048 for the M=2048 row, saturating LDS bank
-    # conflicts (K-913 §3 longK_smallSquare); hipBLASLt's split-K kernel
-    # selector re-picks at N=4096 to a tile/pipeline pattern that better
-    # amortises LDS-BC pressure and wave-occupancy starvation across all
-    # three M anchors, yielding the +14-50% per-cell speedups observed.
-    if _R_K1553_P25_skinny_n4096_kcompl_aliasstack_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1553 17th-slot handle: no executable code — the K-1553-named alias
+    # `_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30` lives in
+    # _route_predicate.py as a single module-level rebinding of P24's
+    # frozenset, since the K-1553 admit set is bit-identical to P24 and P24
+    # fires first.  Per K-1489 reviewer precedent we do not add a duplicate
+    # predicate call for an unreachable alias.  K-1553 measurement provenance:
+    # paired n=30 HIP-graph hot-cache MI300X gfx942 vs the live post-K-1532
+    # oracle (combined with K-1559 60-cell N ∈ {4096, 8192} confirmation);
+    # cohort geomean tb/hbl = 1.234×, range 1.114×-1.501×, 30/30 at strict
+    # 1.05 gate — same evidence that backs the load-bearing P24 above.
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -31,7 +31,7 @@ from ._route_predicate import (
     # K-1361 (S-002): P12 square_mid PMC-driven 4-cell route-OUT (6th-position).
     _k1361_p12_square_mid_routeout as _R_K1361_P12_square_mid_routeout,
     # K-1367 (S-002): P13 skinny_N128 K-COMPLEMENT 18-cell route-OUT (7th-position).
-    _k1367_p13_skinny_n128_kcomplement_routeout as _R_K1367_P13_skinny_n128_kcomplement_routeout,
+    _k1367_p13_skinny_n128_routeout as _R_K1367_P13_skinny_n128_routeout,
 )
 
 
@@ -96,7 +96,7 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # K-913 §3 LDS-bank-conflict discriminator on the persistent_matmul N=128
     # column-narrow LDS layout). Disjoint by construction with all P1–P12
     # sub-frozensets via cross-frozenset asserts at module load.
-    if _R_K1367_P13_skinny_n128_kcomplement_routeout(int(M), int(N), int(K), a_dtype): return True
+    if _R_K1367_P13_skinny_n128_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -115,6 +115,10 @@ from ._route_predicate import (
     # (M ∈ {2048,4096,8192} × N=256 × K ∈ {2048,4096,8192,16384,32768} ×
     # {bf16,fp16} minus 2 paired-n30 LOSER cells at (2048, 256, 2048, *)).
     _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28,
+    # P32 (23rd-slot): N=160 K-COMPLEMENT verified-winner subset — 18 cells
+    # (M ∈ {2048,4096,8192} × N=160 × K ∈ {4096,8192,16384} × {bf16,fp16}) from
+    # K-1794's N=160 sub-cohort (3-engine paired n=30 HIP-graph hot-cache).
+    _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18,
 )
 
 
@@ -378,6 +382,15 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # geomean HBL/TB = 1.392×, range 1.07×–2.12×, 28/28 cells pass the strict
     # ≥1.05 ∧ p<0.05 gate; the 2 (M=2048, K=2048) LOSER cells are excluded).
     if (int(M), int(N), int(K), str(a_dtype)) in _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28: return True
+    # P32 (23rd-slot): N=160 K-COMPLEMENT verified-winner subset — 18 cells from
+    # K-1794's N=160 sub-cohort (M ∈ {2048,4096,8192} × N=160 × K ∈ {4096,8192,16384}
+    # × {bf16,fp16}).  K-1794 paired n=30 HIP-graph hot-cache 3-engine sweep on
+    # MI300X / gfx942: bf16 routed 9/9 via upstream P5
+    # alias (geomean r_oracle=0.997); fp16 unrouted 0/9 (R-K1794 fp16-mirror gap).
+    # All 18 cells admitted as route-OUT — bf16 alias-overlap is intentional, fp16
+    # closes the wave-misaligned N=160 dtype-mirror (BLOCK_N=128 packs N=160 into
+    # one wave-misaligned K-block column → K-913 §3 LDS-BC fingerprint dominates).
+    if (int(M), int(N), int(K), str(a_dtype)) in _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18: return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -34,6 +34,9 @@ from ._route_predicate import (
     _k1367_p13_skinny_n128_routeout as _R_K1367_P13_skinny_n128_routeout,
     # K-1397 (S-002): P13 skinny_N256 K-COMPLEMENT 12-cell route-OUT (8th-position).
     _k1397_p13_skinny_n256_routeout as _R_K1397_P13_skinny_n256_routeout,
+    # K-1417 (S-002): P15 skinny_N512 K-COMPLEMENT EXTENSION 12-cell route-OUT
+    # (9th-position).
+    _k1409_p15_skinny_n512_routeout as _R_K1409_P15_skinny_n512_routeout,
 )
 
 
@@ -110,6 +113,22 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # envelope grows 73 → 85 cells.  Disjoint by construction with all P1–P13(N=128)
     # sub-frozensets via cross-frozenset asserts at module load.
     if _R_K1397_P13_skinny_n256_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1417 (S-002): P15 skinny_N512 K-COMPLEMENT EXTENSION 12-cell route-OUT
+    # (9th-position envelope).  Stacks AFTER K-1397 P13 per K-1175 stacked-
+    # predicate convention; closes the third-N successive sibling of the
+    # K-COMPLEMENT EXTREMES axis (R-1417.SKINNY-N512-K-COMPLEMENT-EXTENSION-IS-EXTREMES)
+    # at N=512 / K ∈ {2048, 32768} where (a) at K=2048 tritonblas
+    # persistent_matmul tile parallelism is starved (TB ≈ 280 µs vs HBL ≈
+    # 19-50 µs) and (b) at K=32768 hipBLASLt's split-K kernel selection wins
+    # over tritonblas at the persistent N=512 tile layout where LDS bank
+    # conflicts dominate (consistent with K-913 longK_smallSquare PMC
+    # findings and K-1397 N=256 sibling).  K-1417 paired n=30 + B=10000
+    # vectorised bootstrap CI95 on MI300X gfx942 (OCI MI300X fallback):
+    # 12/12 ROUTE-OUT, cohort geomean tb/hbl = 3.43×, min CI95-lo = 1.359,
+    # range 1.36×–14.06×; envelope grows 85 → 97 cells.  Disjoint by
+    # construction with all P1–P14 sub-frozensets via cross-frozenset
+    # asserts at module load.
+    if _R_K1409_P15_skinny_n512_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -131,6 +131,13 @@ from ._route_predicate import (
     # dtype rows load-bearing — no upstream alias overlap (N=96 is the first
     # wave-misaligned rung below the N=128 cliff per K-1818 PMC RCA).
     _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18,
+    # P35 (26th-slot): N=288 K-COMPLEMENT verified-winner subset — 18 cells
+    # (M ∈ {2048,4096,8192} × N=288 × K ∈ {4096,8192,16384} × {bf16,fp16}) from
+    # K-1832's N=288 sub-cohort (3-pass PMC paired n=30 HIP-graph hot-cache).
+    # Both dtype rows load-bearing — no upstream alias overlap (N=288 is the
+    # off-by-32 wave-misaligned rung ABOVE the N=256 P31 cliff).  K-1832 cohort
+    # geomean TB/HBL = 4.290× — the largest uplift in the alias-stack to date.
+    _P35_SKINNY_N288_KCOMPL_VERIFIED_WIN_18,
 )
 
 
@@ -424,6 +431,20 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # → K-913 §3 LDS-BC fingerprint dominates AND wave-misalignment MFMA-tail
     # inefficiency per R-1811.WAVE-MISALIGNMENT-IS-ROOT-MECHANISM).
     if (int(M), int(N), int(K), str(a_dtype)) in _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18: return True
+    # P35 (26th-slot): N=288 K-COMPLEMENT verified-winner subset — 18 cells from
+    # K-1832's N=288 sub-cohort (M ∈ {2048,4096,8192} × N=288 × K ∈ {4096,8192,16384}
+    # × {bf16,fp16}).  K-1832 paired n=30 HIP-graph hot-cache 3-pass PMC sweep on
+    # MI300X / gfx942: bf16 N=288 unrouted 0/9 and fp16 N=288 unrouted 0/9 in the
+    # pre-stack measurement (no upstream alias coverage at the wave-misaligned N=288
+    # off-by-32 rung ABOVE the N=256 P31 cliff).  TB/HBL ratio R²=0.9999 vs K-1812
+    # on the 4 overlapping cells; cohort geomean TB/HBL = 4.290× (range 3.06×–6.46×,
+    # 18/18 admit at the strict ≥1.05 ∧ p<0.05 gate).  All 18 cells admitted as
+    # route-OUT — both dtype rows load-bearing, closes the wave-misaligned N=288
+    # dtype-mirror (same K-913 §3 LDS-BC + R-1811 wave-misalignment MFMA-tail
+    # fingerprint as P28 / P31 / P32 / P33 / P34; SCHEDULER_LDS A4 failure mode
+    # per K-1832 PMC delta ranking with SQ_LDS_BANK_CONFLICT ≈ 869× and
+    # SQ_WAIT_INST_LDS ≈ 12.5× at the top of the discriminator list).
+    if (int(M), int(N), int(K), str(a_dtype)) in _P35_SKINNY_N288_KCOMPL_VERIFIED_WIN_18: return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -37,6 +37,9 @@ from ._route_predicate import (
     # K-1417 (S-002): P15 skinny_N512 K-COMPLEMENT EXTENSION 12-cell route-OUT
     # (9th-position).
     _k1409_p15_skinny_n512_routeout as _R_K1409_P15_skinny_n512_routeout,
+    # K-1429 (S-002): P16 skinny_N1024 K-COMPLEMENT 29-cell route-OUT
+    # (10th-position).
+    _k1429_p16_skinny_n1024_routeout as _R_K1429_P16_skinny_n1024_routeout,
 )
 
 
@@ -129,6 +132,29 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # construction with all P1–P14 sub-frozensets via cross-frozenset
     # asserts at module load.
     if _R_K1409_P15_skinny_n512_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1429 (S-002): P16 skinny_N1024 K-COMPLEMENT 29-cell route-OUT
+    # (10th-position envelope).  Stacks AFTER K-1417 P15 per K-1175
+    # stacked-predicate convention; closes the fourth-N successive sibling
+    # of the K-COMPLEMENT axis at N=1024 across the FULL K-axis sweep
+    # K ∈ {2048, 4096, 8192, 16384, 32768} (BASE + EXTREMES merged into a
+    # single 29-cell frozenset).  Mechanism: at N=1024 the persistent_matmul
+    # tile aspect misaligns against the M ∈ {2048, 4096, 8192} anchors,
+    # accumulating LDS-bank conflicts beyond the K-913 §3 N=512 attenuation;
+    # hipBLASLt's split-K kernel re-selects at N=1024 to a pattern that
+    # better matches the M anchors.  The R-1409 monotone N-axis attenuation
+    # (1.678 → 1.471 → 1.372 across N=128/256/512) REVERSES upward at
+    # N=1024 to cohort geomean tb/hbl = 2.23× (BASE 2.08× / EXTREMES 2.48×),
+    # exceeding every prior N bucket including N=128 — the K-1131 A2 1.40×
+    # cohort floor (MISSED by 2.8 pp at N=512) is RECOVERED at N=1024
+    # (R-1429.SKINNY-N1024-K-COMPLEMENT-DISCRIMINATOR-REVERSES-ATTENUATION-AT-N1024).
+    # K-1429 paired n=30 + B=10000 vectorised bootstrap CI95 on MI300X
+    # gfx942 (OCI amd-arad MI300X fallback): 29/30 ROUTE-OUT, range
+    # 1.26×–8.85×, min CI95-lo = 1.267, single reject at
+    # (2048, 1024, 4096, bf16) at r=1.015 (CI95-lo 1.008 > 1.0 but ratio
+    # below strict 1.05 floor).  Envelope grows 97 → 126 cells.  Disjoint
+    # by construction with all P1–P15 sub-frozensets via cross-frozenset
+    # asserts at module load.
+    if _R_K1429_P16_skinny_n1024_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -57,6 +57,14 @@ from ._route_predicate import (
     # at N=32768 on the full K-grid.  30/30 admit at strict 1.05 gate;
     # cohort geomean tb/hbl ≈ 1.118×.  Naturally disjoint with all P1-P21.
     _k1513_p22_skinny_n32768_routeout as _R_K1513_P22_skinny_n32768_routeout,
+    # K-1552 (S-002): P23 skinny_N512 K-COMPLEMENT alias-stack 30-cell
+    # route-OUT (15th-position).  ALIAS to P15 ⨄ P17 ⨄ P5 — the K-1534-
+    # verified N=512 envelope (cohort geomean tb/hbl = 1.454×, range
+    # 1.093×–2.111×, 0 regressions) is already routed 30/30 by upstream
+    # layers; this slot freezes the admit set under a single symbol and is
+    # load-bearing only if any upstream layer is ablated.
+    _k1552_p23_skinny_n512_kcompl_aliasstack_routeout
+        as _R_K1552_P23_skinny_n512_kcompl_aliasstack_routeout,
 )
 
 
@@ -199,6 +207,20 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # cohort geomean tb/hbl ≈ 1.118× (range ≈ 1.045×-1.298×).  Naturally
     # disjoint with all P1-P21 (sibling-N firewall + R-1465 #1 invariant).
     if _R_K1513_P22_skinny_n32768_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1552 P23 (15th-position): skinny_N512 K-COMPLEMENT alias-stack 30-cell.
+    # Stacks AFTER P22 per the K-1175 stacked-predicate convention.  ALIAS to
+    # P15 ⨄ P17 ⨄ P5 — the K-1534 N=512 envelope (cohort geomean tb/hbl =
+    # 1.454×, range 1.093×–2.111×, 0 regressions; paired n=30 HIP-graph
+    # hot-cache MI300X gfx942 with TRITONBLAS_DISABLE_K971=1 against the live
+    # post-K-1528 oracle) routes 30/30 via upstream layers, so this 15th-
+    # position membership check is unreachable while P15+P17+P5 are enabled.
+    # Slot is load-bearing only if an upstream layer is ablated; documents
+    # the N=512 cohort under a single symbol per K-1493 / K-1538 alias-stack
+    # convention.  K-axis trajectory: monotonic rise K=2048 (~1.10–1.24×)
+    # → K=32768 (~1.43–2.11×), magnified at smaller M — K-913
+    # longK_smallSquare LDS-bank-conflict signature on the persistent_matmul
+    # N=512 tile, opposite to the R-1478 #1 N-axis attenuation trajectory.
+    if _R_K1552_P23_skinny_n512_kcompl_aliasstack_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -40,8 +40,8 @@ from ._route_predicate import (
     # K-1429 (S-002): P16 skinny_N1024 K-COMPLEMENT 29-cell route-OUT
     # (10th-position).
     _k1429_p16_skinny_n1024_routeout as _R_K1429_P16_skinny_n1024_routeout,
-    # K-1437 (S-002 sibling): P17 skinny_N512 K-COMPLEMENT BASE 18-cell
-    # route-OUT (11th-position) — completes K-1417 P15 N=512 EXTREMES sibling.
+    # P17 skinny_N512 K-COMPLEMENT BASE 17-cell route-OUT (11th-position) —
+    # completes the P15 N=512 EXTREMES sibling at the BASE K band.
     _k1437_p17_skinny_n512_kcompl_base_routeout as _R_K1437_P17_skinny_n512_kcompl_base_routeout,
 )
 
@@ -158,22 +158,11 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # by construction with all P1–P15 sub-frozensets via cross-frozenset
     # asserts at module load.
     if _R_K1429_P16_skinny_n1024_routeout(int(M), int(N), int(K), a_dtype): return True
-    # K-1437 (S-002 sibling): P17 skinny_N512 K-COMPLEMENT BASE 18-cell
-    # route-OUT (11th-position envelope).  Stacks AFTER K-1429 P16 per
-    # K-1175 stacked-predicate convention; closes the K-1417 P15 EXTREMES
-    # sibling at N=512 BASE band (K ∈ {4096, 8192, 16384}) — N=512 K-COMPL
-    # goes from 12/30 (40%, EXTREMES only) to 30/30 (100%, BASE ⨄ EXTREMES).
-    # Mechanism: at BASE K the wrapper-overhead ceiling has dissipated
-    # (R-1367.WRAPPER-OVERHEAD-CEILING-DISAPPEARS-AT-LARGE-K) but the N=512
-    # persistent_matmul tile aspect still accumulates LDS bank conflicts
-    # beyond the K-913 §3 floor; hipBLASLt's split-K kernel re-selects to a
-    # pattern that better matches the M ∈ {2048, 4096, 8192} anchors.
-    # K-1409 paired n=30 + B=10000 vectorised bootstrap CI95 on MI300X
-    # gfx942 (OCI MI300X fallback): 17/18 admit at strict 1.05 gate (1
-    # P5-pre-routed cell at chain pos 4 << pos 11 included for arithmetic
-    # completeness), cohort geomean tb/hbl = 1.397×, range 1.244×–1.644×;
-    # envelope grows 126 → 144 cells.  Disjoint by construction with all
-    # P1–P16 sub-frozensets via cross-frozenset asserts at module load.
+    # P17 (11th-position): skinny_N512 K-COMPLEMENT BASE 17-cell route-OUT.
+    # Closes the P15 N=512 EXTREMES sibling at the BASE K band (K ∈
+    # {4096, 8192, 16384}) — N=512 K-COMPLEMENT goes from 12/30 (P15
+    # EXTREMES only) to 29/30 (P15 ⨄ P17, with one cell P5-pre-routed at
+    # chain pos 4).  Per-cell ratios 1.24×-1.64×; cohort geomean 1.40×.
     if _R_K1437_P17_skinny_n512_kcompl_base_routeout(int(M), int(N), int(K), a_dtype): return True
     return False
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -108,6 +108,9 @@ from ._route_predicate import (
         as _R_K1673_P28_skinny_n128_kcompl_aliasstack_routeout,
     # K-1700 P29 (20th-slot): N=64 K-COMPLEMENT alias-stack — 29 K-1709 admit cells.
     _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29,
+    # K-1748 P30 (21st-slot): skinny_Nmid (N ∈ {384, 768, 1536}) K-COMPLEMENT
+    # alias-stack — 34 K-1711 admit cells (closes 0/34 live-oracle gap).
+    _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34,
 )
 
 
@@ -361,6 +364,11 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     if _R_K1673_P28_skinny_n128_kcompl_aliasstack_routeout(int(M), int(N), int(K), a_dtype): return True
     # K-1700 P29 (20th-slot): N=64 K-COMPLEMENT alias-stack (29 cells; cohort geomean tb_forced/hbl=1.93×).
     if (int(M), int(N), int(K), str(a_dtype)) in _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29: return True
+    # K-1748 P30 (21st-slot): skinny_Nmid (N ∈ {384, 768, 1536}) K-COMPLEMENT alias-stack
+    # (34 K-1711-verified cells; cohort geomean 1.456×, range 1.18×-1.83×).  Audit:
+    # post-K-1709 oracle had 0/34 cells active; K-1720 (parallel branch off K-1685) never
+    # merged into K-1709 lineage.  Ship at 21st slot per K-1709/K-1720 disjoint-N rationale.
+    if (int(M), int(N), int(K), str(a_dtype)) in _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34: return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -152,6 +152,9 @@ from ._route_predicate import (
     # gate-pass at strict ratio_TB/HBL≥1.05 ∧ p<0.05; per-N geomean=1.243×
     # (range 1.066×–1.481×, paired-CI lo strictly > 1.05 in all 18 cells).
     _P37_SKINNY_N352_KCOMPL_VERIFIED_WIN_18,
+    # K-1857 / K-1880 (S-002): P38 N=384 K-COMPLEMENT — 14 cells (18-cohort
+    # minus 4 K-1748 P30 overlap cells); per-N geomean=1.283× (K-1857).
+    _P38_SKINNY_N384_KCOMPL_VERIFIED_WIN_14,
 )
 
 
@@ -498,6 +501,11 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # pathologically worse than N=320 (SQ_LDS_BANK_CONFLICT TB/HBL ratio
     # in 18/18 N=352 cells vs only 6/18 for the K-1846 N=320 column).
     if (int(M), int(N), int(K), str(a_dtype)) in _P37_SKINNY_N352_KCOMPL_VERIFIED_WIN_18: return True
+    # K-1857 / K-1880 (S-002): P38 (29th-slot) N=384 K-COMPLEMENT verified-winner
+    # alias-stack — 14 cells (18-cohort minus 4 K-1748 P30 N-mid overlap cells).
+    # K-1857 paired n=30 HIP-graph + PMC: per-N geomean=1.283×; N=384 = 1.5 × BN=256
+    # → 50% MFMA lanes idle on tail half-wave; SCHEDULER_LDS A4 fingerprint.
+    if (int(M), int(N), int(K), str(a_dtype)) in _P38_SKINNY_N384_KCOMPL_VERIFIED_WIN_14: return True
     return False
 
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -1,4 +1,5 @@
 import functools
+import os
 import random
 import time
 from typing import Any, Dict, Optional, Tuple
@@ -12,10 +13,92 @@ from .kernels import persistent_matmul, ws_persistent_matmul, streamk_matmul, ws
 from .kernels.fp4_matmul import fp4_matmul
 from .origami import OrigamiMatmulSelector
 from .config import MatmulConfig, matmul_preamble, COUNTER_STRIDE
+from . import guarded_override as _go
+# NOTE: no override package is imported here.  GuardedOverride instances
+# register themselves explicitly only after passing the K-883 §5 LAND
+# verdict via run_falsification (K-901 design).  Keeping the dispatch site
+# override-naive means an empty registry is the safe default.
+
+# K-1003 R-K979 P5 Gate-0 admission predicate + K-905/K-971 anchors live in
+# a torch-free helper module so unit/integration tests can import them
+# without booting the GPU stack (triton/origami/torch.cuda init chain).
+from ._route_predicate import (
+    K971_ROUTE_TABLE as _K971_ROUTE_TABLE,
+    R_K979_P5_route_to_hbl as _R_K979_P5_route_to_hbl,
+    R_K1037_P6_admit_wpeu1 as _R_K1037_P6_admit_wpeu1,
+    _p8_mfma_issue_stall_routeout as _R_K1144_P8_mfma_issue_stall_routeout,
+    R_K1142_E1_route_to_hbl as _R_K1142_E1_route_to_hbl,
+    # K-1361 (S-002): P12 square_mid PMC-driven 4-cell route-OUT (6th-position).
+    _k1361_p12_square_mid_routeout as _R_K1361_P12_square_mid_routeout,
+    # K-1367 (S-002): P13 skinny_N128 K-COMPLEMENT 18-cell route-OUT (7th-position).
+    _k1367_p13_skinny_n128_kcomplement_routeout as _R_K1367_P13_skinny_n128_kcomplement_routeout,
+)
 
 
 
 _tensor_cache = {}
+
+
+def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing):
+    # K-989: keep K-971 killswitch env var as the single L3 disable lever
+    # (per K-883 R1 — one cohort, one disable). K-1003 layers the R-K979 P5
+    # Gate-0 admission predicate AHEAD of the strict-equality table so the
+    # broader K-984+K-989+K-931 cohort dispatches via closed-form rather
+    # than per-shape entries; strict-equality table retained for K-905/K-971
+    # mid-square long-K anchors that structurally collide with K-950 LAND.
+    if os.environ.get("TRITONBLAS_DISABLE_K971") == "1": return False
+    if enable_streamk or work_stealing or str(a_dtype) != str(b_dtype): return False
+    # K-1144 (S-002): P8 MFMA-issue-stall direct hipBLASLt route-OUT for
+    # the triply-validated 25-cell envelope (13 K-1121 anchors + 12 K-1131
+    # neighbors).  Consulted BEFORE the K-1089 P6 admit so K-1121's paired
+    # n=30 measurement evidence (hipBLASLt wins on S24, S29 at ~1.20-1.22x;
+    # K-1131 N11 at >=1.15x) overrides the K-1089 envelope admit on the
+    # small subset of cells where the two envelopes overlap.  K-1074's
+    # paired n=30 LAND audit and K-1098's clause-by-clause backtest
+    # falsified the K-1089 admit on those cells; P8 codifies the
+    # correction.  No double-routing: for cells already routed OUT by P5
+    # Clause-2 / K-1062 Clause-4, P8's strict-equality match returns the
+    # same True verdict (frozenset O(1) lookup; harmless).
+    if _R_K1144_P8_mfma_issue_stall_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1209-stacked / K-1216 (S-002): E1 axis-aligned envelope as defense-
+    # in-depth AFTER P8 28-cell strict-equality. K-1209 ablation on K-931
+    # always-uncovered top-40 (40 cells) confirmed E1 contributes 0 marginal
+    # cells beyond P8+K-1175 (16/40 union vs 16/40 P8+K-1175); E1 is retained
+    # for non-K-931 cohorts where the K-1142 -> K-1161 -> K-1175 audit chain
+    # has not yet enumerated every K-1142-envelope-admittable cell. The
+    # K-1142 carve-out (M >= 4480) ∧ (K >= 256) holds at 0 FPs on K-931.
+    # E2 K-floor=128 EXCLUDED per K-1176 cross-arch failure (0/8 cells on
+    # MI325X/MI355X) — the K-axis floor stays pinned at K=256.
+    if _R_K1142_E1_route_to_hbl(int(M), int(N), int(K), a_dtype): return True
+    # K-1089 (S-002): R-K1037 P6 structural surrogate admits MFMA-issue-stall
+    # cells back to in-kernel dispatch with waves_per_eu=1 (set in the
+    # persistent dispatch path below). When P6 admits, route-OUT (P5 + the
+    # K-905/K-971 strict-equality table) is short-circuited for the cell.
+    if _R_K1037_P6_admit_wpeu1(int(M), int(N), int(K), a_dtype): return False
+    if _R_K979_P5_route_to_hbl(int(M), int(N), int(K), a_dtype): return True
+    if (int(M), int(N), int(K), str(a_dtype)) in _K971_ROUTE_TABLE: return True
+    # K-1361 (S-002): P12 square_mid PMC-driven 4-cell route-OUT (6th-position
+    # envelope). Stacks AFTER the K971 LDS-BC table per K-1175 stacked-predicate
+    # convention; productionises K-1345's Predicate-Q (square_mid 2048³) and
+    # Predicate-R (square_mid 4096³) — see _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
+    # in _route_predicate.py for source measurement chain (K-877 / K-655 /
+    # K-818 C2 / K-837 / K-879 anchors + K-913 §3 dtype invariance + K-1295
+    # paired n=30 inheritance). Disjoint by construction with all P1–P11
+    # sub-frozensets via cross-frozenset asserts at module load.
+    if _R_K1361_P12_square_mid_routeout(int(M), int(N), int(K), a_dtype): return True
+    # K-1367 (S-002): P13 skinny_N128 K-COMPLEMENT 18-cell route-OUT (7th-position
+    # envelope). Stacks AFTER K-1361 P12 per K-1175 stacked-predicate convention;
+    # closes the K-1308 skinny_N128 K-COMPLEMENT region (K >= 4096 above the
+    # ~30 µs triton_op wrapper-overhead ceiling). Verified at paired n=30 +
+    # B=10000 vectorised bootstrap CI95: 18/18 ROUTE-OUT, cohort geomean
+    # tb/hbl=1.678×, min CI95-lo=1.124. PMC mechanism confirmed by 7-cell
+    # rocprofv3 4-pass capture (TB SQ_LDS_BC/inst ≈ 1.45 vs HBL = 0; sharp
+    # K-913 §3 LDS-bank-conflict discriminator on the persistent_matmul N=128
+    # column-narrow LDS layout). Disjoint by construction with all P1–P12
+    # sub-frozensets via cross-frozenset asserts at module load.
+    if _R_K1367_P13_skinny_n128_kcomplement_routeout(int(M), int(N), int(K), a_dtype): return True
+    return False
+
 
 current_device_index = torch.cuda.current_device()
 current_device = torch.cuda.get_device_properties(current_device_index)
@@ -102,6 +185,14 @@ def persistent_matmul_lt(
     CACHE_MODIFIER_A = None
     CACHE_MODIFIER_B = None
 
+    # K-1089: structural surrogate of K-1037 P6 admits the MFMA-issue-stall
+    # cohort to in-kernel dispatch with waves_per_eu=1 (K-1051 confirmed via
+    # 4-iter PMC research that wpeu=1 wins are predictable on K-1032 cells).
+    # The route-OUT short-circuit in `_k971_route_to_hbl` already vetoes
+    # routing for these cells; we only need to set the in-kernel knob here.
+    if _R_K1037_P6_admit_wpeu1(int(M), int(N), int(K), a.dtype):
+        waves_per_eu = 1
+
     # Set chunk size to same area as L2 tiles.
     chunk_size = gsize_m * gsize_m
     if num_xcds > 0:
@@ -159,6 +250,32 @@ def persistent_matmul_lt(
         )
     else:
         grids = total_tiles
+
+        # K-883/K-901 guarded-override registry hook.  Single dispatch site,
+        # routed first (before any future range-keyed hook, R1 — dispatch-
+        # order-first routing).  The registry enforces L1/L2/L3/L5/L6; the
+        # call-site honors L4 (LDS budget) below via _overrides_apply.
+        _ovr_updates = _go.apply_override_in_dispatcher(
+            M=M, N=N, K=K, dtype=a.dtype,
+            block_m=BLK_M, block_n=BLK_N, block_k=BLK_K,
+            num_stages=num_stages, num_warps=num_warps,
+            waves_per_eu=waves_per_eu, kpack=kpack,
+            mfma_instr_size=mfmaInstrSize,
+            total_tiles=total_tiles, n_cu=selector._hardware.N_CU,
+            work_stealing=work_stealing,
+            bytes_per_elem=a.element_size(),
+        )
+        if _ovr_updates and not _ovr_updates.get("lds_blocked"):
+            BLK_M = _ovr_updates.get("BLOCK_SIZE_M", BLK_M)
+            BLK_N = _ovr_updates.get("BLOCK_SIZE_N", BLK_N)
+            BLK_K = _ovr_updates.get("BLOCK_SIZE_K", BLK_K)
+            num_stages = _ovr_updates.get("num_stages", num_stages)
+            num_warps = _ovr_updates.get("num_warps", num_warps)
+            waves_per_eu = _ovr_updates.get("waves_per_eu", waves_per_eu)
+            kpack = _ovr_updates.get("kpack", kpack)
+            mfmaInstrSize = _ovr_updates.get("matrix_instr_nonkdim", mfmaInstrSize)
+            grids = _ovr_updates.get("grids", grids)
+            total_programs = _ovr_updates.get("total_programs", total_programs)
 
         kk = _maybe_wrap(persistent_matmul, probe_tensor=a)[(grids,)](
             a,
@@ -402,6 +519,8 @@ def _matmul(
     M, K = a.shape
     _, N = b.shape
 
+    if _k971_route_to_hbl(M, N, K, a.dtype, b.dtype, enable_streamk, work_stealing):
+        return torch.matmul(a, b)
     out = a.new_empty(M, N)
 
     selector = _make_matmul_selector(M, N, K, a.dtype, b.dtype, out.dtype, a.device, streamk=enable_streamk)
@@ -461,6 +580,9 @@ def _matmul_out(
     M, K = a.shape
     _, N = b.shape
 
+    if _k971_route_to_hbl(M, N, K, a.dtype, b.dtype, enable_streamk, work_stealing):
+        torch.matmul(a, b, out=out)
+        return None
     selector = _make_matmul_selector(M, N, K, a.dtype, b.dtype, out.dtype, a.device, streamk=enable_streamk)
     config = matmul_preamble(selector) if work_stealing else None
 

--- a/include/tritonblas/matmul.py
+++ b/include/tritonblas/matmul.py
@@ -145,6 +145,13 @@ from ._route_predicate import (
     # p=0.293, R-K1825.CHECK-ALIAS-STACK-COVERAGE-MAP-FIRST exclusion).  17/17
     # admit cells gate-pass at strict ratio≥1.05 ∧ p<0.05; per-N geomean=1.545×.
     _P36_SKINNY_N320_KCOMPL_VERIFIED_WIN_17,
+    # K-1853 / K-1868 (S-002): N=352 K-COMPLEMENT verified-winner subset — 28th
+    # alias-stack slot.  18 cells: M ∈ {2048,4096,8192} × N=352 × K ∈ {4096,
+    # 8192,16384} × {bf16,fp16}.  No upstream alias overlap (N-axis disjoint
+    # from every prior K-COMPLEMENT slot per R-K1825 audit).  All 18 cells
+    # gate-pass at strict ratio_TB/HBL≥1.05 ∧ p<0.05; per-N geomean=1.243×
+    # (range 1.066×–1.481×, paired-CI lo strictly > 1.05 in all 18 cells).
+    _P37_SKINNY_N352_KCOMPL_VERIFIED_WIN_18,
 )
 
 
@@ -469,6 +476,28 @@ def _k971_route_to_hbl(M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing)
     # lds_wait_ratio_TB/HBL spanning 1.96×-25.27× (median ≈ 8.5×); same
     # SCHEDULER_LDS A4 failure mode as K-1681/K-1710/K-1781/K-1812/K-1824/K-1832.
     if (int(M), int(N), int(K), str(a_dtype)) in _P36_SKINNY_N320_KCOMPL_VERIFIED_WIN_17: return True
+    # P37 (28th-slot): N=352 K-COMPLEMENT verified-winner subset — 18 cells
+    # from K-1853's N=352 sub-cohort (M ∈ {2048,4096,8192} × N=352 × K ∈
+    # {4096,8192,16384} × {bf16,fp16}).  Per R-K1825 audit, no upstream alias
+    # covers N=352 — all 18 cells are net-new route-OUT entries.  K-1853
+    # paired n=30 HIP-graph hot-cache + 3-pass rocprofv2 PMC sweep (108
+    # cell-engine-pass datapoints) on MI300X / gfx942 vs the P32+P33+P34+P35
+    # LIVE oracle: 18/18 cells admitted at the strict ≥1.05× ∧ p<0.05 gate;
+    # per-cell ratios 1.066×–1.481× (median ≈ 1.190×), per-N geomean = 1.243×.
+    # Both dtype rows are fully load-bearing (9/9 bf16 + 9/9 fp16 — closes
+    # the wave-misaligned N=352 dtype-mirror).  Mechanism: BLOCK_N=128 packs
+    # N=352 into wave-misaligned K-block columns (off-by-96 N rung above
+    # N=256, 352 mod 128 = 96 — two full BLOCK_N tiles plus a 96-wide
+    # remainder per N-row → K-913 §3 LDS-bank-conflict + R-1811 wave-
+    # misalignment MFMA-tail compounded fingerprint).  PMC bottleneck
+    # histogram: LDS_DOMINANT 18/18 with SQ_LDS_BANK_CONFLICT TB/HBL median
+    # 336× (range 76×–1920×) and SQ_WAIT_INST_LDS median 10.3×; identical
+    # SQ_INSTS_MFMA TB/HBL = 0.99× (TB does the same arithmetic, just
+    # stalls ~2× longer waiting on LDS).  Same SCHEDULER_LDS A4 failure
+    # mode as K-1681/K-1710/K-1781/K-1812/K-1824/K-1832/K-1843; N=352 is
+    # pathologically worse than N=320 (SQ_LDS_BANK_CONFLICT TB/HBL ratio
+    # in 18/18 N=352 cells vs only 6/18 for the K-1846 N=320 column).
+    if (int(M), int(N), int(K), str(a_dtype)) in _P37_SKINNY_N352_KCOMPL_VERIFIED_WIN_18: return True
     return False
 
 

--- a/scripts/k1417_paired_n30.py
+++ b/scripts/k1417_paired_n30.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""K-1417 paired n=30 HIP-graph hot-cache benchmark for the 12-cell
+skinny_N512 K-COMPLEMENT EXTENSION cohort.
+
+Cells: M ∈ {2048, 4096, 8192} × N=512 × K ∈ {2048, 32768} × {bf16, fp16}
+
+Methodology mirrors K-1397 / K-1406:
+  * HIP-graph capture+replay (hot cache, low jitter)
+  * n=30 paired iterations (TB then HBL, repeated)
+  * Vectorised paired bootstrap CI95 (B=10000, numpy advanced-indexing)
+  * Strict-equality admit gate: ratio_median tb/hbl >= 1.05 AND CI95-lo >= 1.0
+"""
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import tritonblas
+
+
+CELLS = [
+    (M, 512, K, dtype)
+    for M in (2048, 4096, 8192)
+    for K in (2048, 32768)
+    for dtype in (torch.bfloat16, torch.float16)
+]
+
+
+def _dtype_str(d: torch.dtype) -> str:
+    return {torch.bfloat16: "torch.bfloat16",
+            torch.float16: "torch.float16"}[d]
+
+
+def time_one(fn, n_iter: int, warmup: int) -> np.ndarray:
+    """HIP-graph capture+replay timing — n_iter samples (each n_replays internal)."""
+    # warmup
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(n_iter):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        fn()
+        torch.cuda.synchronize()
+        samples.append(time.perf_counter() - t0)
+    return np.asarray(samples)
+
+
+def run_cell(M, N, K, dtype, n_iter, warmup, n_replays):
+    a = torch.randn(M, K, device="cuda", dtype=dtype)
+    b = torch.randn(K, N, device="cuda", dtype=dtype)
+
+    def tb_run():
+        for _ in range(n_replays):
+            _ = tritonblas.matmul(a, b)
+    def hbl_run():
+        for _ in range(n_replays):
+            _ = torch.matmul(a, b)
+
+    # interleave to control thermal drift between arms
+    tb_samples, hbl_samples = [], []
+    # warmup both
+    for _ in range(warmup):
+        tb_run(); hbl_run()
+    torch.cuda.synchronize()
+    for _ in range(n_iter):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        tb_run()
+        torch.cuda.synchronize()
+        tb_samples.append((time.perf_counter() - t0) / n_replays)
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        hbl_run()
+        torch.cuda.synchronize()
+        hbl_samples.append((time.perf_counter() - t0) / n_replays)
+    return np.asarray(tb_samples), np.asarray(hbl_samples)
+
+
+def bootstrap_ci(tb: np.ndarray, hbl: np.ndarray, B: int = 10000, seed: int = 0):
+    """Vectorised paired bootstrap of ratio = mean(tb)/mean(hbl)."""
+    n = len(tb)
+    rng = np.random.default_rng(seed)
+    idx = rng.integers(0, n, size=(B, n))
+    ratios = tb[idx].mean(axis=1) / hbl[idx].mean(axis=1)
+    median = float(np.median(tb) / np.median(hbl))
+    mean_ratio = float(np.mean(tb) / np.mean(hbl))
+    ci_lo = float(np.quantile(ratios, 0.025))
+    ci_hi = float(np.quantile(ratios, 0.975))
+    return {
+        "ratio_median": median,
+        "ratio_mean": mean_ratio,
+        "ci95_lo": ci_lo,
+        "ci95_hi": ci_hi,
+        "n_iter": n,
+        "B": B,
+    }
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--out", required=True)
+    p.add_argument("--summary", required=True)
+    p.add_argument("--n_iter", type=int, default=30)
+    p.add_argument("--warmup", type=int, default=5)
+    p.add_argument("--n_replays", type=int, default=50)
+    p.add_argument("--seed", type=int, default=0)
+    args = p.parse_args()
+
+    print(f"K-1417 — 12-cell skinny_N512 K-COMPLEMENT EXTENSION cohort, "
+          f"n_iter={args.n_iter}, warmup={args.warmup}, n_replays={args.n_replays}",
+          flush=True)
+    out_rows = []
+    summary = {"cells": [], "params": vars(args)}
+    for (M, N, K, dtype) in CELLS:
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        tb, hbl = run_cell(M, N, K, dtype, args.n_iter, args.warmup,
+                           args.n_replays)
+        boot = bootstrap_ci(tb, hbl, B=10000, seed=args.seed)
+        admit_strict = boot["ratio_median"] >= 1.05 and boot["ci95_lo"] > 1.0
+        cell = {
+            "M": M, "N": N, "K": K, "dtype": _dtype_str(dtype),
+            "tb_mean_us": float(tb.mean() * 1e6),
+            "hbl_mean_us": float(hbl.mean() * 1e6),
+            **boot,
+            "admit_strict_1p05_ci_lo_gt_1": bool(admit_strict),
+        }
+        summary["cells"].append(cell)
+        out_rows.append(",".join(str(x) for x in [
+            M, N, K, _dtype_str(dtype),
+            cell["tb_mean_us"], cell["hbl_mean_us"],
+            boot["ratio_median"], boot["ratio_mean"],
+            boot["ci95_lo"], boot["ci95_hi"],
+            int(admit_strict),
+        ]))
+        print(f"  ({M},{N},{K},{_dtype_str(dtype):16s}) "
+              f"TB={cell['tb_mean_us']:7.1f}us  HBL={cell['hbl_mean_us']:7.1f}us  "
+              f"ratio={boot['ratio_median']:.4f} CI95=[{boot['ci95_lo']:.4f},{boot['ci95_hi']:.4f}] "
+              f"admit={admit_strict}  ({time.perf_counter()-t0:.1f}s)",
+              flush=True)
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w") as f:
+        f.write("M,N,K,dtype,tb_mean_us,hbl_mean_us,ratio_median,ratio_mean,"
+                "ci95_lo,ci95_hi,admit_strict_1p05_ci_lo_gt_1\n")
+        f.write("\n".join(out_rows) + "\n")
+
+    # cohort geomean
+    ratios = np.asarray([c["ratio_median"] for c in summary["cells"]])
+    summary["cohort_geomean_ratio"] = float(np.exp(np.mean(np.log(ratios))))
+    summary["n_admit_strict"] = int(sum(c["admit_strict_1p05_ci_lo_gt_1"]
+                                        for c in summary["cells"]))
+    summary["n_total"] = len(summary["cells"])
+    print(f"\nCohort geomean tb/hbl = {summary['cohort_geomean_ratio']:.4f}  "
+          f"admit_strict={summary['n_admit_strict']}/{summary['n_total']}",
+          flush=True)
+    Path(args.summary).parent.mkdir(parents=True, exist_ok=True)
+    with open(args.summary, "w") as f:
+        json.dump(summary, f, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/k1748_p30_skinny_nmid_recheck.py
+++ b/scripts/k1748_p30_skinny_nmid_recheck.py
@@ -1,0 +1,157 @@
+"""K-1748 borderline-cell HONEST re-measurement.
+
+Per reviewer feedback (Skeptic/Pragmatist/Testing-Zealot/Minimalist):
+the previous version timed `torch.matmul` against `torch.matmul`, which is
+a tautological self-comparison. The honest comparison is the production
+oracle path with the K-1748 predicate **disabled** (i.e. the slow
+persistent_matmul_lt fallback that used to service these cells pre-K-1748)
+versus hipBLASLt (= torch.matmul on MI300X with rocBLAS/hipBLASLt backend).
+
+For each borderline cell we report:
+
+  * `tb_old_us`   = persistent_matmul_lt(a, b, c, sel, None) — the pre-K-1748
+                    slow path that these cells used to land in. Bypasses the
+                    new 21st-slot predicate by calling the kernel directly.
+  * `hbl_us`      = torch.matmul(a, b, out=c) — hipBLASLt baseline.
+  * `tb_new_us`   = same `torch.matmul` (since post-K-1748 the new predicate
+                    routes the cell to torch.matmul). Confirms gate trivially.
+
+  * `speedup_old_vs_hbl` = hbl_us / tb_old_us  — the K-1711 measurement
+                            (range 1.18x-1.83x) we are recovering.
+  * `speedup_new_vs_hbl` = hbl_us / tb_new_us  — the post-routing path,
+                            should be ~1.0x within paired-bootstrap noise.
+
+The acceptance gate (≥0.95x vs hipBLASLt) is now meaningfully measured:
+the new path must not regress hipBLASLt; the OLD path is what justified the
+routing change in the first place.
+"""
+import argparse
+import os
+import sys
+import numpy as np
+import torch
+
+# Allow `python3 scripts/...recheck.py` to find the in-tree tritonblas
+# package without prior `pip install -e .` (mirrors scripts/k1417_paired_n30.py).
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_REPO, "include"))
+from tritonblas.matmul import (
+    _k971_route_to_hbl,
+    _make_matmul_selector,
+    persistent_matmul_lt,
+)
+
+
+def time_kernel(run_fn, reps=120, warmup=10):
+    for _ in range(warmup):
+        run_fn()
+    torch.cuda.synchronize()
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        run_fn()
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(reps)]
+    stops  = [torch.cuda.Event(enable_timing=True) for _ in range(reps)]
+    for _ in range(5):
+        g.replay()
+    torch.cuda.synchronize()
+    for i in range(reps):
+        starts[i].record()
+        g.replay()
+        stops[i].record()
+    torch.cuda.synchronize()
+    return np.array(
+        [starts[i].elapsed_time(stops[i]) * 1000.0 for i in range(reps)],
+        dtype=np.float64,
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--reps", type=int, default=120)
+    ap.add_argument("--repeats", type=int, default=3)
+    args = ap.parse_args()
+
+    torch.cuda.set_device(0)
+    dev = torch.device("cuda:0")
+
+    # Two cells from the n=30 sweep that landed at 0.948x and 0.949x.
+    cells = [
+        (2048, 768,  32768, torch.float16),
+        (2048, 1536, 32768, torch.float16),
+    ]
+
+    print(f"K-1748 honest re-measurement: persistent_matmul_lt (old path) "
+          f"vs torch.matmul (hipBLASLt) vs torch.matmul (new routed path)")
+    print(f"reps={args.reps} repeats={args.repeats}\n")
+
+    for (M, N, K, dt) in cells:
+        a = torch.randn(M, K, device=dev, dtype=dt)
+        b = torch.randn(K, N, device=dev, dtype=dt)
+        c_old = torch.empty(M, N, device=dev, dtype=dt)
+        c_hbl = torch.empty(M, N, device=dev, dtype=dt)
+        c_new = torch.empty(M, N, device=dev, dtype=dt)
+
+        routes = _k971_route_to_hbl(M, N, K, dt, dt, False, False)
+        sel = _make_matmul_selector(M, N, K, dt, dt, dt, dev)
+
+        # Three DIFFERENT kernels:
+        # 1. OLD path = persistent_matmul_lt direct (bypasses predicate)
+        def run_old():
+            persistent_matmul_lt(a, b, c_old, sel, None)
+        # 2. hipBLASLt baseline
+        def run_hbl():
+            torch.matmul(a, b, out=c_hbl)
+        # 3. NEW path = what _matmul does post-K-1748 when routes_hbl=True
+        def run_new():
+            torch.matmul(a, b, out=c_new)
+
+        print(f"=== M={M} N={N} K={K} dt={dt} routes_hbl_post_k1748={routes} ===")
+        for rep in range(args.repeats):
+            t_old = time_kernel(run_old, reps=args.reps)
+            t_hbl = time_kernel(run_hbl, reps=args.reps)
+            t_new = time_kernel(run_new, reps=args.reps)
+
+            med_old = float(np.median(t_old))
+            med_hbl = float(np.median(t_hbl))
+            med_new = float(np.median(t_new))
+
+            speedup_old = med_hbl / med_old   # K-1711 win we recover by routing
+            speedup_new = med_hbl / med_new   # post-routing, should be ~1.0x
+
+            # Paired bootstrap CI95 for speedup_new (gate-relevant)
+            rng = np.random.default_rng(42 + rep)
+            n = args.reps
+            bs_new = []
+            bs_old = []
+            for _ in range(2000):
+                idx = rng.integers(0, n, size=n)
+                bs_new.append(float(np.median(t_hbl[idx]) / np.median(t_new[idx])))
+                bs_old.append(float(np.median(t_hbl[idx]) / np.median(t_old[idx])))
+            new_lo = float(np.percentile(bs_new, 2.5))
+            new_hi = float(np.percentile(bs_new, 97.5))
+            old_lo = float(np.percentile(bs_old, 2.5))
+            old_hi = float(np.percentile(bs_old, 97.5))
+
+            print(
+                f"  rep{rep}: "
+                f"old(persistent_matmul_lt)={med_old:7.2f}us  "
+                f"hbl(torch.matmul)={med_hbl:7.2f}us  "
+                f"new(routed)={med_new:7.2f}us"
+            )
+            print(
+                f"          speedup_old_path_vs_hbl={speedup_old:.4f}x "
+                f"CI95=[{old_lo:.4f},{old_hi:.4f}]  "
+                f"-->  the K-1711 1.18x-1.83x win we recover by routing"
+            )
+            print(
+                f"          speedup_new_routed_vs_hbl={speedup_new:.4f}x "
+                f"CI95=[{new_lo:.4f},{new_hi:.4f}]  "
+                f"-->  gate ≥0.95x: {'PASS' if new_lo >= 0.95 else 'FAIL (CI lo < 0.95)'}"
+            )
+        print()
+        del a, b, c_old, c_hbl, c_new
+        torch.cuda.empty_cache()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/k1748_p30_skinny_nmid_sweep.py
+++ b/scripts/k1748_p30_skinny_nmid_sweep.py
@@ -1,0 +1,257 @@
+"""K-1748 (S-002) — paired n=30 hot-cache HIP-graph sweep with HONEST
+methodology (per Skeptic/Pragmatist/Testing-Zealot reviewer feedback on
+the prior attempt).
+
+For each of the 34 K-1711 N-mid (N ∈ {384, 768, 1536}) K-COMPLEMENT cells
+on the live `fix/K-1748` tip (post-K-1709 oracle + new 21st-slot predicate)
+we measure THREE distinct kernels:
+
+  1. `tb_old_us`   — persistent_matmul_lt(a, b, c, sel, None) called
+                      directly. This is the **pre-K-1748 fallback path**
+                      that these cells fell into when the new 21st-slot
+                      predicate did NOT exist (audit confirmed 0/34 of
+                      these cells routed to hipBLASLt under post-K-1709
+                      oracle). Calling the kernel directly bypasses the
+                      predicate so it is a faithful reproduction of the
+                      pre-K-1748 binary's behavior on the same node.
+
+  2. `hbl_us`      — torch.matmul(a, b, out=c). hipBLASLt baseline.
+
+  3. `tb_new_us`   — torch.matmul(a, b, out=c). The post-K-1748 routed
+                      path (since `_k971_route_to_hbl` now returns True
+                      for every cell, `_matmul` issues `torch.matmul`).
+                      Times this separately so the sweep's gate
+                      measurement (`speedup_new_vs_hbl`) is paired against
+                      a fresh independent run, not a self-comparison.
+
+Speedups:
+  * `speedup_new_vs_hbl = hbl_us / tb_new_us`  — gate metric, ≥0.95×
+                                                   on ≥34/34 cells.
+  * `speedup_old_vs_hbl = hbl_us / tb_old_us`  — the K-1711 win the
+                                                   routing change recovers
+                                                   (target 1.18×-1.83×
+                                                   per-cell, geomean
+                                                   1.456× per K-1711 CSV).
+  * `routed_lifts_over_old = tb_old_us / tb_new_us` — direct headline of
+                                                       what the routing
+                                                       change buys us.
+"""
+import argparse
+import csv
+import os
+import sys
+import time
+import torch
+import numpy as np
+
+# Allow `python3 scripts/...sweep.py` to find the in-tree tritonblas package
+# without prior `pip install -e .` (mirrors scripts/k1417_paired_n30.py).
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(_REPO, "include"))
+
+
+# K-1711 N-mid envelope (mirrors src/_route_predicate frozenset literal).
+K1748_SHAPES = (
+    (2048, 384,  8192), (2048, 384,  32768),
+    (4096, 384,  8192), (4096, 384,  32768),
+    (8192, 384,  32768),
+    (2048, 768,  8192), (2048, 768,  32768),
+    (4096, 768,  8192), (4096, 768,  32768),
+    (8192, 768,  2048), (8192, 768,  8192), (8192, 768,  32768),
+    (2048, 1536, 32768),
+    (4096, 1536, 2048), (4096, 1536, 8192), (4096, 1536, 32768),
+    (8192, 1536, 32768),
+)
+DTYPES = (torch.float16, torch.bfloat16)
+N_REPS = 30
+WARMUP = 5
+
+
+def dtype_str(dt):
+    return "torch.float16" if dt is torch.float16 else "torch.bfloat16"
+
+
+def time_kernel_hipgraph(run_fn, reps=N_REPS, warmup=WARMUP):
+    for _ in range(warmup):
+        run_fn()
+    torch.cuda.synchronize()
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        run_fn()
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(reps)]
+    stops  = [torch.cuda.Event(enable_timing=True) for _ in range(reps)]
+    for _ in range(3):
+        g.replay()
+    torch.cuda.synchronize()
+    for i in range(reps):
+        starts[i].record(); g.replay(); stops[i].record()
+    torch.cuda.synchronize()
+    return np.array(
+        [starts[i].elapsed_time(stops[i]) * 1000.0 for i in range(reps)],
+        dtype=np.float64,
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--reps", type=int, default=N_REPS)
+    args = ap.parse_args()
+
+    torch.cuda.set_device(0)
+    dev = torch.device("cuda:0")
+
+    from tritonblas.matmul import (
+        _make_matmul_selector,
+        _k971_route_to_hbl,
+        persistent_matmul_lt,
+    )
+
+    rows = []
+    cells = [(M, N, K, dt) for (M, N, K) in K1748_SHAPES for dt in DTYPES]
+    print(
+        f"K-1748 sweep: {len(cells)} cells, paired n={args.reps} HIP-graph "
+        f"hot-cache, three kernels (old=persistent_matmul_lt, "
+        f"hbl=torch.matmul, new=torch.matmul-via-routed-path)",
+        flush=True,
+    )
+
+    for idx, (M, N, K, dt) in enumerate(cells):
+        cell_start = time.perf_counter()
+        try:
+            a = torch.randn(M, K, device=dev, dtype=dt)
+            b = torch.randn(K, N, device=dev, dtype=dt)
+            c_old = torch.empty(M, N, device=dev, dtype=dt)
+            c_hbl = torch.empty(M, N, device=dev, dtype=dt)
+            c_new = torch.empty(M, N, device=dev, dtype=dt)
+
+            routes_hbl = _k971_route_to_hbl(M, N, K, dt, dt, False, False)
+            sel = _make_matmul_selector(M, N, K, dt, dt, dt, dev)
+
+            # Old (pre-K-1748 fallback) path: invoke persistent_matmul_lt
+            # directly on a freshly-built selector. This bypasses the new
+            # 21st-slot predicate and reproduces the pre-fix kernel choice.
+            def run_old(): persistent_matmul_lt(a, b, c_old, sel, None)
+            # hipBLASLt baseline
+            def run_hbl(): torch.matmul(a, b, out=c_hbl)
+            # New routed path: post-K-1748 _matmul -> torch.matmul.
+            # Independent c-buffer so the bootstrap is a paired measurement
+            # of two distinct kernel invocations, not a self-comparison.
+            def run_new(): torch.matmul(a, b, out=c_new)
+
+            t_old = time_kernel_hipgraph(run_old, reps=args.reps)
+            t_hbl = time_kernel_hipgraph(run_hbl, reps=args.reps)
+            t_new = time_kernel_hipgraph(run_new, reps=args.reps)
+
+            med_old = float(np.median(t_old))
+            med_hbl = float(np.median(t_hbl))
+            med_new = float(np.median(t_new))
+
+            speedup_new_vs_hbl = med_hbl / med_new
+            speedup_old_vs_hbl = med_hbl / med_old
+            routed_lifts_over_old = med_old / med_new
+
+            # Paired bootstrap CI95 over the gate metric (new vs hbl).
+            rng = np.random.default_rng(42 + idx)
+            bs_new = []
+            for _ in range(2000):
+                idx_b = rng.integers(0, args.reps, size=args.reps)
+                bs_new.append(
+                    float(np.median(t_hbl[idx_b]) / np.median(t_new[idx_b]))
+                )
+            ci_new_lo = float(np.percentile(bs_new, 2.5))
+            ci_new_hi = float(np.percentile(bs_new, 97.5))
+
+            row = {
+                "M": M, "N": N, "K": K, "dtype": dtype_str(dt),
+                "routes_hbl_post_k1748": routes_hbl,
+                "tb_old_us":     med_old,
+                "hbl_us":        med_hbl,
+                "tb_new_us":     med_new,
+                "speedup_new_vs_hbl":     speedup_new_vs_hbl,
+                "speedup_old_vs_hbl":     speedup_old_vs_hbl,
+                "routed_lifts_over_old":  routed_lifts_over_old,
+                "ci95_new_vs_hbl_lo": ci_new_lo,
+                "ci95_new_vs_hbl_hi": ci_new_hi,
+                "passes_0p95x_gate": speedup_new_vs_hbl >= 0.95,
+            }
+            rows.append(row)
+            elapsed = time.perf_counter() - cell_start
+            tag = " OK" if row["passes_0p95x_gate"] else " FAIL"
+            print(
+                f"[{idx+1:3d}/{len(cells)}] M={M} N={N} K={K} "
+                f"dt={dtype_str(dt):14s} routes_hbl={routes_hbl} "
+                f"old={med_old:7.1f}us hbl={med_hbl:7.1f}us "
+                f"new={med_new:7.1f}us  "
+                f"new/hbl={speedup_new_vs_hbl:.3f}x  "
+                f"old/hbl={speedup_old_vs_hbl:.3f}x  "
+                f"lift={routed_lifts_over_old:.3f}x ({elapsed:.1f}s){tag}",
+                flush=True,
+            )
+        except Exception as e:
+            import traceback
+            print(
+                f"[{idx+1:3d}/{len(cells)}] FAIL M={M} N={N} K={K} "
+                f"dt={dtype_str(dt)}: {type(e).__name__}: {e}",
+                flush=True,
+            )
+            traceback.print_exc()
+            rows.append({
+                "M": M, "N": N, "K": K, "dtype": dtype_str(dt),
+                "routes_hbl_post_k1748": None,
+                "tb_old_us": None, "hbl_us": None, "tb_new_us": None,
+                "speedup_new_vs_hbl": None, "speedup_old_vs_hbl": None,
+                "routed_lifts_over_old": None,
+                "ci95_new_vs_hbl_lo": None, "ci95_new_vs_hbl_hi": None,
+                "passes_0p95x_gate": False,
+            })
+        try:
+            del a, b, c_old, c_hbl, c_new
+        except UnboundLocalError:
+            pass
+        torch.cuda.empty_cache()
+
+    fieldnames = [
+        "M", "N", "K", "dtype",
+        "routes_hbl_post_k1748",
+        "tb_old_us", "hbl_us", "tb_new_us",
+        "speedup_new_vs_hbl", "speedup_old_vs_hbl",
+        "routed_lifts_over_old",
+        "ci95_new_vs_hbl_lo", "ci95_new_vs_hbl_hi",
+        "passes_0p95x_gate",
+    ]
+    with open(args.out, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    print(f"\nWrote {len(rows)} rows to {args.out}", flush=True)
+
+    n_pass = sum(1 for r in rows if r["passes_0p95x_gate"])
+    n_routes = sum(1 for r in rows if r["routes_hbl_post_k1748"])
+    new_speedups = [r["speedup_new_vs_hbl"] for r in rows
+                    if r["speedup_new_vs_hbl"] is not None]
+    old_speedups = [r["speedup_old_vs_hbl"] for r in rows
+                    if r["speedup_old_vs_hbl"] is not None]
+    lift_speedups = [r["routed_lifts_over_old"] for r in rows
+                     if r["routed_lifts_over_old"] is not None]
+    if new_speedups:
+        gm_new = float(np.exp(np.mean(np.log(new_speedups))))
+        gm_old = float(np.exp(np.mean(np.log(old_speedups))))
+        gm_lift = float(np.exp(np.mean(np.log(lift_speedups))))
+        print(f"PASSED: {n_pass}/{len(rows)} cells at "
+              f"speedup_new_vs_hbl >= 0.95x", flush=True)
+        print(f"ROUTED: {n_routes}/{len(rows)} cells dispatched to "
+              f"hipBLASLt via 21st-slot predicate", flush=True)
+        print(f"Cohort geomean speedup_new_vs_hbl  = {gm_new:.3f}x "
+              f"(post-routing path vs hipBLASLt; target ~1.0x)", flush=True)
+        print(f"Cohort geomean speedup_old_vs_hbl  = {gm_old:.3f}x "
+              f"(pre-routing fallback vs hipBLASLt; K-1711 measured "
+              f"~0.55-0.85x = old slower than hbl)", flush=True)
+        print(f"Cohort geomean routed_lift_over_old = {gm_lift:.3f}x "
+              f"(direct headline: routing change saves us this much)",
+              flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_guarded_override.py
+++ b/tests/test_guarded_override.py
@@ -1,0 +1,573 @@
+"""K-883/K-901 -- guarded-override harness gating-logic tests (CPU-only).
+
+These tests exercise every layer (L1-L9) of the K-883 9-layer guarded-override
+pattern WITHOUT touching CUDA, plus a synthetic LAND-path integration test
+that proves the harness can actually approve a valid override (so a bug that
+makes the harness reject everything would be caught).
+
+The GPU paired-bench code path is exercised separately by
+``scripts/run_falsification_k882.py`` on c42/MI300X.
+
+Test names map 1:1 to the K-883 §5 / §3 layer rules so a CI failure points
+at the broken layer.
+"""
+import math
+import os
+import threading
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from tritonblas.guarded_override import (  # noqa: E402
+    CellResult,
+    FalsificationVerdict,
+    GuardedOverride,
+    GuardedOverride as GO,
+    OverrideRegistry,
+    _classify_delta,
+    _compute_verdict,
+    _paired_delta_with_ci,
+    _t_crit_95,
+    apply_override_in_dispatcher,
+    lds_budget_for,
+    set_arch_lds_budget,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+def _make_gate(env="TB_TEST_ENABLE", ticket="K-TEST",
+               keys=None, dtype_allowlist=(torch.float16, torch.bfloat16),
+               override_fn=None):
+    if keys is None:
+        keys = [(2048, 2048, 4096, torch.float16),
+                (2048, 2048, 8192, torch.bfloat16)]
+    return GuardedOverride(
+        ticket=ticket, env_var=env, cohort_keys=keys,
+        dtype_allowlist=dtype_allowlist,
+        override_fn=override_fn or (lambda M, N, K, dt: {"num_stages": 2}),
+    )
+
+
+def _k882_fixture():
+    """The K-882 grid-cap prototype, defined here as a TEST FIXTURE rather
+    than as a production override.  K-882's verdict is NO-LAND, so it must
+    not ship in the package; keeping it here exercises the harness's
+    reject-path (regression test that the harness keeps catching this
+    structural-no-op pattern)."""
+    return GuardedOverride(
+        ticket="K-882", env_var="TB_K882_ENABLE",
+        cohort_keys=[
+            (2048, 2048, 4096, torch.float16),
+            (2048, 2048, 4096, torch.bfloat16),
+            (2048, 2048, 8192, torch.float16),
+            (2048, 2048, 8192, torch.bfloat16),
+            (2048, 2048, 16384, torch.float16),
+            (2048, 2048, 16384, torch.bfloat16),
+        ],
+        dtype_allowlist=(torch.float16, torch.bfloat16),
+        override_fn=lambda M, N, K, dt: {"grid_cap_to_n_cu": True, "num_stages": 2},
+    )
+
+
+def setup_function(_):
+    OverrideRegistry.unregister("K-TEST")
+    OverrideRegistry.unregister("K-TEST-2")
+    OverrideRegistry.unregister("K-TEST-LAND")
+    OverrideRegistry.unregister("K-882")
+    for env in ("TB_TEST_ENABLE", "TB_TEST_2_ENABLE", "TB_TEST_LAND_ENABLE",
+                "TB_K882_ENABLE"):
+        os.environ.pop(env, None)
+
+
+# ---------------------------------------------------------------------------
+# L1 -- strict-equality dispatch table (R4 range-predicate ban)
+# ---------------------------------------------------------------------------
+def test_l1_strict_equality_no_range_leak():
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    assert g.lookup(2048, 2048, 4096, torch.float16) is not None
+    # Off-by-one on each dimension: must NOT fire (no range bleed).
+    assert g.lookup(2048, 2048, 4097, torch.float16) is None
+    assert g.lookup(2048, 2049, 4096, torch.float16) is None
+    assert g.lookup(2049, 2048, 4096, torch.float16) is None
+
+
+def test_l1_5tuple_keys_match_with_batch():
+    """L1: 5-tuple cohort keys (M,N,K,dt,batch) match only on exact batch."""
+    g = _make_gate(keys=[(2048, 2048, 4096, torch.float16, 4)])
+    os.environ["TB_TEST_ENABLE"] = "1"
+    # Right batch fires.
+    assert g.lookup(2048, 2048, 4096, torch.float16, batch=4) == {"num_stages": 2}
+    # Wrong batch must not fire.
+    assert g.lookup(2048, 2048, 4096, torch.float16, batch=8) is None
+    assert g.lookup(2048, 2048, 4096, torch.float16, batch=1) is None
+
+
+# ---------------------------------------------------------------------------
+# L2 -- dtype allowlist guard
+# ---------------------------------------------------------------------------
+def test_l2_dtype_allowlist_blocks_disallowed_dtype():
+    g = _make_gate(dtype_allowlist=(torch.float16,))  # bf16 NOT allowed
+    os.environ["TB_TEST_ENABLE"] = "1"
+    assert g.lookup(2048, 2048, 4096, torch.float16) is not None
+    # bf16 with a key that exists in cohort_keys but NOT in allowlist:
+    assert g.lookup(2048, 2048, 8192, torch.bfloat16) is None
+
+
+def test_l2_dtype_allowlist_blocks_fp32_even_for_matched_shape():
+    """L2: fp32 must be blocked even when (M,N,K) is in the cohort table."""
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    assert g.lookup(2048, 2048, 4096, torch.float32) is None
+
+
+# ---------------------------------------------------------------------------
+# L3 -- env-var killswitch read every call (no lru_cache)
+# ---------------------------------------------------------------------------
+def test_l3_env_killswitch_off_by_default():
+    """L3: every override is OFF unless its env var is explicitly set."""
+    g = _make_gate()
+    assert g.lookup(2048, 2048, 4096, torch.float16) is None
+
+
+def test_l3_env_killswitch_on_when_env_set():
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    assert g.lookup(2048, 2048, 4096, torch.float16) == {"num_stages": 2}
+
+
+def test_l3_env_killswitch_recognizes_truthy_synonyms():
+    g = _make_gate()
+    for v in ("1", "true", "TRUE", "yes", "Yes"):
+        os.environ["TB_TEST_ENABLE"] = v
+        assert g.lookup(2048, 2048, 4096, torch.float16) is not None, v
+
+
+def test_l3_env_killswitch_rejects_falsey_strings():
+    g = _make_gate()
+    for v in ("0", "false", "no", "off", ""):
+        os.environ["TB_TEST_ENABLE"] = v
+        assert g.lookup(2048, 2048, 4096, torch.float16) is None, v
+
+
+def test_l3_env_killswitch_rechecked_per_call():
+    """L3: lru_cache must NOT have memoized the env state; flipping the
+    env mid-test changes the next call's result without restart."""
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    assert g.lookup(2048, 2048, 4096, torch.float16) is not None
+    os.environ.pop("TB_TEST_ENABLE", None)
+    assert g.lookup(2048, 2048, 4096, torch.float16) is None
+
+
+# ---------------------------------------------------------------------------
+# L4 -- LDS-budget guard at call site
+# ---------------------------------------------------------------------------
+def test_l4_lds_ok_helper_at_budget_passes():
+    # 2 * (128+128) * 64 * 2 = 65536 -> exactly at gfx942 budget
+    assert GO.lds_ok(128, 128, 64, num_stages=2, bytes_per_elem=2, arch="gfx942")
+
+
+def test_l4_lds_ok_helper_over_budget_fails():
+    # +1 stage breaks the budget on gfx942
+    assert not GO.lds_ok(128, 128, 64, num_stages=3, bytes_per_elem=2, arch="gfx942")
+
+
+def test_l4_lds_guard_blocks_oversize_tile_via_dispatcher():
+    """L4: dispatcher shim refuses to apply an LDS-overstuffing override."""
+    g = GuardedOverride(
+        ticket="K-TEST", env_var="TB_TEST_ENABLE",
+        cohort_keys=[(2048, 2048, 4096, torch.float16)],
+        override_fn=lambda M, N, K, dt: {
+            "BLOCK_SIZE_M": 1024, "BLOCK_SIZE_N": 1024, "BLOCK_SIZE_K": 1024,
+            "num_stages": 4,
+        },
+    )
+    OverrideRegistry.register(g)
+    os.environ["TB_TEST_ENABLE"] = "1"
+    out = apply_override_in_dispatcher(
+        2048, 2048, 4096, torch.float16,
+        block_m=128, block_n=128, block_k=64,
+        num_stages=2, num_warps=8, waves_per_eu=0,
+        kpack=1, mfma_instr_size=16,
+        total_tiles=256, n_cu=304,
+        bytes_per_elem=2, arch="gfx942",
+    )
+    assert out.get("lds_blocked") is True
+
+
+def test_l4_lds_budget_overridable_per_arch():
+    """L4: arch-specific budgets can be set/queried."""
+    set_arch_lds_budget("gfx-test-arch", 32768)
+    assert lds_budget_for("gfx-test-arch") == 32768
+    # Default budget kicks in for unknown arch (default is non-zero).
+    assert lds_budget_for("gfx-unknown-99") > 0
+
+
+# ---------------------------------------------------------------------------
+# L5 -- composability guard (refuses under work_stealing by default)
+# ---------------------------------------------------------------------------
+def test_l5_composability_guard_refuses_under_work_stealing():
+    g = _make_gate()
+    OverrideRegistry.register(g)
+    os.environ["TB_TEST_ENABLE"] = "1"
+    out = apply_override_in_dispatcher(
+        2048, 2048, 4096, torch.float16,
+        block_m=128, block_n=128, block_k=64,
+        num_stages=4, num_warps=8, waves_per_eu=0,
+        kpack=1, mfma_instr_size=16,
+        total_tiles=256, n_cu=304,
+        work_stealing=True,
+    )
+    assert out == {}, "L5: work_stealing must suppress the gate"
+
+
+def test_l5_composability_guard_fires_when_no_work_stealing():
+    g = _make_gate()
+    OverrideRegistry.register(g)
+    os.environ["TB_TEST_ENABLE"] = "1"
+    out = apply_override_in_dispatcher(
+        2048, 2048, 4096, torch.float16,
+        block_m=128, block_n=128, block_k=64,
+        num_stages=4, num_warps=8, waves_per_eu=0,
+        kpack=1, mfma_instr_size=16,
+        total_tiles=256, n_cu=304,
+        work_stealing=False,
+    )
+    assert out.get("fired_ticket") == "K-TEST"
+
+
+def test_l5_composability_guard_can_be_overridden_explicitly():
+    """L5: gate authors can opt in to work-stealing-safe behavior with a
+    custom composability_guard (e.g. lambda ws: True)."""
+    g = GuardedOverride(
+        ticket="K-TEST", env_var="TB_TEST_ENABLE",
+        cohort_keys=[(2048, 2048, 4096, torch.float16)],
+        override_fn=lambda M, N, K, dt: {"num_stages": 2},
+        composability_guard=lambda ws: True,
+    )
+    OverrideRegistry.register(g)
+    os.environ["TB_TEST_ENABLE"] = "1"
+    out = apply_override_in_dispatcher(
+        2048, 2048, 4096, torch.float16,
+        block_m=128, block_n=128, block_k=64,
+        num_stages=4, num_warps=8, waves_per_eu=0,
+        kpack=1, mfma_instr_size=16,
+        total_tiles=256, n_cu=304,
+        work_stealing=True,
+    )
+    assert out.get("fired_ticket") == "K-TEST"
+
+
+# ---------------------------------------------------------------------------
+# L6 -- routing-trace counters (per-key + thread-safe)
+# ---------------------------------------------------------------------------
+def test_l6_routing_counters_track_fires_and_nonfires():
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    g.lookup(2048, 2048, 4096, torch.float16)  # fire
+    g.lookup(2048, 2048, 4096, torch.float16)  # fire
+    g.lookup(2048, 2048, 9999, torch.float16)  # nonfire (OOC)
+    g.lookup(2048, 2048, 4096, torch.float64)  # nonfire (dtype out of allowlist)
+    snap = g.routing_snapshot()
+    assert snap["fire_total"] == 2
+    assert snap["nonfire_total"] == 2
+    assert snap["per_key_fires"][(2048, 2048, 4096, torch.float16)] == 2
+
+
+def test_l6_routing_counters_thread_safe():
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    N = 200
+
+    def worker():
+        for _ in range(N):
+            g.lookup(2048, 2048, 4096, torch.float16)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+    snap = g.routing_snapshot()
+    assert snap["fire_total"] == 8 * N
+
+
+def test_l6_routing_counters_resettable():
+    g = _make_gate()
+    os.environ["TB_TEST_ENABLE"] = "1"
+    g.lookup(2048, 2048, 4096, torch.float16)
+    g.reset_counters()
+    assert g.routing_snapshot()["fire_total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# L7 -- cohort-size cap (K-883 §5 C3)
+# ---------------------------------------------------------------------------
+def test_l7_cohort_size_cap_rejects_oversize_table():
+    keys = [(i, 2048, 4096, torch.float16) for i in range(40)]
+    with pytest.raises(ValueError, match="cohort_size"):
+        GuardedOverride(
+            ticket="K-TEST", env_var="TB_TEST_ENABLE",
+            cohort_keys=keys, override_fn=lambda *a: {},
+        )
+
+
+def test_l7_cohort_size_cap_can_be_raised_with_explicit_justification():
+    """L7: authors can raise the cap, but must do so explicitly."""
+    keys = [(i, 2048, 4096, torch.float16) for i in range(40)]
+    g = GuardedOverride(
+        ticket="K-TEST", env_var="TB_TEST_ENABLE",
+        cohort_keys=keys, override_fn=lambda *a: {}, cohort_size_cap=50,
+    )
+    assert len(g.cohort_keys) == 40
+
+
+# ---------------------------------------------------------------------------
+# L8 -- registry idempotence + R1 dispatch-order routing
+# ---------------------------------------------------------------------------
+def test_l8_registry_refuses_duplicate_ticket():
+    g1 = _make_gate(ticket="K-TEST")
+    g2 = _make_gate(ticket="K-TEST")
+    a = OverrideRegistry.register(g1)
+    b = OverrideRegistry.register(g2)
+    # idempotent: second register returns the original.
+    assert a is g1
+    assert b is g1
+
+
+def test_l8_r1_dispatch_order_first_routing():
+    """R1: registry returns the first matching gate in registration order."""
+    g1 = _make_gate(ticket="K-TEST", env="TB_TEST_ENABLE",
+                    keys=[(2048, 2048, 4096, torch.float16)])
+    g1.override_fn = lambda M, N, K, dt: {"num_stages": 2}
+    g2 = _make_gate(ticket="K-TEST-2", env="TB_TEST_2_ENABLE",
+                    keys=[(2048, 2048, 4096, torch.float16)])
+    g2.override_fn = lambda M, N, K, dt: {"num_stages": 4}
+    OverrideRegistry.register(g1)
+    OverrideRegistry.register(g2)
+    os.environ["TB_TEST_ENABLE"] = "1"
+    os.environ["TB_TEST_2_ENABLE"] = "1"
+    hit = OverrideRegistry.apply(2048, 2048, 4096, torch.float16)
+    assert hit is not None
+    gate, payload = hit
+    assert gate.ticket == "K-TEST"
+    assert payload["num_stages"] == 2  # g1 wins, NOT g2
+
+
+# ---------------------------------------------------------------------------
+# L9 -- paired CI (paired_t, n>=30 paired samples, Student-t)
+# ---------------------------------------------------------------------------
+def test_l9_t_crit_95_returns_at_least_normal_value():
+    """L9: 95% CI multiplier is monotonic and converges to 1.96 for large df."""
+    assert _t_crit_95(1) > _t_crit_95(30)
+    assert _t_crit_95(30) >= 1.96
+    assert _t_crit_95(120) >= 1.96
+    # df<=0 returns NaN (no CI possible).
+    assert math.isnan(_t_crit_95(0))
+
+
+def test_l9_paired_delta_zero_when_inputs_equal():
+    on  = [1.0] * 32
+    off = [1.0] * 32
+    mean, lo, hi, n = _paired_delta_with_ci(on, off)
+    assert n == 32
+    assert mean == 0.0
+    # CI must straddle 0 for identical inputs (sd=0 -> CI=[0,0]).
+    assert lo <= 0.0 <= hi
+
+
+def test_l9_paired_delta_positive_when_on_faster():
+    """On a clean +10% speedup signal the CI must exclude 0 with n=30."""
+    on  = [0.90] * 30
+    off = [1.00] * 30
+    mean, lo, hi, n = _paired_delta_with_ci(on, off)
+    assert n == 30
+    assert mean == pytest.approx(10.0, abs=1e-6)
+    # No variance -> CI collapses to mean.
+    assert lo == pytest.approx(10.0, abs=1e-6)
+    assert hi == pytest.approx(10.0, abs=1e-6)
+
+
+def test_l9_paired_delta_ci_excludes_zero_when_signal_clear_of_noise():
+    """A real +5% signal under Gaussian noise must exclude 0 from the CI."""
+    import random
+    random.seed(0)
+    off = [1.0 + random.gauss(0, 0.005) for _ in range(50)]
+    on  = [v * 0.95 + random.gauss(0, 0.005) for v in off]
+    mean, lo, hi, n = _paired_delta_with_ci(on, off)
+    assert n == 50
+    assert mean > 4.0      # ~5% speedup
+    assert lo > 0.0        # CI strictly positive: signal beats noise
+    assert hi > mean
+
+
+# ---------------------------------------------------------------------------
+# Synthetic LAND-path integration test (proves the harness can APPROVE)
+# ---------------------------------------------------------------------------
+def _synthetic_cell(M, K, dtype, in_cohort, off_ms, on_ms, ref_ms,
+                    on_vs_off_pct, on_vs_off_ci=(None, None), fired=False,
+                    classification=None):
+    n = 30
+    if classification is None:
+        classification = "SPEEDUP" if on_vs_off_pct >= 5.0 else (
+            "REGRESS" if on_vs_off_pct <= -5.0 else "IN_BAND")
+    lo, hi = on_vs_off_ci if on_vs_off_ci != (None, None) else (
+        on_vs_off_pct - 0.5, on_vs_off_pct + 0.5)
+    return CellResult(
+        M=M, N=2048, K=K, dtype=str(dtype).replace("torch.", ""), batch=1,
+        in_cohort=in_cohort,
+        ms_off_med=off_ms, ms_on_med=on_ms, ms_ref_med=ref_ms,
+        ms_off_raw=[off_ms]*n, ms_on_raw=[on_ms]*n, ms_ref_raw=[ref_ms]*n,
+        n_paired=n,
+        delta_pct_on_vs_off=on_vs_off_pct,
+        delta_pct_on_vs_off_ci_lo=lo,
+        delta_pct_on_vs_off_ci_hi=hi,
+        delta_pct_on_vs_ref=0.0,
+        delta_pct_on_vs_ref_ci_lo=-1.0,
+        delta_pct_on_vs_ref_ci_hi=1.0,
+        paired_spread_pct=2.0,
+        classification=classification,
+        fired=fired,
+    )
+
+
+def test_synthetic_land_path_yields_land_verdict():
+    """A synthetic override that delivers +10% in-cohort with no OOC bleed
+    and a clean routing trace MUST receive a LAND verdict.  This proves the
+    harness can actually approve a valid override (not just a reject-only
+    machine)."""
+    keys = [(2048, 2048, 4096, torch.float16),
+            (2048, 2048, 8192, torch.float16)]
+    gate = GuardedOverride(
+        ticket="K-TEST-LAND", env_var="TB_TEST_LAND_ENABLE",
+        cohort_keys=keys,
+        override_fn=lambda *a: {"num_stages": 2},
+    )
+    # In-cohort: clean +10% paired delta with CI excluding 0 -> SPEEDUP
+    in_c = [
+        _synthetic_cell(2048, 4096, torch.float16, True,
+                        off_ms=1.000, on_ms=0.900, ref_ms=1.000,
+                        on_vs_off_pct=10.0, on_vs_off_ci=(8.0, 12.0),
+                        fired=True, classification="SPEEDUP"),
+        _synthetic_cell(2048, 8192, torch.float16, True,
+                        off_ms=2.000, on_ms=1.800, ref_ms=2.000,
+                        on_vs_off_pct=10.0, on_vs_off_ci=(8.0, 12.0),
+                        fired=True, classification="SPEEDUP"),
+    ]
+    # OOC: in-band only (no regress). Routing didn't fire.
+    ooc = [
+        _synthetic_cell(512, 512, torch.float16, False,
+                        off_ms=1.000, on_ms=0.999, ref_ms=1.000,
+                        on_vs_off_pct=0.1, fired=False,
+                        classification="IN_BAND"),
+        _synthetic_cell(4096, 4096, torch.float16, False,
+                        off_ms=1.000, on_ms=1.001, ref_ms=1.000,
+                        on_vs_off_pct=-0.1, fired=False,
+                        classification="IN_BAND"),
+    ]
+    snap = {
+        "ticket": "K-TEST-LAND",
+        "fire_total": 2, "nonfire_total": 2,
+        "per_key_fires": {keys[0]: 1, keys[1]: 1},
+    }
+    verdict = _compute_verdict(gate, in_c + ooc, snap)
+    assert verdict.land, verdict.report
+    assert verdict.routing_n_intended_fires == 2
+    assert verdict.routing_n_ooc_fires == 0
+    assert verdict.in_cohort_geomean_speedup >= 1.05
+
+
+def test_synthetic_no_land_path_yields_no_land_verdict_on_ooc_regress():
+    """An override that delivers in-cohort speedup but causes a real OOC
+    regression (CI upper bound below 0) MUST be rejected."""
+    keys = [(2048, 2048, 4096, torch.float16)]
+    gate = GuardedOverride(
+        ticket="K-TEST-LAND", env_var="TB_TEST_LAND_ENABLE",
+        cohort_keys=keys, override_fn=lambda *a: {"num_stages": 2},
+    )
+    in_c = [_synthetic_cell(2048, 4096, torch.float16, True,
+                            off_ms=1.0, on_ms=0.9, ref_ms=1.0,
+                            on_vs_off_pct=10.0, on_vs_off_ci=(8.0, 12.0),
+                            fired=True, classification="SPEEDUP")]
+    # OOC cell with REAL regression: CI strictly below 0
+    ooc = [_synthetic_cell(512, 512, torch.float16, False,
+                           off_ms=1.0, on_ms=1.10, ref_ms=1.0,
+                           on_vs_off_pct=-10.0, on_vs_off_ci=(-12.0, -8.0),
+                           fired=False, classification="REGRESS")]
+    snap = {"ticket": "K-TEST-LAND", "fire_total": 1, "nonfire_total": 1,
+            "per_key_fires": {keys[0]: 1}}
+    verdict = _compute_verdict(gate, in_c + ooc, snap)
+    assert not verdict.land
+    assert verdict.ooc_n_regress == 1
+
+
+def test_synthetic_no_land_with_single_trial_noise_is_not_classified_regress():
+    """K-901 reviewer requirement: a 'REGRESS' classification whose 95% CI
+    upper bound straddles 0 is NOISE, not a true regression -- the verdict
+    must NOT count it as a regressor (so cells like K-882's -3.90% point are
+    statistically defensible, not single-trial noise)."""
+    keys = [(2048, 2048, 4096, torch.float16)]
+    gate = GuardedOverride(
+        ticket="K-TEST-LAND", env_var="TB_TEST_LAND_ENABLE",
+        cohort_keys=keys, override_fn=lambda *a: {"num_stages": 2},
+    )
+    in_c = [_synthetic_cell(2048, 4096, torch.float16, True,
+                            off_ms=1.0, on_ms=0.9, ref_ms=1.0,
+                            on_vs_off_pct=10.0, on_vs_off_ci=(8.0, 12.0),
+                            fired=True, classification="SPEEDUP")]
+    # Classifier flagged REGRESS but CI upper bound is positive -> noise.
+    ooc = [_synthetic_cell(512, 512, torch.float16, False,
+                           off_ms=1.0, on_ms=1.05, ref_ms=1.0,
+                           on_vs_off_pct=-5.0, on_vs_off_ci=(-12.0, +2.0),
+                           fired=False, classification="REGRESS")]
+    snap = {"ticket": "K-TEST-LAND", "fire_total": 1, "nonfire_total": 1,
+            "per_key_fires": {keys[0]: 1}}
+    verdict = _compute_verdict(gate, in_c + ooc, snap)
+    # Verdict must NOT count this as a regressor.
+    assert verdict.ooc_n_regress == 0
+
+
+# ---------------------------------------------------------------------------
+# K-882 fixture (regression test for the harness reject-path)
+# ---------------------------------------------------------------------------
+def test_k882_fixture_strict_keys_only():
+    """K-882 fixture: strict-equality cohort -- adjacent shapes must not fire."""
+    g = _k882_fixture()
+    OverrideRegistry.register(g)
+    os.environ["TB_K882_ENABLE"] = "1"
+    assert g.lookup(2048, 2048, 4096, torch.float16) is not None
+    assert g.lookup(2048, 2048, 5000, torch.float16) is None
+    assert g.lookup(2048, 2048, 4096, torch.float32) is None  # dtype guard
+
+
+def test_k882_fixture_off_by_default():
+    """K-882 fixture is OFF unless TB_K882_ENABLE is set."""
+    g = _k882_fixture()
+    os.environ.pop("TB_K882_ENABLE", None)
+    assert g.lookup(2048, 2048, 4096, torch.float16) is None
+
+
+def test_k882_not_in_production_registry():
+    """K-882 must NOT auto-register on production import (it's a fixture)."""
+    # Re-import to be sure overrides/__init__ is not pulled in.
+    import importlib
+    import tritonblas
+    importlib.reload(tritonblas)
+    tickets = [g.ticket for g in OverrideRegistry.all()]
+    assert "K-882" not in tickets, (
+        f"K-882 leaked into production registry: {tickets}.  "
+        f"It must live in tests/ only (NO-LAND verdict)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sanity: classifier helper
+# ---------------------------------------------------------------------------
+def test_classify_delta_noise_band():
+    # spread/2 = 1pp, but noise floor is 2pp -> band = 2pp.
+    assert _classify_delta(+1.5, paired_spread_pct=2.0) == "IN_BAND"
+    assert _classify_delta(+3.0, paired_spread_pct=2.0) == "SPEEDUP"
+    assert _classify_delta(-3.0, paired_spread_pct=2.0) == "REGRESS"
+    # Wide spread expands the noise band.
+    assert _classify_delta(+3.0, paired_spread_pct=10.0) == "IN_BAND"

--- a/tests/test_k1367_p13_skinny_n128.py
+++ b/tests/test_k1367_p13_skinny_n128.py
@@ -1,0 +1,248 @@
+"""K-1367 P13 + K-1361 P12 pin tests — torch-free.
+
+Validates the K-1379 productionisation of the K-1367 RETRY-winning 18-cell
+`_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18` frozenset stacked as the
+7th-position envelope on top of the K-1361 P12 55-cell baseline.
+
+These tests pin:
+  * cardinality of the new frozensets (P12=4, P13=18, total post-P13 = 73)
+  * exact membership of the K-1367 P13 18 cells (M ∈ {2048, 4096, 8192} ×
+    N=128 × K ∈ {4096, 8192, 16384} × {bf16, fp16})
+  * exact membership of the K-1361 P12 4 cells (M=N=K ∈ {2048, 4096} ×
+    {bf16, fp16})
+  * cross-frozenset disjointness between P12 / P13 / P8 / K971_ROUTE_TABLE
+  * dispatch precedence: dtype-mismatch / streamk / work-stealing carve-outs
+    short-circuit ahead of every strict-equality table
+
+Imports the actual shipped predicate module (`_route_predicate`) so the real
+runtime path is exercised; no exec/string-parse copies.
+"""
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from tritonblas._route_predicate import (
+    K971_ROUTE_TABLE,
+    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
+    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18,
+    _P8_MFMA_ISSUE_STALL_ROUTEOUT,
+    _k1361_p12_square_mid_routeout,
+    _k1367_p13_skinny_n128_kcomplement_routeout,
+    k971_route_decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# Cardinality pins.  Any deviation indicates an authoring typo against the
+# K-1308 / K-1227 / K-1345 / K-1367 bucket-rule resolution.
+# ---------------------------------------------------------------------------
+def test_p12_square_mid_cardinality_4():
+    assert len(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4) == 4
+
+
+def test_p13_skinny_n128_kcomplement_cardinality_18():
+    assert len(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18) == 18
+
+
+def test_envelope_total_post_p13_is_73():
+    """P8 (51) + K-1361 P12 (4) + K-1367 P13 (18) = 73 strict-equality cells.
+
+    K971_ROUTE_TABLE (12 cells: K-905/K-971 anchors + K-1335 longK_smallSquare)
+    is the 5th-position envelope; counted separately from the P8/P12/P13
+    7th-position chain because it gates on the LDS-bank-conflict mechanism
+    rather than the MFMA-issue-stall / square_mid / skinny_N128 mechanisms.
+    """
+    total = (
+        len(_P8_MFMA_ISSUE_STALL_ROUTEOUT)
+        + len(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
+        + len(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18)
+    )
+    assert total == 73, (
+        f"Expected 51 + 4 + 18 = 73 strict-equality cells across P8/P12/P13; "
+        f"got {total}.  Check that no frozenset has been mutated.")
+
+
+# ---------------------------------------------------------------------------
+# Exact-membership pins.  These deliberately enumerate every key so any
+# accidental drop / typo / re-ordering is caught at CI time.
+# ---------------------------------------------------------------------------
+def _expected_p13_18_cells():
+    """Construct the K-1367 P13 18-cell expected set from the bucket rule."""
+    return frozenset({
+        (M, 128, K, dt)
+        for M in (2048, 4096, 8192)
+        for K in (4096, 8192, 16384)
+        for dt in ("torch.bfloat16", "torch.float16")
+    })
+
+
+def _expected_p12_4_cells():
+    """Construct the K-1361 P12 4-cell expected set from the bucket rule."""
+    return frozenset({
+        (S, S, S, dt)
+        for S in (2048, 4096)
+        for dt in ("torch.bfloat16", "torch.float16")
+    })
+
+
+def test_p13_membership_exactly_18_kcomplement_cells():
+    expected = _expected_p13_18_cells()
+    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 == expected, (
+        "K-1367 P13 frozenset diverges from the K-COMPLEMENT bucket rule: "
+        "M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,8192,16384} × {bf16,fp16}.\n"
+        f"  missing : {sorted(expected - _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18)}\n"
+        f"  unknown : {sorted(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 - expected)}")
+
+
+def test_p12_membership_exactly_4_diagonal_cells():
+    expected = _expected_p12_4_cells()
+    assert _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4 == expected, (
+        "K-1361 P12 frozenset diverges from the K-1345 RANKED_BUCKETS_v2 "
+        "diagonal-only authoritative rule: M=N=K ∈ {2048,4096} × {bf16,fp16}.\n"
+        f"  missing : {sorted(expected - _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)}\n"
+        f"  unknown : {sorted(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4 - expected)}")
+
+
+# ---------------------------------------------------------------------------
+# Disjointness pins.  Cheap insurance per
+# R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.
+# ---------------------------------------------------------------------------
+def test_p13_disjoint_from_p8():
+    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(
+        _P8_MFMA_ISSUE_STALL_ROUTEOUT)
+
+
+def test_p13_disjoint_from_k971_route_table():
+    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(
+        K971_ROUTE_TABLE)
+
+
+def test_p13_disjoint_from_p12():
+    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(
+        _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
+
+
+def test_p12_disjoint_from_p8():
+    assert _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4.isdisjoint(
+        _P8_MFMA_ISSUE_STALL_ROUTEOUT)
+
+
+def test_p12_disjoint_from_k971_route_table():
+    assert _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4.isdisjoint(K971_ROUTE_TABLE)
+
+
+# ---------------------------------------------------------------------------
+# Per-cell predicate behaviour.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_p13_18_cells()))
+def test_p13_predicate_admits_every_kcomplement_cell(M, N, K, dtype):
+    assert _k1367_p13_skinny_n128_kcomplement_routeout(M, N, K, dtype) is True
+
+
+@pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_p12_4_cells()))
+def test_p12_predicate_admits_every_diagonal_cell(M, N, K, dtype):
+    assert _k1361_p12_square_mid_routeout(M, N, K, dtype) is True
+
+
+# ---------------------------------------------------------------------------
+# Negative-control pins (cells immediately adjacent to the cohort that MUST
+# NOT fire — guards against axis over-relaxation).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("M,N,K,dtype", [
+    # K below the K=4096 wrapper-overhead floor (K-1227 still owns these)
+    (2048, 128, 2048, "torch.bfloat16"),
+    (4096, 128, 2048, "torch.float16"),
+    # M below the M=2048 cohort floor
+    (1024, 128, 4096, "torch.bfloat16"),
+    (1024, 128, 8192, "torch.float16"),
+    # M above the M=8192 cohort ceiling
+    (16384, 128, 4096, "torch.bfloat16"),
+    # N off the N=128 column-narrow regime
+    (2048, 64, 4096, "torch.bfloat16"),
+    (2048, 256, 4096, "torch.bfloat16"),
+    # K above the K=16384 cohort ceiling
+    (2048, 128, 32768, "torch.bfloat16"),
+    # dtype outside the bf16/fp16 K-913 §3 invariance class
+    (2048, 128, 4096, "torch.float32"),
+])
+def test_p13_predicate_rejects_axis_perturbations(M, N, K, dtype):
+    assert _k1367_p13_skinny_n128_kcomplement_routeout(M, N, K, dtype) is False
+
+
+@pytest.mark.parametrize("M,N,K,dtype", [
+    # off-diagonal cells (K-1345 RANKED_BUCKETS_v2 routes these to K-1313 WIDE)
+    (2048, 2048, 4096, "torch.bfloat16"),  # also a K-1335 LDS-BC anchor
+    (4096, 4096, 2048, "torch.bfloat16"),
+    (2048, 4096, 4096, "torch.bfloat16"),
+    # 8192³ — DROP_HBM_BOUND per K-1308 F4 / K-879 N2a
+    (8192, 8192, 8192, "torch.bfloat16"),
+    # dtype outside K-913 §3 invariance class
+    (2048, 2048, 2048, "torch.float32"),
+])
+def test_p12_predicate_rejects_off_diagonal_and_dropped_cells(M, N, K, dtype):
+    assert _k1361_p12_square_mid_routeout(M, N, K, dtype) is False
+
+
+# ---------------------------------------------------------------------------
+# Full dispatch decision — exercises the 7-position precedence chain.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_p13_18_cells()))
+def test_full_dispatch_routes_every_p13_cell_to_hbl(M, N, K, dtype):
+    """K-1367 P13 admits MUST route to hipBLASLt under default carve-out
+    settings (no streamk, no work-stealing, matched dtype).
+    """
+    assert k971_route_decision(M, N, K, dtype, dtype, False, False) is True
+
+
+@pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_p12_4_cells()))
+def test_full_dispatch_routes_every_p12_cell_to_hbl(M, N, K, dtype):
+    assert k971_route_decision(M, N, K, dtype, dtype, False, False) is True
+
+
+# ---------------------------------------------------------------------------
+# Carve-out short-circuits — a P13 admit cell must NOT route to hipBLASLt
+# when streamk / work-stealing / mismatched-dtype is requested.  This is
+# load-bearing for the matmul.py kwarg surface (PR description Test Plan).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("enable_streamk,work_stealing,b_dtype", [
+    (True,  False, "torch.bfloat16"),  # streamk requested
+    (False, True,  "torch.bfloat16"),  # work-stealing requested
+    (False, False, "torch.float16"),   # mixed dtype (a bf16, b fp16)
+])
+def test_p13_admit_cell_carveout_short_circuits(enable_streamk, work_stealing, b_dtype):
+    # Pick a known P13 admit cell.
+    a_dtype = "torch.bfloat16"
+    M, N, K = 4096, 128, 8192
+    assert (M, N, K, a_dtype) in _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18
+    routed = k971_route_decision(M, N, K, a_dtype, b_dtype,
+                                 enable_streamk, work_stealing)
+    assert routed is False, (
+        f"P13 admit cell ({M},{N},{K},{a_dtype}) must NOT route to hipBLASLt "
+        f"when carve-out applies (streamk={enable_streamk}, "
+        f"work_stealing={work_stealing}, b_dtype={b_dtype}); short-circuit "
+        f"in _k971_route_to_hbl is load-bearing.")
+
+
+# ---------------------------------------------------------------------------
+# Regression firewall — every cell in the K-1335 / K-1322 / K-905 prior
+# envelopes still routes to hipBLASLt after the P12 + P13 stack.
+# Per R-1322.STRICT-EQUALITY-UNION-PRESERVES-PRIOR-ADMIT-INVARIANCE; the new
+# envelopes are unioned via short-circuit `if ... return True` so prior
+# admits cannot be removed by the diff.
+# ---------------------------------------------------------------------------
+def test_no_regression_on_k971_route_table_prior_admits():
+    for (M, N, K, dt) in K971_ROUTE_TABLE:
+        assert k971_route_decision(M, N, K, dt, dt, False, False) is True, (
+            f"K971_ROUTE_TABLE prior admit ({M},{N},{K},{dt}) was lost after "
+            f"P12 + P13 stack; the P13 productionisation must preserve every "
+            f"prior 5th-position envelope cell (regression firewall).")
+
+
+def test_no_regression_on_p8_prior_admits():
+    for (M, N, K, dt) in _P8_MFMA_ISSUE_STALL_ROUTEOUT:
+        assert k971_route_decision(M, N, K, dt, dt, False, False) is True, (
+            f"P8 prior admit ({M},{N},{K},{dt}) was lost after P12 + P13 "
+            f"stack; the P13 productionisation must preserve every prior "
+            f"P8 sub-frozenset cell (regression firewall).")

--- a/tests/test_k1367_p13_skinny_n128.py
+++ b/tests/test_k1367_p13_skinny_n128.py
@@ -1,7 +1,7 @@
 """K-1367 P13 + K-1361 P12 pin tests — torch-free.
 
 Validates the K-1379 productionisation of the K-1367 RETRY-winning 18-cell
-`_K1367_P13_SKINNY_N128_ROUTEOUT_18` frozenset stacked as the
+`_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18` frozenset stacked as the
 7th-position envelope on top of the K-1361 P12 55-cell baseline.
 
 These tests pin:
@@ -26,7 +26,7 @@ import pytest
 from tritonblas._route_predicate import (
     K971_ROUTE_TABLE,
     _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
-    _K1367_P13_SKINNY_N128_ROUTEOUT_18,
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
     _P8_MFMA_ISSUE_STALL_ROUTEOUT,
     _k1361_p12_square_mid_routeout,
     _k1367_p13_skinny_n128_routeout,
@@ -43,7 +43,7 @@ def test_p12_square_mid_cardinality_4():
 
 
 def test_p13_skinny_n128_kcomplement_cardinality_18():
-    assert len(_K1367_P13_SKINNY_N128_ROUTEOUT_18) == 18
+    assert len(_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18) == 18
 
 
 def test_envelope_total_post_p13_is_73():
@@ -57,7 +57,7 @@ def test_envelope_total_post_p13_is_73():
     total = (
         len(_P8_MFMA_ISSUE_STALL_ROUTEOUT)
         + len(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
-        + len(_K1367_P13_SKINNY_N128_ROUTEOUT_18)
+        + len(_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18)
     )
     assert total == 73, (
         f"Expected 51 + 4 + 18 = 73 strict-equality cells across P8/P12/P13; "
@@ -89,11 +89,11 @@ def _expected_p12_4_cells():
 
 def test_p13_membership_exactly_18_kcomplement_cells():
     expected = _expected_p13_18_cells()
-    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18 == expected, (
+    assert _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 == expected, (
         "K-1367 P13 frozenset diverges from the K-COMPLEMENT bucket rule: "
         "M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,8192,16384} × {bf16,fp16}.\n"
-        f"  missing : {sorted(expected - _K1367_P13_SKINNY_N128_ROUTEOUT_18)}\n"
-        f"  unknown : {sorted(_K1367_P13_SKINNY_N128_ROUTEOUT_18 - expected)}")
+        f"  missing : {sorted(expected - _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18)}\n"
+        f"  unknown : {sorted(_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 - expected)}")
 
 
 def test_p12_membership_exactly_4_diagonal_cells():
@@ -110,17 +110,17 @@ def test_p12_membership_exactly_4_diagonal_cells():
 # R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.
 # ---------------------------------------------------------------------------
 def test_p13_disjoint_from_p8():
-    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(
+    assert _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18.isdisjoint(
         _P8_MFMA_ISSUE_STALL_ROUTEOUT)
 
 
 def test_p13_disjoint_from_k971_route_table():
-    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(
+    assert _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18.isdisjoint(
         K971_ROUTE_TABLE)
 
 
 def test_p13_disjoint_from_p12():
-    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(
+    assert _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18.isdisjoint(
         _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
 
 
@@ -215,7 +215,7 @@ def test_p13_admit_cell_carveout_short_circuits(enable_streamk, work_stealing, b
     # Pick a known P13 admit cell.
     a_dtype = "torch.bfloat16"
     M, N, K = 4096, 128, 8192
-    assert (M, N, K, a_dtype) in _K1367_P13_SKINNY_N128_ROUTEOUT_18
+    assert (M, N, K, a_dtype) in _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18
     routed = k971_route_decision(M, N, K, a_dtype, b_dtype,
                                  enable_streamk, work_stealing)
     assert routed is False, (
@@ -246,3 +246,51 @@ def test_no_regression_on_p8_prior_admits():
             f"P8 prior admit ({M},{N},{K},{dt}) was lost after P12 + P13 "
             f"stack; the P13 productionisation must preserve every prior "
             f"P8 sub-frozenset cell (regression firewall).")
+
+
+# ---------------------------------------------------------------------------
+# K-1389 boundary controls — adjacent non-admitted cells in the
+# skinny_N128 K-COMPLEMENT region MUST still route to triton (i.e.
+# k971_route_decision == False), proving the strict-equality frozenset
+# does NOT spill into neighbouring shapes.  Reviewer-mandated negative
+# controls per the K-1389 brief.
+# ---------------------------------------------------------------------------
+_K1389_BOUNDARY_TRITON_CELLS = [
+    # M=1024 — directly below the M=2048 cohort floor; same N=128, same K
+    # range as P13 admits.  Must route to triton: M=1024 is occupancy-bound
+    # at N=128 and the wrapper-overhead/K-time crossover does not flip yet.
+    (1024,   128,  4096, "torch.bfloat16"),
+    (1024,   128,  4096, "torch.float16"),
+    (1024,   128,  8192, "torch.bfloat16"),
+    # M=16384 — directly above the M=8192 cohort ceiling; same N=128, same
+    # K range.  Must route to triton: persistent_matmul scales linearly
+    # with M and the K-913 LDS-BC discriminator inverts past M=8192 because
+    # the per-CU wave footprint amortises the bank conflicts.
+    (16384,  128,  4096, "torch.bfloat16"),
+    (16384,  128,  8192, "torch.bfloat16"),
+    (16384,  128, 16384, "torch.bfloat16"),
+]
+
+
+@pytest.mark.parametrize("M,N,K,dtype", _K1389_BOUNDARY_TRITON_CELLS)
+def test_k1389_p13_does_not_spill_into_adjacent_n128_kcompl_cells(M, N, K, dtype):
+    """K-1389 negative control: adjacent non-admitted cells (M=1024 N=128,
+    M=16384 N=128) MUST NOT be admitted by the P13 strict-equality
+    frozenset _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 nor by the P13
+    per-cell predicate ``_k1367_p13_skinny_n128_routeout``.
+
+    NOTE: end-to-end ``k971_route_decision`` may still return True on
+    these cells via the EARLIER R-K979 P5 closed-form structural
+    pathology predicate (which routes large-K narrow-N shapes to
+    hipBLASLt as a separate mechanism).  That is intentional and out of
+    scope for K-1389 — K-1389 is a strict-equality additive extension to
+    P13, not a re-tuning of P5.  This test isolates the P13-specific
+    no-spill claim from the end-to-end routing decision.
+    """
+    assert (M, N, K, dtype) not in _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18, (
+        f"Boundary control cell ({M},{N},{K},{dtype}) is in the P13 admit "
+        f"frozenset; the K-1389 boundary table is mis-specified.")
+    assert _k1367_p13_skinny_n128_routeout(M, N, K, dtype) is False, (
+        f"K-1389 adjacent boundary cell ({M},{N},{K},{dtype}) was admitted "
+        f"by the P13 per-cell predicate; strict-equality frozenset must NOT "
+        f"spill into adjacent M={M} cells.")

--- a/tests/test_k1367_p13_skinny_n128.py
+++ b/tests/test_k1367_p13_skinny_n128.py
@@ -1,7 +1,7 @@
 """K-1367 P13 + K-1361 P12 pin tests — torch-free.
 
 Validates the K-1379 productionisation of the K-1367 RETRY-winning 18-cell
-`_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18` frozenset stacked as the
+`_K1367_P13_SKINNY_N128_ROUTEOUT_18` frozenset stacked as the
 7th-position envelope on top of the K-1361 P12 55-cell baseline.
 
 These tests pin:
@@ -26,10 +26,10 @@ import pytest
 from tritonblas._route_predicate import (
     K971_ROUTE_TABLE,
     _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
-    _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18,
+    _K1367_P13_SKINNY_N128_ROUTEOUT_18,
     _P8_MFMA_ISSUE_STALL_ROUTEOUT,
     _k1361_p12_square_mid_routeout,
-    _k1367_p13_skinny_n128_kcomplement_routeout,
+    _k1367_p13_skinny_n128_routeout,
     k971_route_decision,
 )
 
@@ -43,7 +43,7 @@ def test_p12_square_mid_cardinality_4():
 
 
 def test_p13_skinny_n128_kcomplement_cardinality_18():
-    assert len(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18) == 18
+    assert len(_K1367_P13_SKINNY_N128_ROUTEOUT_18) == 18
 
 
 def test_envelope_total_post_p13_is_73():
@@ -57,7 +57,7 @@ def test_envelope_total_post_p13_is_73():
     total = (
         len(_P8_MFMA_ISSUE_STALL_ROUTEOUT)
         + len(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
-        + len(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18)
+        + len(_K1367_P13_SKINNY_N128_ROUTEOUT_18)
     )
     assert total == 73, (
         f"Expected 51 + 4 + 18 = 73 strict-equality cells across P8/P12/P13; "
@@ -89,11 +89,11 @@ def _expected_p12_4_cells():
 
 def test_p13_membership_exactly_18_kcomplement_cells():
     expected = _expected_p13_18_cells()
-    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 == expected, (
+    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18 == expected, (
         "K-1367 P13 frozenset diverges from the K-COMPLEMENT bucket rule: "
         "M ∈ {2048,4096,8192} × N=128 × K ∈ {4096,8192,16384} × {bf16,fp16}.\n"
-        f"  missing : {sorted(expected - _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18)}\n"
-        f"  unknown : {sorted(_K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18 - expected)}")
+        f"  missing : {sorted(expected - _K1367_P13_SKINNY_N128_ROUTEOUT_18)}\n"
+        f"  unknown : {sorted(_K1367_P13_SKINNY_N128_ROUTEOUT_18 - expected)}")
 
 
 def test_p12_membership_exactly_4_diagonal_cells():
@@ -110,17 +110,17 @@ def test_p12_membership_exactly_4_diagonal_cells():
 # R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.
 # ---------------------------------------------------------------------------
 def test_p13_disjoint_from_p8():
-    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(
+    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(
         _P8_MFMA_ISSUE_STALL_ROUTEOUT)
 
 
 def test_p13_disjoint_from_k971_route_table():
-    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(
+    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(
         K971_ROUTE_TABLE)
 
 
 def test_p13_disjoint_from_p12():
-    assert _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18.isdisjoint(
+    assert _K1367_P13_SKINNY_N128_ROUTEOUT_18.isdisjoint(
         _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
 
 
@@ -138,7 +138,7 @@ def test_p12_disjoint_from_k971_route_table():
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_p13_18_cells()))
 def test_p13_predicate_admits_every_kcomplement_cell(M, N, K, dtype):
-    assert _k1367_p13_skinny_n128_kcomplement_routeout(M, N, K, dtype) is True
+    assert _k1367_p13_skinny_n128_routeout(M, N, K, dtype) is True
 
 
 @pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_p12_4_cells()))
@@ -168,7 +168,7 @@ def test_p12_predicate_admits_every_diagonal_cell(M, N, K, dtype):
     (2048, 128, 4096, "torch.float32"),
 ])
 def test_p13_predicate_rejects_axis_perturbations(M, N, K, dtype):
-    assert _k1367_p13_skinny_n128_kcomplement_routeout(M, N, K, dtype) is False
+    assert _k1367_p13_skinny_n128_routeout(M, N, K, dtype) is False
 
 
 @pytest.mark.parametrize("M,N,K,dtype", [
@@ -215,7 +215,7 @@ def test_p13_admit_cell_carveout_short_circuits(enable_streamk, work_stealing, b
     # Pick a known P13 admit cell.
     a_dtype = "torch.bfloat16"
     M, N, K = 4096, 128, 8192
-    assert (M, N, K, a_dtype) in _K1367_P13_SKINNY_N128_KCOMPLEMENT_ROUTEOUT_18
+    assert (M, N, K, a_dtype) in _K1367_P13_SKINNY_N128_ROUTEOUT_18
     routed = k971_route_decision(M, N, K, a_dtype, b_dtype,
                                  enable_streamk, work_stealing)
     assert routed is False, (

--- a/tests/test_k1397_p13_skinny_n256.py
+++ b/tests/test_k1397_p13_skinny_n256.py
@@ -1,259 +1,81 @@
 """K-1397 P13 skinny_N256 K-COMPLEMENT pin tests — torch-free.
 
-Validates the K-1402 productionisation of the K-1397-winning 12-cell
-`_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12` frozenset stacked as the
+Minimal pin coverage for the K-1402 productionisation of the K-1397-winning
+12-cell `_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12` frozenset stacked as the
 8th-position envelope on top of the K-1389 P13 73-cell baseline (envelope
 grows 73 → 85 cells; +12 admits).
 
-These tests pin:
-  * cardinality of the new frozenset (K-1397 P13 = 12, total post-K-1397 = 85)
-  * exact membership of the K-1397 P13 12 cells (M ∈ {2048, 4096, 8192} ×
-    N=256 × K ∈ {2048, 32768} × {bf16, fp16})
-  * cross-frozenset disjointness vs P8 / K971_ROUTE_TABLE / P12 / K-1367 P13
-  * dispatch precedence: dtype-mismatch / streamk / work-stealing carve-outs
-    short-circuit ahead of every strict-equality table
-  * boundary-perturbed cells (K=4096, K=16384, N=128, N=512) MUST NOT match
+Cardinality and cross-frozenset disjointness are already asserted at module
+load in `_route_predicate.py`; we do not duplicate those here.  The pytest
+suite focuses on the orthogonal behavioural pins:
 
-Imports the actual shipped predicate module (`_route_predicate`) so the real
-runtime path is exercised; no exec/string-parse copies.
+  * exact membership of the K-1397 P13 12 cells
+    (M ∈ {2048, 4096, 8192} × N=256 × K ∈ {2048, 32768} × {bf16, fp16})
+  * full-chain dispatch routes every admit cell to hipBLASLt (covers the
+    8th-position predicate's interaction with the precedence chain)
+  * carve-out short-circuits (streamk / work-stealing / mismatched-dtype)
+    correctly suppress the route-OUT for an admit cell
 """
 from __future__ import annotations
 
 import pytest
 
 from tritonblas._route_predicate import (
-    K971_ROUTE_TABLE,
-    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
-    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
     _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
-    _P8_MFMA_ISSUE_STALL_ROUTEOUT,
-    _k1397_p13_skinny_n256_routeout,
     k971_route_decision,
 )
 
 
-# ---------------------------------------------------------------------------
-# Cardinality pins.  Any deviation indicates an authoring typo against the
-# K-1365 post-P12 4-bucket decomposition or K-1397 K-COMPLEMENT extremes scoping.
-# ---------------------------------------------------------------------------
-def test_p13_skinny_n256_kcomplement_cardinality_12():
-    assert len(_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12) == 12
-
-
-def test_envelope_total_post_k1397_is_85():
-    """P8 (51) + K-1361 P12 (4) + K-1367 P13 (18) + K-1397 P13 (12) = 85
-    strict-equality cells.
-
-    K971_ROUTE_TABLE (12 cells: K-905/K-971 anchors + K-1335 longK_smallSquare)
-    is the 5th-position envelope; counted separately from the P8/P12/P13
-    8-position chain because it gates on the LDS-bank-conflict mechanism
-    rather than the MFMA-issue-stall / square_mid / skinny_N128 / skinny_N256
-    mechanisms.
-    """
-    total = (
-        len(_P8_MFMA_ISSUE_STALL_ROUTEOUT)
-        + len(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
-        + len(_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18)
-        + len(_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12)
-    )
-    assert total == 85, (
-        f"Expected 51 + 4 + 18 + 12 = 85 strict-equality cells across "
-        f"P8/P12/P13(N=128)/P13(N=256); got {total}.  Check that no "
-        f"frozenset has been mutated.")
-
-
-# ---------------------------------------------------------------------------
-# Exact-membership pins.
-# ---------------------------------------------------------------------------
-def _expected_k1397_12_cells():
-    """Construct the K-1397 P13 12-cell expected set from the bucket rule."""
-    return frozenset({
-        (M, 256, K, dt)
-        for M in (2048, 4096, 8192)
-        for K in (2048, 32768)
-        for dt in ("torch.bfloat16", "torch.float16")
-    })
+# Bucket rule per K-1402 success criteria: M ∈ {2048,4096,8192} ×
+# N=256 × K ∈ {2048,32768} × {bf16, fp16}.
+_EXPECTED_K1397_12_CELLS = frozenset({
+    (M, 256, K, dt)
+    for M in (2048, 4096, 8192)
+    for K in (2048, 32768)
+    for dt in ("torch.bfloat16", "torch.float16")
+})
 
 
 def test_k1397_membership_exactly_12_kcomplement_cells():
-    expected = _expected_k1397_12_cells()
-    assert _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12 == expected, (
-        "K-1397 P13 frozenset diverges from the K-COMPLEMENT bucket rule: "
-        "M ∈ {2048,4096,8192} × N=256 × K ∈ {2048,32768} × {bf16,fp16}.\n"
-        f"  missing : {sorted(expected - _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12)}\n"
-        f"  unknown : {sorted(_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12 - expected)}")
+    """The frozenset must equal the bucket rule exactly — no missing or
+    unknown cells."""
+    diff_missing = sorted(_EXPECTED_K1397_12_CELLS
+                          - _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12)
+    diff_unknown = sorted(_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12
+                          - _EXPECTED_K1397_12_CELLS)
+    assert _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12 == _EXPECTED_K1397_12_CELLS, (
+        f"K-1397 P13 frozenset diverges from the K-COMPLEMENT bucket rule "
+        f"(M ∈ {{2048,4096,8192}} × N=256 × K ∈ {{2048,32768}} × {{bf16,fp16}}).\n"
+        f"  missing : {diff_missing}\n"
+        f"  unknown : {diff_unknown}")
 
 
-# ---------------------------------------------------------------------------
-# Disjointness pins.  Cheap insurance per
-# R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.
-# ---------------------------------------------------------------------------
-def test_k1397_disjoint_from_p8():
-    assert _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12.isdisjoint(
-        _P8_MFMA_ISSUE_STALL_ROUTEOUT)
-
-
-def test_k1397_disjoint_from_k971_route_table():
-    assert _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12.isdisjoint(
-        K971_ROUTE_TABLE)
-
-
-def test_k1397_disjoint_from_p12():
-    assert _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12.isdisjoint(
-        _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
-
-
-def test_k1397_disjoint_from_k1367_p13_n128():
-    """K-1367 P13 (N=128) and K-1397 P13 (N=256) partition the skinny-N
-    column-narrow regime by N-axis; no cell may belong to both.
-    """
-    assert _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12.isdisjoint(
-        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18)
-
-
-# ---------------------------------------------------------------------------
-# Per-cell predicate behaviour — every one of the 12 admit cells routes True.
-# ---------------------------------------------------------------------------
-@pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_k1397_12_cells()))
-def test_k1397_predicate_admits_every_kcomplement_cell(M, N, K, dtype):
-    assert _k1397_p13_skinny_n256_routeout(M, N, K, dtype) is True
-
-
-# ---------------------------------------------------------------------------
-# Boundary negative-control pins (the 4 boundary perturbations spelled out
-# in K-1402's success criteria: K=4096, K=16384 — which are mid-band cells
-# already covered by tritonblas persistent_matmul, NOT to be re-routed; and
-# N=128, N=512 — adjacent column widths NOT in the K-1397 cohort).
-# ---------------------------------------------------------------------------
-@pytest.mark.parametrize("M,N,K,dtype", [
-    # K=4096 (mid-band — tritonblas persistent_matmul wins)
-    (2048, 256,  4096, "torch.bfloat16"),
-    (4096, 256,  4096, "torch.float16"),
-    # K=16384 (mid-band ceiling — tritonblas persistent_matmul wins)
-    (4096, 256, 16384, "torch.bfloat16"),
-    (8192, 256, 16384, "torch.float16"),
-    # N=128 (K-1367 P13 territory, NOT K-1397)
-    (2048, 128,  2048, "torch.bfloat16"),
-    (8192, 128, 32768, "torch.float16"),
-    # N=512 (above N=256 column-narrow regime; not in K-1365 skinny_N256 bucket)
-    (2048, 512,  2048, "torch.bfloat16"),
-    (4096, 512, 32768, "torch.float16"),
-])
-def test_k1397_predicate_rejects_boundary_perturbations(M, N, K, dtype):
-    assert _k1397_p13_skinny_n256_routeout(M, N, K, dtype) is False
-
-
-# ---------------------------------------------------------------------------
-# Additional axis-perturbation negative controls (M-axis and dtype-axis).
-# ---------------------------------------------------------------------------
-@pytest.mark.parametrize("M,N,K,dtype", [
-    # M below the M=2048 cohort floor
-    (1024, 256, 2048, "torch.bfloat16"),
-    (1024, 256, 32768, "torch.float16"),
-    # M above the M=8192 cohort ceiling
-    (16384, 256, 2048, "torch.bfloat16"),
-    # K mid-band (between {2048, 32768})
-    (2048, 256, 8192, "torch.bfloat16"),
-    # dtype outside the bf16/fp16 K-913 §3 invariance class
-    (2048, 256, 2048, "torch.float32"),
-    (4096, 256, 32768, "torch.float32"),
-])
-def test_k1397_predicate_rejects_axis_perturbations(M, N, K, dtype):
-    assert _k1397_p13_skinny_n256_routeout(M, N, K, dtype) is False
-
-
-# ---------------------------------------------------------------------------
-# Full dispatch decision — exercises the 8-position precedence chain.
-# Every K-1397 admit cell MUST route to hipBLASLt under default carve-out
-# settings (no streamk, no work-stealing, matched dtype).
-# ---------------------------------------------------------------------------
-@pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_k1397_12_cells()))
+@pytest.mark.parametrize("M,N,K,dtype", sorted(_EXPECTED_K1397_12_CELLS))
 def test_full_dispatch_routes_every_k1397_cell_to_hbl(M, N, K, dtype):
+    """Every K-1397 admit cell must route to hipBLASLt under the full
+    8-position precedence chain with default carve-out settings."""
     assert k971_route_decision(M, N, K, dtype, dtype, False, False) is True
 
 
-# ---------------------------------------------------------------------------
-# Boundary cells must NOT route under the full dispatch chain either —
-# guards against leakage via any earlier 1st–7th-position predicate.
-# ---------------------------------------------------------------------------
-@pytest.mark.parametrize("M,N,K,dtype", [
-    # K=4096 / K=16384 mid-band (NOT covered by any envelope at N=256 outside
-    # of any prior P5/P6/P8/E1 admits — these specific tuples should fall
-    # through to in-kernel dispatch).
-    (2048, 256,  4096, "torch.bfloat16"),
-    (8192, 256, 16384, "torch.float16"),
-    # N=512 (no envelope claims this column width at these (M,K) tuples)
-    (2048, 512, 32768, "torch.bfloat16"),
-    (4096, 512,  2048, "torch.float16"),
-])
-def test_full_dispatch_rejects_k1397_boundary_perturbations(M, N, K, dtype):
-    """These boundary cells lie outside the K-1397 envelope.  They must not
-    be claimed by the K-1397 8th-position predicate.  (Cells may still be
-    routed by an earlier predicate if independently admitted — but in that
-    case the rejection is from the K-1397 predicate alone, not the chain.)
-    """
-    # Direct predicate must reject:
-    assert _k1397_p13_skinny_n256_routeout(M, N, K, dtype) is False
-
-
-# ---------------------------------------------------------------------------
-# Carve-out short-circuits — a K-1397 admit cell must NOT route to hipBLASLt
-# when streamk / work-stealing / mismatched-dtype is requested.
-# ---------------------------------------------------------------------------
 @pytest.mark.parametrize("enable_streamk,work_stealing,b_dtype", [
     (True,  False, "torch.bfloat16"),  # streamk requested
     (False, True,  "torch.bfloat16"),  # work-stealing requested
-    (False, False, "torch.float16"),   # mixed dtype (a bf16, b fp16)
+    (False, False, "torch.float16"),   # mismatched dtype (a bf16, b fp16)
 ])
-def test_k1397_admit_cell_carveout_short_circuits(enable_streamk, work_stealing, b_dtype):
-    # Pick a known K-1397 admit cell.
+def test_k1397_admit_cell_carveout_short_circuits(
+    enable_streamk, work_stealing, b_dtype,
+):
+    """Admit cells must NOT route to hipBLASLt when streamk / work-stealing
+    / mismatched-dtype is requested.  Pick (4096, 256, 32768, bf16) as a
+    representative K-1397 admit cell."""
     a_dtype = "torch.bfloat16"
     M, N, K = 4096, 256, 32768
     assert (M, N, K, a_dtype) in _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12
-    routed = k971_route_decision(M, N, K, a_dtype, b_dtype,
-                                 enable_streamk, work_stealing)
+    routed = k971_route_decision(
+        M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing,
+    )
     assert routed is False, (
         f"K-1397 P13 admit cell ({M},{N},{K},{a_dtype}) must NOT route to "
         f"hipBLASLt when carve-out applies (streamk={enable_streamk}, "
         f"work_stealing={work_stealing}, b_dtype={b_dtype}); short-circuit "
         f"in _k971_route_to_hbl is load-bearing.")
-
-
-# ---------------------------------------------------------------------------
-# Regression firewall — every cell in the K-1335 / K-1322 / K-905 / K-1361
-# / K-1367 prior envelopes still routes to hipBLASLt after the K-1397 stack.
-# Per R-1322.STRICT-EQUALITY-UNION-PRESERVES-PRIOR-ADMIT-INVARIANCE; the new
-# envelope is unioned via short-circuit `if ... return True` so prior admits
-# cannot be removed by the diff.
-# ---------------------------------------------------------------------------
-def test_no_regression_on_k971_route_table_prior_admits():
-    for (M, N, K, dt) in K971_ROUTE_TABLE:
-        assert k971_route_decision(M, N, K, dt, dt, False, False) is True, (
-            f"K971_ROUTE_TABLE prior admit ({M},{N},{K},{dt}) was lost after "
-            f"K-1397 P13 stack; the K-1397 productionisation must preserve every "
-            f"prior 5th-position envelope cell (regression firewall).")
-
-
-def test_no_regression_on_p8_prior_admits():
-    for (M, N, K, dt) in _P8_MFMA_ISSUE_STALL_ROUTEOUT:
-        assert k971_route_decision(M, N, K, dt, dt, False, False) is True, (
-            f"P8 prior admit ({M},{N},{K},{dt}) was lost after K-1397 P13 "
-            f"stack; the K-1397 productionisation must preserve every prior "
-            f"P8 sub-frozenset cell (regression firewall).")
-
-
-def test_no_regression_on_p12_prior_admits():
-    for (M, N, K, dt) in _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4:
-        assert k971_route_decision(M, N, K, dt, dt, False, False) is True, (
-            f"K-1361 P12 prior admit ({M},{N},{K},{dt}) was lost after "
-            f"K-1397 P13 stack; the K-1397 productionisation must preserve "
-            f"every prior 6th-position P12 cell (regression firewall).")
-
-
-def test_no_regression_on_k1367_p13_n128_prior_admits():
-    for (M, N, K, dt) in _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18:
-        assert k971_route_decision(M, N, K, dt, dt, False, False) is True, (
-            f"K-1367 P13 (N=128) prior admit ({M},{N},{K},{dt}) was lost "
-            f"after K-1397 P13 stack; the K-1397 productionisation must "
-            f"preserve every prior 7th-position P13 cell (regression "
-            f"firewall).")

--- a/tests/test_k1397_p13_skinny_n256.py
+++ b/tests/test_k1397_p13_skinny_n256.py
@@ -1,0 +1,259 @@
+"""K-1397 P13 skinny_N256 K-COMPLEMENT pin tests — torch-free.
+
+Validates the K-1402 productionisation of the K-1397-winning 12-cell
+`_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12` frozenset stacked as the
+8th-position envelope on top of the K-1389 P13 73-cell baseline (envelope
+grows 73 → 85 cells; +12 admits).
+
+These tests pin:
+  * cardinality of the new frozenset (K-1397 P13 = 12, total post-K-1397 = 85)
+  * exact membership of the K-1397 P13 12 cells (M ∈ {2048, 4096, 8192} ×
+    N=256 × K ∈ {2048, 32768} × {bf16, fp16})
+  * cross-frozenset disjointness vs P8 / K971_ROUTE_TABLE / P12 / K-1367 P13
+  * dispatch precedence: dtype-mismatch / streamk / work-stealing carve-outs
+    short-circuit ahead of every strict-equality table
+  * boundary-perturbed cells (K=4096, K=16384, N=128, N=512) MUST NOT match
+
+Imports the actual shipped predicate module (`_route_predicate`) so the real
+runtime path is exercised; no exec/string-parse copies.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tritonblas._route_predicate import (
+    K971_ROUTE_TABLE,
+    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+    _P8_MFMA_ISSUE_STALL_ROUTEOUT,
+    _k1397_p13_skinny_n256_routeout,
+    k971_route_decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# Cardinality pins.  Any deviation indicates an authoring typo against the
+# K-1365 post-P12 4-bucket decomposition or K-1397 K-COMPLEMENT extremes scoping.
+# ---------------------------------------------------------------------------
+def test_p13_skinny_n256_kcomplement_cardinality_12():
+    assert len(_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12) == 12
+
+
+def test_envelope_total_post_k1397_is_85():
+    """P8 (51) + K-1361 P12 (4) + K-1367 P13 (18) + K-1397 P13 (12) = 85
+    strict-equality cells.
+
+    K971_ROUTE_TABLE (12 cells: K-905/K-971 anchors + K-1335 longK_smallSquare)
+    is the 5th-position envelope; counted separately from the P8/P12/P13
+    8-position chain because it gates on the LDS-bank-conflict mechanism
+    rather than the MFMA-issue-stall / square_mid / skinny_N128 / skinny_N256
+    mechanisms.
+    """
+    total = (
+        len(_P8_MFMA_ISSUE_STALL_ROUTEOUT)
+        + len(_K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
+        + len(_K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18)
+        + len(_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12)
+    )
+    assert total == 85, (
+        f"Expected 51 + 4 + 18 + 12 = 85 strict-equality cells across "
+        f"P8/P12/P13(N=128)/P13(N=256); got {total}.  Check that no "
+        f"frozenset has been mutated.")
+
+
+# ---------------------------------------------------------------------------
+# Exact-membership pins.
+# ---------------------------------------------------------------------------
+def _expected_k1397_12_cells():
+    """Construct the K-1397 P13 12-cell expected set from the bucket rule."""
+    return frozenset({
+        (M, 256, K, dt)
+        for M in (2048, 4096, 8192)
+        for K in (2048, 32768)
+        for dt in ("torch.bfloat16", "torch.float16")
+    })
+
+
+def test_k1397_membership_exactly_12_kcomplement_cells():
+    expected = _expected_k1397_12_cells()
+    assert _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12 == expected, (
+        "K-1397 P13 frozenset diverges from the K-COMPLEMENT bucket rule: "
+        "M ∈ {2048,4096,8192} × N=256 × K ∈ {2048,32768} × {bf16,fp16}.\n"
+        f"  missing : {sorted(expected - _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12)}\n"
+        f"  unknown : {sorted(_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12 - expected)}")
+
+
+# ---------------------------------------------------------------------------
+# Disjointness pins.  Cheap insurance per
+# R-1329.K-AXIS-PROJECTION-DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE.
+# ---------------------------------------------------------------------------
+def test_k1397_disjoint_from_p8():
+    assert _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12.isdisjoint(
+        _P8_MFMA_ISSUE_STALL_ROUTEOUT)
+
+
+def test_k1397_disjoint_from_k971_route_table():
+    assert _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12.isdisjoint(
+        K971_ROUTE_TABLE)
+
+
+def test_k1397_disjoint_from_p12():
+    assert _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12.isdisjoint(
+        _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
+
+
+def test_k1397_disjoint_from_k1367_p13_n128():
+    """K-1367 P13 (N=128) and K-1397 P13 (N=256) partition the skinny-N
+    column-narrow regime by N-axis; no cell may belong to both.
+    """
+    assert _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12.isdisjoint(
+        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18)
+
+
+# ---------------------------------------------------------------------------
+# Per-cell predicate behaviour — every one of the 12 admit cells routes True.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_k1397_12_cells()))
+def test_k1397_predicate_admits_every_kcomplement_cell(M, N, K, dtype):
+    assert _k1397_p13_skinny_n256_routeout(M, N, K, dtype) is True
+
+
+# ---------------------------------------------------------------------------
+# Boundary negative-control pins (the 4 boundary perturbations spelled out
+# in K-1402's success criteria: K=4096, K=16384 — which are mid-band cells
+# already covered by tritonblas persistent_matmul, NOT to be re-routed; and
+# N=128, N=512 — adjacent column widths NOT in the K-1397 cohort).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("M,N,K,dtype", [
+    # K=4096 (mid-band — tritonblas persistent_matmul wins)
+    (2048, 256,  4096, "torch.bfloat16"),
+    (4096, 256,  4096, "torch.float16"),
+    # K=16384 (mid-band ceiling — tritonblas persistent_matmul wins)
+    (4096, 256, 16384, "torch.bfloat16"),
+    (8192, 256, 16384, "torch.float16"),
+    # N=128 (K-1367 P13 territory, NOT K-1397)
+    (2048, 128,  2048, "torch.bfloat16"),
+    (8192, 128, 32768, "torch.float16"),
+    # N=512 (above N=256 column-narrow regime; not in K-1365 skinny_N256 bucket)
+    (2048, 512,  2048, "torch.bfloat16"),
+    (4096, 512, 32768, "torch.float16"),
+])
+def test_k1397_predicate_rejects_boundary_perturbations(M, N, K, dtype):
+    assert _k1397_p13_skinny_n256_routeout(M, N, K, dtype) is False
+
+
+# ---------------------------------------------------------------------------
+# Additional axis-perturbation negative controls (M-axis and dtype-axis).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("M,N,K,dtype", [
+    # M below the M=2048 cohort floor
+    (1024, 256, 2048, "torch.bfloat16"),
+    (1024, 256, 32768, "torch.float16"),
+    # M above the M=8192 cohort ceiling
+    (16384, 256, 2048, "torch.bfloat16"),
+    # K mid-band (between {2048, 32768})
+    (2048, 256, 8192, "torch.bfloat16"),
+    # dtype outside the bf16/fp16 K-913 §3 invariance class
+    (2048, 256, 2048, "torch.float32"),
+    (4096, 256, 32768, "torch.float32"),
+])
+def test_k1397_predicate_rejects_axis_perturbations(M, N, K, dtype):
+    assert _k1397_p13_skinny_n256_routeout(M, N, K, dtype) is False
+
+
+# ---------------------------------------------------------------------------
+# Full dispatch decision — exercises the 8-position precedence chain.
+# Every K-1397 admit cell MUST route to hipBLASLt under default carve-out
+# settings (no streamk, no work-stealing, matched dtype).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("M,N,K,dtype", sorted(_expected_k1397_12_cells()))
+def test_full_dispatch_routes_every_k1397_cell_to_hbl(M, N, K, dtype):
+    assert k971_route_decision(M, N, K, dtype, dtype, False, False) is True
+
+
+# ---------------------------------------------------------------------------
+# Boundary cells must NOT route under the full dispatch chain either —
+# guards against leakage via any earlier 1st–7th-position predicate.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("M,N,K,dtype", [
+    # K=4096 / K=16384 mid-band (NOT covered by any envelope at N=256 outside
+    # of any prior P5/P6/P8/E1 admits — these specific tuples should fall
+    # through to in-kernel dispatch).
+    (2048, 256,  4096, "torch.bfloat16"),
+    (8192, 256, 16384, "torch.float16"),
+    # N=512 (no envelope claims this column width at these (M,K) tuples)
+    (2048, 512, 32768, "torch.bfloat16"),
+    (4096, 512,  2048, "torch.float16"),
+])
+def test_full_dispatch_rejects_k1397_boundary_perturbations(M, N, K, dtype):
+    """These boundary cells lie outside the K-1397 envelope.  They must not
+    be claimed by the K-1397 8th-position predicate.  (Cells may still be
+    routed by an earlier predicate if independently admitted — but in that
+    case the rejection is from the K-1397 predicate alone, not the chain.)
+    """
+    # Direct predicate must reject:
+    assert _k1397_p13_skinny_n256_routeout(M, N, K, dtype) is False
+
+
+# ---------------------------------------------------------------------------
+# Carve-out short-circuits — a K-1397 admit cell must NOT route to hipBLASLt
+# when streamk / work-stealing / mismatched-dtype is requested.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("enable_streamk,work_stealing,b_dtype", [
+    (True,  False, "torch.bfloat16"),  # streamk requested
+    (False, True,  "torch.bfloat16"),  # work-stealing requested
+    (False, False, "torch.float16"),   # mixed dtype (a bf16, b fp16)
+])
+def test_k1397_admit_cell_carveout_short_circuits(enable_streamk, work_stealing, b_dtype):
+    # Pick a known K-1397 admit cell.
+    a_dtype = "torch.bfloat16"
+    M, N, K = 4096, 256, 32768
+    assert (M, N, K, a_dtype) in _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12
+    routed = k971_route_decision(M, N, K, a_dtype, b_dtype,
+                                 enable_streamk, work_stealing)
+    assert routed is False, (
+        f"K-1397 P13 admit cell ({M},{N},{K},{a_dtype}) must NOT route to "
+        f"hipBLASLt when carve-out applies (streamk={enable_streamk}, "
+        f"work_stealing={work_stealing}, b_dtype={b_dtype}); short-circuit "
+        f"in _k971_route_to_hbl is load-bearing.")
+
+
+# ---------------------------------------------------------------------------
+# Regression firewall — every cell in the K-1335 / K-1322 / K-905 / K-1361
+# / K-1367 prior envelopes still routes to hipBLASLt after the K-1397 stack.
+# Per R-1322.STRICT-EQUALITY-UNION-PRESERVES-PRIOR-ADMIT-INVARIANCE; the new
+# envelope is unioned via short-circuit `if ... return True` so prior admits
+# cannot be removed by the diff.
+# ---------------------------------------------------------------------------
+def test_no_regression_on_k971_route_table_prior_admits():
+    for (M, N, K, dt) in K971_ROUTE_TABLE:
+        assert k971_route_decision(M, N, K, dt, dt, False, False) is True, (
+            f"K971_ROUTE_TABLE prior admit ({M},{N},{K},{dt}) was lost after "
+            f"K-1397 P13 stack; the K-1397 productionisation must preserve every "
+            f"prior 5th-position envelope cell (regression firewall).")
+
+
+def test_no_regression_on_p8_prior_admits():
+    for (M, N, K, dt) in _P8_MFMA_ISSUE_STALL_ROUTEOUT:
+        assert k971_route_decision(M, N, K, dt, dt, False, False) is True, (
+            f"P8 prior admit ({M},{N},{K},{dt}) was lost after K-1397 P13 "
+            f"stack; the K-1397 productionisation must preserve every prior "
+            f"P8 sub-frozenset cell (regression firewall).")
+
+
+def test_no_regression_on_p12_prior_admits():
+    for (M, N, K, dt) in _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4:
+        assert k971_route_decision(M, N, K, dt, dt, False, False) is True, (
+            f"K-1361 P12 prior admit ({M},{N},{K},{dt}) was lost after "
+            f"K-1397 P13 stack; the K-1397 productionisation must preserve "
+            f"every prior 6th-position P12 cell (regression firewall).")
+
+
+def test_no_regression_on_k1367_p13_n128_prior_admits():
+    for (M, N, K, dt) in _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18:
+        assert k971_route_decision(M, N, K, dt, dt, False, False) is True, (
+            f"K-1367 P13 (N=128) prior admit ({M},{N},{K},{dt}) was lost "
+            f"after K-1397 P13 stack; the K-1397 productionisation must "
+            f"preserve every prior 7th-position P13 cell (regression "
+            f"firewall).")

--- a/tests/test_k1417_p15_skinny_n512.py
+++ b/tests/test_k1417_p15_skinny_n512.py
@@ -1,0 +1,96 @@
+"""K-1417 P15 skinny_N512 K-COMPLEMENT EXTENSION pin tests — torch-free.
+
+Minimal pin coverage for the K-1417 productionisation of the K-1409-derived
+12-cell `_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12` frozenset stacked as the
+9th-position envelope on top of the K-1406 P14 8-predicate stack (envelope
+grows 85 → 97 cells; +12 admits at the K-axis EXTREMES of the N=512
+column-narrow regime).
+
+Cardinality and cross-frozenset disjointness are already asserted at module
+load in `_route_predicate.py`; we do not duplicate those here (per
+R-1406.MODULE-LOAD-ASSERTS-MAKE-PYTEST-CARDINALITY-DISJOINTNESS-DUPS-DEAD-WEIGHT).
+The pytest suite focuses on the orthogonal behavioural pins:
+
+  * exact membership of the K-1417 P15 12 cells
+    (M ∈ {2048, 4096, 8192} × N=512 × K ∈ {2048, 32768} × {bf16, fp16})
+  * full-chain dispatch routes every admit cell to hipBLASLt (covers the
+    9th-position predicate's interaction with the 8-predicate precedence
+    chain)
+  * carve-out short-circuits (streamk / work-stealing / mismatched-dtype)
+    correctly suppress the route-OUT for an admit cell
+  * P14 (K-1397 N=256) cells STILL route to hipBLASLt under the new chain
+    (zero regression on the prior 8th-position envelope)
+"""
+from __future__ import annotations
+
+import pytest
+
+from tritonblas._route_predicate import (
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12,
+    k971_route_decision,
+)
+
+
+# Bucket rule per K-1417 success criteria: M ∈ {2048,4096,8192} ×
+# N=512 × K ∈ {2048,32768} × {bf16, fp16}.
+_EXPECTED_K1417_12_CELLS = frozenset({
+    (M, 512, K, dt)
+    for M in (2048, 4096, 8192)
+    for K in (2048, 32768)
+    for dt in ("torch.bfloat16", "torch.float16")
+})
+
+
+def test_k1417_membership_exactly_12_kcomplement_extension_cells():
+    """The frozenset must equal the bucket rule exactly — no missing or
+    unknown cells."""
+    diff_missing = sorted(_EXPECTED_K1417_12_CELLS
+                          - _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12)
+    diff_unknown = sorted(_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12
+                          - _EXPECTED_K1417_12_CELLS)
+    assert _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12 == _EXPECTED_K1417_12_CELLS, (
+        f"K-1417 P15 frozenset diverges from the K-COMPLEMENT EXTENSION "
+        f"bucket rule (M ∈ {{2048,4096,8192}} × N=512 × K ∈ {{2048,32768}} × "
+        f"{{bf16,fp16}}).\n"
+        f"  missing : {diff_missing}\n"
+        f"  unknown : {diff_unknown}")
+
+
+@pytest.mark.parametrize("M,N,K,dtype", sorted(_EXPECTED_K1417_12_CELLS))
+def test_full_dispatch_routes_every_k1417_cell_to_hbl(M, N, K, dtype):
+    """Every K-1417 admit cell must route to hipBLASLt under the full
+    9-position precedence chain with default carve-out settings."""
+    assert k971_route_decision(M, N, K, dtype, dtype, False, False) is True
+
+
+@pytest.mark.parametrize("enable_streamk,work_stealing,b_dtype", [
+    (True,  False, "torch.bfloat16"),  # streamk requested
+    (False, True,  "torch.bfloat16"),  # work-stealing requested
+    (False, False, "torch.float16"),   # mismatched dtype (a bf16, b fp16)
+])
+def test_k1417_admit_cell_carveout_short_circuits(
+    enable_streamk, work_stealing, b_dtype,
+):
+    """Admit cells must NOT route to hipBLASLt when streamk / work-stealing
+    / mismatched-dtype is requested.  Pick (4096, 512, 32768, bf16) as a
+    representative K-1417 admit cell."""
+    a_dtype = "torch.bfloat16"
+    M, N, K = 4096, 512, 32768
+    assert (M, N, K, a_dtype) in _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12
+    routed = k971_route_decision(
+        M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing,
+    )
+    assert routed is False, (
+        f"K-1417 P15 admit cell ({M},{N},{K},{a_dtype}) must NOT route to "
+        f"hipBLASLt when carve-out applies (streamk={enable_streamk}, "
+        f"work_stealing={work_stealing}, b_dtype={b_dtype}); short-circuit "
+        f"in _k971_route_to_hbl is load-bearing.")
+
+
+@pytest.mark.parametrize("M,N,K,dtype", sorted(_K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12))
+def test_k1397_p14_envelope_unchanged_under_p15_stack(M, N, K, dtype):
+    """Regression: every K-1397 (P14, 8th-position, N=256) cell must STILL
+    route to hipBLASLt under the new 9-position stack.  Asserts bit-identical
+    routing behaviour on the prior productionisation envelope."""
+    assert k971_route_decision(M, N, K, dtype, dtype, False, False) is True

--- a/tests/test_k1417_p15_skinny_n512.py
+++ b/tests/test_k1417_p15_skinny_n512.py
@@ -1,7 +1,7 @@
 """K-1417 P15 skinny_N512 K-COMPLEMENT EXTENSION pin tests — torch-free.
 
 Minimal pin coverage for the K-1417 productionisation of the K-1409-derived
-12-cell `_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12` frozenset stacked as the
+12-cell `_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT` frozenset stacked as the
 9th-position envelope on top of the K-1406 P14 8-predicate stack (envelope
 grows 85 → 97 cells; +12 admits at the K-axis EXTREMES of the N=512
 column-narrow regime).
@@ -27,7 +27,8 @@ import pytest
 
 from tritonblas._route_predicate import (
     _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
-    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12,
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT,
+    _k1409_p15_skinny_n512_routeout,
     k971_route_decision,
 )
 
@@ -46,10 +47,10 @@ def test_k1417_membership_exactly_12_kcomplement_extension_cells():
     """The frozenset must equal the bucket rule exactly — no missing or
     unknown cells."""
     diff_missing = sorted(_EXPECTED_K1417_12_CELLS
-                          - _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12)
-    diff_unknown = sorted(_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12
+                          - _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT)
+    diff_unknown = sorted(_K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT
                           - _EXPECTED_K1417_12_CELLS)
-    assert _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12 == _EXPECTED_K1417_12_CELLS, (
+    assert _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT == _EXPECTED_K1417_12_CELLS, (
         f"K-1417 P15 frozenset diverges from the K-COMPLEMENT EXTENSION "
         f"bucket rule (M ∈ {{2048,4096,8192}} × N=512 × K ∈ {{2048,32768}} × "
         f"{{bf16,fp16}}).\n"
@@ -77,7 +78,7 @@ def test_k1417_admit_cell_carveout_short_circuits(
     representative K-1417 admit cell."""
     a_dtype = "torch.bfloat16"
     M, N, K = 4096, 512, 32768
-    assert (M, N, K, a_dtype) in _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT_12
+    assert (M, N, K, a_dtype) in _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT
     routed = k971_route_decision(
         M, N, K, a_dtype, b_dtype, enable_streamk, work_stealing,
     )
@@ -94,3 +95,58 @@ def test_k1397_p14_envelope_unchanged_under_p15_stack(M, N, K, dtype):
     route to hipBLASLt under the new 9-position stack.  Asserts bit-identical
     routing behaviour on the prior productionisation envelope."""
     assert k971_route_decision(M, N, K, dtype, dtype, False, False) is True
+
+
+# ---------------------------------------------------------------------------
+# Negative pin tests — strict-equality firewall against silent over-routing
+# from the P15 predicate.
+# ---------------------------------------------------------------------------
+# Per Skeptic guidance on K-1417 RETRY: a strict-equality frozenset must be
+# explicitly fenced off against adjacent-but-not-admitted shapes that a
+# future broadening (e.g. range / pattern predicate refactor) could silently
+# absorb.  These near-miss shapes each vary exactly ONE axis off the K-1417
+# admit grid:
+#
+#   * (2048, 512,  4096, bf16)  — N/M admit, K=4096 OFF (mid-K K-1409 BASE)
+#   * (1024, 512,  2048, bf16)  — N/K admit, M=1024 OFF (M-axis OFF)
+#   * (8192, 512,  4096, fp16)  — N/M admit, K=4096 OFF (mid-K)
+#   * (2048, 512,  2048, fp32)  — M/N/K admit, dtype=fp32 OFF (P15 admits
+#                                  bf16/fp16 only)
+#   * (4096, 1024, 2048, bf16)  — M/K admit, N=1024 OFF (one column-step
+#                                  out of the column-narrow regime)
+#
+# These tests target the P15 predicate function directly (NOT the full
+# `k971_route_decision`), because some of these near-miss shapes may be
+# legitimately routed by an *earlier* predicate (P5 / K971_ROUTE_TABLE / P12)
+# in the precedence chain.  The P15 firewall guarantee is: P15 itself does
+# NOT contribute a route decision for any shape outside its 12-cell admit set.
+_K1417_NEAR_MISS_NEGATIVES = [
+    # (M,    N,    K,    a_dtype,           reason)
+    (2048,  512,  4096, "torch.bfloat16", "K=4096 mid-K, NOT in K-1417 EXTREMES set"),
+    (1024,  512,  2048, "torch.bfloat16", "M=1024 NOT in K-1417 anchor row"),
+    (8192,  512,  4096, "torch.float16",  "K=4096 mid-K, NOT in K-1417 EXTREMES set"),
+    (2048,  512,  2048, "torch.float32",  "dtype=fp32 NOT admitted by P15"),
+    (4096, 1024,  2048, "torch.bfloat16", "N=1024 OFF column-narrow regime (P15 fixes N=512)"),
+]
+
+
+@pytest.mark.parametrize("M,N,K,dtype,reason", _K1417_NEAR_MISS_NEGATIVES)
+def test_k1417_near_miss_shapes_not_admitted_by_p15_predicate(
+    M, N, K, dtype, reason,
+):
+    """Negative pin: near-miss shapes one axis off the K-1417 admit grid
+    must NOT be admitted by the P15 strict-equality predicate function
+    `_k1409_p15_skinny_n512_routeout`.  Targets the P15 firewall directly
+    (independent of earlier-precedence predicates that may legitimately
+    claim these shapes for their own reasons)."""
+    # Sanity: the near-miss shape is genuinely outside the P15 admit set.
+    assert (M, N, K, dtype) not in _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT, (
+        f"Test scaffolding bug: near-miss ({M},{N},{K},{dtype}) is actually "
+        f"in the P15 admit set — the negative test would pass trivially.")
+    p15_admit = _k1409_p15_skinny_n512_routeout(M, N, K, dtype)
+    assert p15_admit is False, (
+        f"P15 strict-equality firewall LEAK: ({M},{N},{K},{dtype}) — {reason} "
+        f"— P15 predicate returned True, but the K-1417 admit set is exactly "
+        f"the 12-cell EXTREMES grid (M ∈ {{2048,4096,8192}} × N=512 × "
+        f"K ∈ {{2048,32768}} × {{bf16,fp16}}); any True outside this set "
+        f"signals an over-broad predicate.")

--- a/tests/test_k1429_p16_skinny_n1024.py
+++ b/tests/test_k1429_p16_skinny_n1024.py
@@ -1,0 +1,159 @@
+"""K-1429 (S-002): pin tests for the P16 `skinny_N1024` K-COMPLEMENT
+29-cell route-OUT frozenset (10th-position).
+
+Pin coverage (analogous to K-1409, K-1417 productionisation tests):
+
+* 29 admit cells × 1 dispatch trace each (positive admit verification)
+* 1 reject cell (boundary) — verifies the strict 1.05 floor correctly
+  excludes the (2048, 1024, 4096, bf16) cell at r=1.015
+* 5 boundary controls — N just above/below 1024 cells must NOT route
+* Frozenset-shape pin (29 cells exactly, anchor enumeration)
+* Disjointness pins vs P8 / K971 / P12 / K-1367 P13 / K-1397 P13 / K-1409 P15
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tritonblas._route_predicate import (
+    _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29,
+    _k1429_p16_skinny_n1024_routeout,
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT,
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
+    K971_ROUTE_TABLE,
+    _P8_MFMA_ISSUE_STALL_ROUTEOUT,
+)
+
+
+# ---------------------------------------------------------------------------
+# Frozenset shape pins (regression — must match K-1429 paired n=30 admit set)
+# ---------------------------------------------------------------------------
+
+EXPECTED_ADMIT_29 = frozenset({
+    # BASE region (K ∈ {4096, 8192, 16384}) — 17 admit cells
+    (2048, 1024,  4096, "torch.float16"),
+    (2048, 1024,  8192, "torch.bfloat16"),
+    (2048, 1024,  8192, "torch.float16"),
+    (2048, 1024, 16384, "torch.bfloat16"),
+    (2048, 1024, 16384, "torch.float16"),
+    (4096, 1024,  4096, "torch.bfloat16"),
+    (4096, 1024,  4096, "torch.float16"),
+    (4096, 1024,  8192, "torch.bfloat16"),
+    (4096, 1024,  8192, "torch.float16"),
+    (4096, 1024, 16384, "torch.bfloat16"),
+    (4096, 1024, 16384, "torch.float16"),
+    (8192, 1024,  4096, "torch.bfloat16"),
+    (8192, 1024,  4096, "torch.float16"),
+    (8192, 1024,  8192, "torch.bfloat16"),
+    (8192, 1024,  8192, "torch.float16"),
+    (8192, 1024, 16384, "torch.bfloat16"),
+    (8192, 1024, 16384, "torch.float16"),
+    # EXTENSION region (K ∈ {2048, 32768}) — 12 admit cells
+    (2048, 1024,  2048, "torch.bfloat16"),
+    (2048, 1024,  2048, "torch.float16"),
+    (2048, 1024, 32768, "torch.bfloat16"),
+    (2048, 1024, 32768, "torch.float16"),
+    (4096, 1024,  2048, "torch.bfloat16"),
+    (4096, 1024,  2048, "torch.float16"),
+    (4096, 1024, 32768, "torch.bfloat16"),
+    (4096, 1024, 32768, "torch.float16"),
+    (8192, 1024,  2048, "torch.bfloat16"),
+    (8192, 1024,  2048, "torch.float16"),
+    (8192, 1024, 32768, "torch.bfloat16"),
+    (8192, 1024, 32768, "torch.float16"),
+})
+
+REJECT_CELL = (2048, 1024, 4096, "torch.bfloat16")  # r=1.015, fails 1.05 floor
+
+
+def test_frozenset_size_is_exactly_29():
+    assert len(_K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29) == 29
+
+
+def test_frozenset_matches_expected_admit_set():
+    assert _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29 == EXPECTED_ADMIT_29
+
+
+def test_reject_cell_is_excluded():
+    assert REJECT_CELL not in _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29
+
+
+# ---------------------------------------------------------------------------
+# Predicate behavior — admit cells
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("M,N,K,dtype_str", sorted(EXPECTED_ADMIT_29))
+def test_predicate_returns_true_for_admit_cell(M, N, K, dtype_str):
+    dtype = torch.bfloat16 if dtype_str == "torch.bfloat16" else torch.float16
+    assert _k1429_p16_skinny_n1024_routeout(M, N, K, dtype) is True
+
+
+def test_predicate_returns_false_for_reject_cell():
+    M, N, K, dtype_str = REJECT_CELL
+    dtype = torch.bfloat16
+    assert _k1429_p16_skinny_n1024_routeout(M, N, K, dtype) is False
+
+
+# ---------------------------------------------------------------------------
+# Boundary controls — N just outside the bucket must NOT route via P16
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("M,N,K,dtype_str", [
+    (2048,  512, 8192, "torch.bfloat16"),    # adjacent N=512 — covered by P15
+    (2048, 2048, 8192, "torch.bfloat16"),    # adjacent N=2048 — out of bucket
+    (1024, 1024, 8192, "torch.bfloat16"),    # M=1024 — out of bucket
+    (2048, 1024, 8192, "torch.float32"),     # dtype not in {bf16,fp16}
+    (2048, 1024, 1024, "torch.bfloat16"),    # K=1024 — out of bucket
+])
+def test_predicate_returns_false_outside_bucket(M, N, K, dtype_str):
+    dtype = (torch.bfloat16 if dtype_str == "torch.bfloat16"
+             else torch.float16 if dtype_str == "torch.float16"
+             else torch.float32)
+    assert _k1429_p16_skinny_n1024_routeout(M, N, K, dtype) is False
+
+
+# ---------------------------------------------------------------------------
+# Disjointness firewalls vs the prior 9-predicate stack (sibling-N).
+# ---------------------------------------------------------------------------
+
+def test_disjoint_from_p8_mfma_envelope():
+    assert _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29.isdisjoint(
+        _P8_MFMA_ISSUE_STALL_ROUTEOUT)
+
+
+def test_disjoint_from_k971_route_table():
+    assert _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29.isdisjoint(K971_ROUTE_TABLE)
+
+
+def test_disjoint_from_k1361_p12_square_mid():
+    assert _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29.isdisjoint(
+        _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
+
+
+def test_disjoint_from_k1367_p13_skinny_n128():
+    assert _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29.isdisjoint(
+        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18)
+
+
+def test_disjoint_from_k1397_p13_skinny_n256():
+    assert _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29.isdisjoint(
+        _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12)
+
+
+def test_disjoint_from_k1409_p15_skinny_n512():
+    assert _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29.isdisjoint(
+        _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT)
+
+
+# ---------------------------------------------------------------------------
+# Cohort scoping — every admit cell must satisfy the K-1429 sweep grid.
+# ---------------------------------------------------------------------------
+
+def test_every_admit_cell_in_sweep_grid():
+    for M, N, K, dtype_str in _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29:
+        assert M in (2048, 4096, 8192)
+        assert N == 1024
+        assert K in (2048, 4096, 8192, 16384, 32768)
+        assert dtype_str in ("torch.bfloat16", "torch.float16")

--- a/tests/test_k1437_p17_skinny_n512_kcompl_base.py
+++ b/tests/test_k1437_p17_skinny_n512_kcompl_base.py
@@ -1,21 +1,24 @@
-"""K-1437 (S-002 sibling): pin tests for the P17 `skinny_N512` K-COMPLEMENT
-BASE 18-cell route-OUT frozenset (11th-position).
+"""Pin tests for the P17 ``skinny_N512`` K-COMPLEMENT BASE 17-cell
+strict-equality route-OUT frozenset (11th-position).
 
-Pin coverage (analogous to K-1409 / K-1417 / K-1429 productionisation tests):
+Coverage:
 
-* 18 admit cells × 1 dispatch trace each (positive admit verification).  All
-  18 are at realistic production tiles (BK ∈ {128, 256} — NOT a synthetic
-  BK=64 — per K-539 lesson REVISE).  Cells are M ∈ {2048, 4096, 8192} ×
-  N=512 × K ∈ {4096, 8192, 16384} × dtype ∈ {bf16, fp16}.
-* 5 boundary controls — N just above/below 512 cells must NOT route via P17.
-* Frozenset-shape pin (18 cells exactly, anchor enumeration).
-* Disjointness pins vs P8 / K971 / P12 / K-1367 P13 / K-1397 P13 / K-1409 P15
-  / K-1429 P16.  In particular asserts the BASE ⨄ EXTREMES partition of the
-  N=512 K-COMPLEMENT region (BASE K ∈ {4096, 8192, 16384} disjoint from
-  EXTREMES K ∈ {2048, 32768}).
-* Full-stack ``k971_route_decision`` integration test: every admit cell
-  routes via the 11-deep predicate chain (with streamk=False,
-  work_stealing=False, matched dtypes).
+* Frozenset shape (size + exact admit-set match against the bucket rule).
+* Predicate behaviour on every admit cell (17/17 must return True with
+  realistic production tile dispatch — bf16 / fp16, BLOCK_K is set by the
+  autotune flow at 128 / 256 for these shapes).
+* Boundary controls — N just above/below 512 cells must NOT route via P17.
+* Disjointness firewalls vs the prior 10-predicate stack (P8 / K971 /
+  P12 / P13(N=128) / P13(N=256) / P15 / P16); these were previously
+  asserted at module load — moved here per minimalist convention.
+* P15 ⨄ P17 = 29-cell N=512 K-COMPLEMENT closure (one P5-pre-routed cell
+  is the 30th member of the bucket and is pinned separately).
+* **P5-precedence pin**: (2048, 512, 4096, bf16) is intentionally NOT in
+  the P17 frozenset because R_K979_P5 routes it OUT at chain pos 4 — this
+  test pins that precedence so a future P5 change does not silently leave
+  the cell unmeasured.
+* Full-stack ``k971_route_decision`` integration: every P17 admit cell
+  routes True through the 11-deep dispatch chain.
 """
 from __future__ import annotations
 
@@ -23,7 +26,7 @@ import pytest
 import torch
 
 from tritonblas._route_predicate import (
-    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18,
+    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17,
     _k1437_p17_skinny_n512_kcompl_base_routeout,
     _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29,
     _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT,
@@ -32,20 +35,20 @@ from tritonblas._route_predicate import (
     _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
     K971_ROUTE_TABLE,
     _P8_MFMA_ISSUE_STALL_ROUTEOUT,
+    R_K979_P5_route_to_hbl,
     k971_route_decision,
 )
 
 
 # ---------------------------------------------------------------------------
-# Frozenset shape pins (regression — must match K-1409 paired n=30 BASE
-# admit set; bucket-rule enumeration M ∈ {2048,4096,8192} × N=512 ×
-# K ∈ {4096,8192,16384} × {bf16,fp16}).
+# Frozenset shape pin (regression — must match the K-1409 paired n=30 BASE
+# admit set, minus the single (2048,512,4096,bf16) cell which is
+# P5-pre-routed at chain pos 4 < pos 11).
 # ---------------------------------------------------------------------------
 
-EXPECTED_BASE_ADMIT_18 = frozenset({
-    # M=2048 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
-    (2048, 512,  4096, "torch.bfloat16"),  # P5-overlap, included for
-                                           # frozenset completeness
+EXPECTED_BASE_ADMIT_17 = frozenset({
+    # M=2048 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}; (2048,512,4096,bf16)
+    # excluded — P5-pre-routed (test_p5_routes_excluded_cell pins that).
     (2048, 512,  4096, "torch.float16"),
     (2048, 512,  8192, "torch.bfloat16"),
     (2048, 512,  8192, "torch.float16"),
@@ -68,19 +71,27 @@ EXPECTED_BASE_ADMIT_18 = frozenset({
 })
 
 
-def test_frozenset_size_is_exactly_18():
-    assert len(_K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18) == 18
+def test_frozenset_size_is_exactly_17():
+    assert len(_K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17) == 17
 
 
 def test_frozenset_matches_expected_admit_set():
-    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18 == EXPECTED_BASE_ADMIT_18
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17 == EXPECTED_BASE_ADMIT_17
+
+
+def test_every_admit_cell_in_base_sweep_grid():
+    for M, N, K, dtype_str in _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17:
+        assert M in (2048, 4096, 8192)
+        assert N == 512
+        assert K in (4096, 8192, 16384)
+        assert dtype_str in ("torch.bfloat16", "torch.float16")
 
 
 # ---------------------------------------------------------------------------
-# Predicate behavior — admit cells (18 / 18 must return True).
+# Predicate behavior — admit cells (17 / 17 must return True).
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("M,N,K,dtype_str", sorted(EXPECTED_BASE_ADMIT_18))
+@pytest.mark.parametrize("M,N,K,dtype_str", sorted(EXPECTED_BASE_ADMIT_17))
 def test_predicate_returns_true_for_admit_cell(M, N, K, dtype_str):
     dtype = torch.bfloat16 if dtype_str == "torch.bfloat16" else torch.float16
     assert _k1437_p17_skinny_n512_kcompl_base_routeout(M, N, K, dtype) is True
@@ -108,83 +119,116 @@ def test_predicate_returns_false_outside_bucket(M, N, K, dtype_str):
 
 
 # ---------------------------------------------------------------------------
+# P5-precedence pin — (2048, 512, 4096, bf16) is the one bucket cell
+# excluded from the P17 frozenset because R_K979_P5 routes it at chain
+# position 4 (long before P17 at position 11).  This test locks that
+# precedence so a future P5 narrowing cannot silently leave this cell
+# unrouted.
+# ---------------------------------------------------------------------------
+
+P5_OVERLAP_CELL = (2048, 512, 4096, torch.bfloat16)
+
+
+def test_p5_overlap_cell_is_not_in_p17_frozenset():
+    M, N, K, dtype = P5_OVERLAP_CELL
+    assert (M, N, K, str(dtype)) not in _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17
+
+
+def test_p5_routes_excluded_cell_at_chain_pos_4():
+    """The (2048, 512, 4096, bf16) bucket cell must route to hipBLASLt via
+    R_K979_P5 (chain position 4); P17 (position 11) is structurally
+    unreachable for this cell.  A future P5 change that drops this cell
+    must be paired with adding the cell back to P17.
+    """
+    M, N, K, dtype = P5_OVERLAP_CELL
+    assert R_K979_P5_route_to_hbl(M, N, K, dtype) is True
+
+
+def test_full_dispatch_routes_p5_overlap_cell_to_hbl():
+    """Belt-and-braces: even though the cell is not in P17, the full
+    11-deep dispatch chain must still route it OUT to hipBLASLt (via P5).
+    """
+    M, N, K, dtype = P5_OVERLAP_CELL
+    assert k971_route_decision(
+        M, N, K, dtype, dtype,
+        enable_streamk=False, work_stealing=False,
+    ) is True
+
+
+# ---------------------------------------------------------------------------
 # Disjointness firewalls vs the prior 10-predicate stack (sibling-N + N=512
-# BASE ⨄ EXTREMES partition).
+# BASE ⨄ EXTREMES partition).  These were previously asserted at module
+# load; moved into the test suite per minimalist convention.
 # ---------------------------------------------------------------------------
 
 def test_disjoint_from_p8_mfma_envelope():
-    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17.isdisjoint(
         _P8_MFMA_ISSUE_STALL_ROUTEOUT)
 
 
 def test_disjoint_from_k971_route_table():
-    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE)
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17.isdisjoint(K971_ROUTE_TABLE)
 
 
 def test_disjoint_from_k1361_p12_square_mid():
-    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17.isdisjoint(
         _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
 
 
 def test_disjoint_from_k1367_p13_skinny_n128():
-    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17.isdisjoint(
         _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18)
 
 
 def test_disjoint_from_k1397_p13_skinny_n256():
-    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17.isdisjoint(
         _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12)
 
 
 def test_disjoint_from_k1409_p15_skinny_n512_extremes():
     """BASE K ∈ {4096, 8192, 16384} ⨄ EXTREMES K ∈ {2048, 32768}; the
-    union is the full N=512 K-COMPL region at the K-1308 sweep grid."""
-    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+    union is the 29 admitted cells of the 30-cell N=512 K-COMPL grid
+    (one cell — the P5-overlap — routes via P5 instead)."""
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17.isdisjoint(
         _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT)
 
 
 def test_disjoint_from_k1429_p16_skinny_n1024():
-    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17.isdisjoint(
         _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29)
 
 
 # ---------------------------------------------------------------------------
-# Cohort scoping — every admit cell must satisfy the K-1437 BASE bucket rule.
+# N=512 K-COMPL closure pin: P15 EXTREMES ⨄ P17 BASE = 29 cells of the
+# 30-cell bucket grid.  The remaining cell is (2048,512,4096,bf16) which
+# is pinned by test_full_dispatch_routes_p5_overlap_cell_to_hbl.
 # ---------------------------------------------------------------------------
 
-def test_every_admit_cell_in_base_sweep_grid():
-    for M, N, K, dtype_str in _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18:
-        assert M in (2048, 4096, 8192)
-        assert N == 512
-        assert K in (4096, 8192, 16384)
-        assert dtype_str in ("torch.bfloat16", "torch.float16")
-
-
-def test_n512_kcompl_base_union_extremes_is_full_30_cell_grid():
-    """K-1437 P17 BASE (18) ⨄ K-1417 P15 EXTREMES (12) = full 30-cell N=512
-    K-COMPL grid at the K-1308 sweep (K ∈ {2048, 4096, 8192, 16384, 32768}).
-    """
+def test_n512_kcompl_p15_union_p17_covers_29_of_30_bucket_cells():
     union = (
-        _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18
+        _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17
         | _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT
     )
-    assert len(union) == 30
-    expected = frozenset(
+    expected_full_bucket = frozenset(
         (M, 512, K, dt)
         for M in (2048, 4096, 8192)
         for K in (2048, 4096, 8192, 16384, 32768)
         for dt in ("torch.bfloat16", "torch.float16")
     )
-    assert union == expected
+    # P15 may itself omit cells per its own admit gate; only assert P17 ⊆
+    # bucket and that the union contains everything except the single
+    # P5-overlap cell.
+    missing = expected_full_bucket - union
+    assert missing.issubset({(2048, 512, 4096, "torch.bfloat16")})
 
 
 # ---------------------------------------------------------------------------
 # Full-stack k971_route_decision integration — the 11-deep dispatch chain
-# must route every BASE admit cell to hipBLASLt with realistic production
+# must route every P17 admit cell to hipBLASLt with realistic production
 # tile dispatch flags (streamk=False, work_stealing=False, matched dtypes).
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("M,N,K,dtype_str", sorted(EXPECTED_BASE_ADMIT_18))
+@pytest.mark.parametrize("M,N,K,dtype_str", sorted(EXPECTED_BASE_ADMIT_17))
 def test_full_dispatch_chain_routes_admit_cell_to_hbl(M, N, K, dtype_str):
     dtype = torch.bfloat16 if dtype_str == "torch.bfloat16" else torch.float16
     assert k971_route_decision(

--- a/tests/test_k1437_p17_skinny_n512_kcompl_base.py
+++ b/tests/test_k1437_p17_skinny_n512_kcompl_base.py
@@ -1,0 +1,193 @@
+"""K-1437 (S-002 sibling): pin tests for the P17 `skinny_N512` K-COMPLEMENT
+BASE 18-cell route-OUT frozenset (11th-position).
+
+Pin coverage (analogous to K-1409 / K-1417 / K-1429 productionisation tests):
+
+* 18 admit cells × 1 dispatch trace each (positive admit verification).  All
+  18 are at realistic production tiles (BK ∈ {128, 256} — NOT a synthetic
+  BK=64 — per K-539 lesson REVISE).  Cells are M ∈ {2048, 4096, 8192} ×
+  N=512 × K ∈ {4096, 8192, 16384} × dtype ∈ {bf16, fp16}.
+* 5 boundary controls — N just above/below 512 cells must NOT route via P17.
+* Frozenset-shape pin (18 cells exactly, anchor enumeration).
+* Disjointness pins vs P8 / K971 / P12 / K-1367 P13 / K-1397 P13 / K-1409 P15
+  / K-1429 P16.  In particular asserts the BASE ⨄ EXTREMES partition of the
+  N=512 K-COMPLEMENT region (BASE K ∈ {4096, 8192, 16384} disjoint from
+  EXTREMES K ∈ {2048, 32768}).
+* Full-stack ``k971_route_decision`` integration test: every admit cell
+  routes via the 11-deep predicate chain (with streamk=False,
+  work_stealing=False, matched dtypes).
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tritonblas._route_predicate import (
+    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18,
+    _k1437_p17_skinny_n512_kcompl_base_routeout,
+    _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29,
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT,
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
+    K971_ROUTE_TABLE,
+    _P8_MFMA_ISSUE_STALL_ROUTEOUT,
+    k971_route_decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# Frozenset shape pins (regression — must match K-1409 paired n=30 BASE
+# admit set; bucket-rule enumeration M ∈ {2048,4096,8192} × N=512 ×
+# K ∈ {4096,8192,16384} × {bf16,fp16}).
+# ---------------------------------------------------------------------------
+
+EXPECTED_BASE_ADMIT_18 = frozenset({
+    # M=2048 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (2048, 512,  4096, "torch.bfloat16"),  # P5-overlap, included for
+                                           # frozenset completeness
+    (2048, 512,  4096, "torch.float16"),
+    (2048, 512,  8192, "torch.bfloat16"),
+    (2048, 512,  8192, "torch.float16"),
+    (2048, 512, 16384, "torch.bfloat16"),
+    (2048, 512, 16384, "torch.float16"),
+    # M=4096 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (4096, 512,  4096, "torch.bfloat16"),
+    (4096, 512,  4096, "torch.float16"),
+    (4096, 512,  8192, "torch.bfloat16"),
+    (4096, 512,  8192, "torch.float16"),
+    (4096, 512, 16384, "torch.bfloat16"),
+    (4096, 512, 16384, "torch.float16"),
+    # M=8192 row × K ∈ {4096, 8192, 16384} × {bf16, fp16}
+    (8192, 512,  4096, "torch.bfloat16"),
+    (8192, 512,  4096, "torch.float16"),
+    (8192, 512,  8192, "torch.bfloat16"),
+    (8192, 512,  8192, "torch.float16"),
+    (8192, 512, 16384, "torch.bfloat16"),
+    (8192, 512, 16384, "torch.float16"),
+})
+
+
+def test_frozenset_size_is_exactly_18():
+    assert len(_K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18) == 18
+
+
+def test_frozenset_matches_expected_admit_set():
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18 == EXPECTED_BASE_ADMIT_18
+
+
+# ---------------------------------------------------------------------------
+# Predicate behavior — admit cells (18 / 18 must return True).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("M,N,K,dtype_str", sorted(EXPECTED_BASE_ADMIT_18))
+def test_predicate_returns_true_for_admit_cell(M, N, K, dtype_str):
+    dtype = torch.bfloat16 if dtype_str == "torch.bfloat16" else torch.float16
+    assert _k1437_p17_skinny_n512_kcompl_base_routeout(M, N, K, dtype) is True
+
+
+# ---------------------------------------------------------------------------
+# Boundary controls — must NOT route via P17 (other predicates may catch
+# them — these checks are P17-local).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("M,N,K,dtype_str", [
+    (2048,  512, 2048, "torch.bfloat16"),    # K=2048 — P15 EXTREMES territory
+    (2048,  512, 32768, "torch.bfloat16"),   # K=32768 — P15 EXTREMES territory
+    (2048,  256, 8192, "torch.bfloat16"),    # adjacent N=256 — P13 N=256 territory
+    (2048, 1024, 8192, "torch.bfloat16"),    # adjacent N=1024 — P16 N=1024 territory
+    (1024,  512, 8192, "torch.bfloat16"),    # M=1024 — out of bucket
+    (2048,  512, 8192, "torch.float32"),     # dtype not in {bf16,fp16}
+    (2048,  512, 1024, "torch.bfloat16"),    # K=1024 — out of bucket
+])
+def test_predicate_returns_false_outside_bucket(M, N, K, dtype_str):
+    dtype = (torch.bfloat16 if dtype_str == "torch.bfloat16"
+             else torch.float16 if dtype_str == "torch.float16"
+             else torch.float32)
+    assert _k1437_p17_skinny_n512_kcompl_base_routeout(M, N, K, dtype) is False
+
+
+# ---------------------------------------------------------------------------
+# Disjointness firewalls vs the prior 10-predicate stack (sibling-N + N=512
+# BASE ⨄ EXTREMES partition).
+# ---------------------------------------------------------------------------
+
+def test_disjoint_from_p8_mfma_envelope():
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+        _P8_MFMA_ISSUE_STALL_ROUTEOUT)
+
+
+def test_disjoint_from_k971_route_table():
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(K971_ROUTE_TABLE)
+
+
+def test_disjoint_from_k1361_p12_square_mid():
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+        _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
+
+
+def test_disjoint_from_k1367_p13_skinny_n128():
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18)
+
+
+def test_disjoint_from_k1397_p13_skinny_n256():
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+        _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12)
+
+
+def test_disjoint_from_k1409_p15_skinny_n512_extremes():
+    """BASE K ∈ {4096, 8192, 16384} ⨄ EXTREMES K ∈ {2048, 32768}; the
+    union is the full N=512 K-COMPL region at the K-1308 sweep grid."""
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+        _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT)
+
+
+def test_disjoint_from_k1429_p16_skinny_n1024():
+    assert _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18.isdisjoint(
+        _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29)
+
+
+# ---------------------------------------------------------------------------
+# Cohort scoping — every admit cell must satisfy the K-1437 BASE bucket rule.
+# ---------------------------------------------------------------------------
+
+def test_every_admit_cell_in_base_sweep_grid():
+    for M, N, K, dtype_str in _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18:
+        assert M in (2048, 4096, 8192)
+        assert N == 512
+        assert K in (4096, 8192, 16384)
+        assert dtype_str in ("torch.bfloat16", "torch.float16")
+
+
+def test_n512_kcompl_base_union_extremes_is_full_30_cell_grid():
+    """K-1437 P17 BASE (18) ⨄ K-1417 P15 EXTREMES (12) = full 30-cell N=512
+    K-COMPL grid at the K-1308 sweep (K ∈ {2048, 4096, 8192, 16384, 32768}).
+    """
+    union = (
+        _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_18
+        | _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT
+    )
+    assert len(union) == 30
+    expected = frozenset(
+        (M, 512, K, dt)
+        for M in (2048, 4096, 8192)
+        for K in (2048, 4096, 8192, 16384, 32768)
+        for dt in ("torch.bfloat16", "torch.float16")
+    )
+    assert union == expected
+
+
+# ---------------------------------------------------------------------------
+# Full-stack k971_route_decision integration — the 11-deep dispatch chain
+# must route every BASE admit cell to hipBLASLt with realistic production
+# tile dispatch flags (streamk=False, work_stealing=False, matched dtypes).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("M,N,K,dtype_str", sorted(EXPECTED_BASE_ADMIT_18))
+def test_full_dispatch_chain_routes_admit_cell_to_hbl(M, N, K, dtype_str):
+    dtype = torch.bfloat16 if dtype_str == "torch.bfloat16" else torch.float16
+    assert k971_route_decision(
+        M, N, K, dtype, dtype,
+        enable_streamk=False, work_stealing=False,
+    ) is True

--- a/tests/test_k1513_p22_skinny_n32768.py
+++ b/tests/test_k1513_p22_skinny_n32768.py
@@ -1,0 +1,214 @@
+"""Pin tests for the P22 ``skinny_N32768`` K-COMPLEMENT 30-cell strict-equality
+route-OUT frozenset (14th-position).
+
+Coverage:
+
+* Frozenset shape (size + exact admit-set match against the 3 × 1 × 5 × 2
+  bucket grid: M ∈ {2048,4096,8192} × N=32768 × K ∈ {2048,4096,8192,16384,
+  32768} × {bf16,fp16}).
+* Predicate behaviour on every admit cell (30/30 must return True).
+* Boundary controls — N just above/below 32768 and K outside the K-grid
+  must NOT route via P22.
+* Disjointness firewalls vs the prior 13-predicate stack (P8 / K971 /
+  P12 / P13(N=128) / P13(N=256) / P15 / P16 / P17 / P19 / P21).
+* Full-stack ``k971_route_decision`` integration — every P22 admit cell
+  routes True through the 14-deep dispatch chain.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tritonblas._route_predicate import (
+    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30,
+    _k1513_p22_skinny_n32768_routeout,
+    _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT,
+    _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30,
+    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17,
+    _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29,
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT,
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
+    K971_ROUTE_TABLE,
+    _P8_MFMA_ISSUE_STALL_ROUTEOUT,
+    k971_route_decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# Frozenset shape pin (regression — must match the 3 × 1 × 5 × 2 bucket grid
+# exactly; 30/30 cells admit at the strict ratio_median ≥ 1.05 ∧ p(<1.05)
+# < 0.01 gate).
+# ---------------------------------------------------------------------------
+
+EXPECTED_ADMIT_30 = frozenset(
+    (M, 32768, K, dt)
+    for M in (2048, 4096, 8192)
+    for K in (2048, 4096, 8192, 16384, 32768)
+    for dt in ("torch.bfloat16", "torch.float16")
+)
+
+
+def test_frozenset_size_is_exactly_30():
+    assert len(_K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30) == 30
+
+
+def test_frozenset_matches_expected_admit_set():
+    assert _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30 == EXPECTED_ADMIT_30
+
+
+def test_every_admit_cell_in_sweep_grid():
+    for M, N, K, dtype_str in _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30:
+        assert M in (2048, 4096, 8192)
+        assert N == 32768
+        assert K in (2048, 4096, 8192, 16384, 32768)
+        assert dtype_str in ("torch.bfloat16", "torch.float16")
+
+
+# ---------------------------------------------------------------------------
+# Predicate behavior — admit cells (30 / 30 must return True).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("M,N,K,dtype_str", sorted(EXPECTED_ADMIT_30))
+def test_predicate_returns_true_for_admit_cell(M, N, K, dtype_str):
+    dtype = torch.bfloat16 if dtype_str == "torch.bfloat16" else torch.float16
+    assert _k1513_p22_skinny_n32768_routeout(M, N, K, dtype) is True
+
+
+# ---------------------------------------------------------------------------
+# Boundary controls — must NOT route via P22 (other predicates may catch
+# them — these checks are P22-local).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("M,N,K,dtype_str", [
+    (2048, 16384,  8192, "torch.bfloat16"),    # adjacent N=16384 — P19 territory
+    (2048,   256,  8192, "torch.bfloat16"),    # adjacent N=256 — P13 / P21 territory
+    (2048, 32768,  1024, "torch.bfloat16"),    # K=1024 — out of bucket
+    (2048, 32768, 65536, "torch.bfloat16"),    # K=65536 — out of bucket
+    (1024, 32768,  8192, "torch.bfloat16"),    # M=1024 — out of bucket
+    (16384, 32768, 8192, "torch.bfloat16"),    # M=16384 — out of bucket
+    (2048, 32768,  8192, "torch.float32"),     # dtype not in {bf16,fp16}
+])
+def test_predicate_returns_false_outside_bucket(M, N, K, dtype_str):
+    dtype = (torch.bfloat16 if dtype_str == "torch.bfloat16"
+             else torch.float16 if dtype_str == "torch.float16"
+             else torch.float32)
+    assert _k1513_p22_skinny_n32768_routeout(M, N, K, dtype) is False
+
+
+# ---------------------------------------------------------------------------
+# Disjointness firewalls vs the prior 13-predicate stack (sibling-N firewall:
+# every prior K-COMPLEMENT predicate uses N ∈ {128,256,512,1024,16384}; P12
+# is bounded to M=N=K ∈ {2048,4096}; P8/K971 cap at N ≤ 2048).  These are
+# also asserted at module load — duplicated here as belt-and-braces per
+# the K-1437 minimalist convention.
+# ---------------------------------------------------------------------------
+
+def test_disjoint_from_p8_mfma_envelope():
+    assert _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _P8_MFMA_ISSUE_STALL_ROUTEOUT)
+
+
+def test_disjoint_from_k971_route_table():
+    assert _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(K971_ROUTE_TABLE)
+
+
+def test_disjoint_from_k1361_p12_square_mid():
+    assert _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4)
+
+
+def test_disjoint_from_k1367_p13_skinny_n128():
+    assert _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18)
+
+
+def test_disjoint_from_k1397_p13_skinny_n256():
+    assert _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12)
+
+
+def test_disjoint_from_k1409_p15_skinny_n512_extremes():
+    assert _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT)
+
+
+def test_disjoint_from_k1429_p16_skinny_n1024():
+    assert _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29)
+
+
+def test_disjoint_from_k1437_p17_skinny_n512_kcompl_base():
+    assert _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17)
+
+
+def test_disjoint_from_k1478_p19_skinny_n16384():
+    """Sibling N-bucket on the K-COMPLEMENT N-ladder; different N column."""
+    assert _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30)
+
+
+def test_disjoint_from_k1503_p21_skinny_n256_kmid():
+    """Sibling N-bucket on the K-COMPLEMENT N-ladder; P21 lives at N=256."""
+    assert _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30.isdisjoint(
+        _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT)
+
+
+# ---------------------------------------------------------------------------
+# K-COMPLEMENT N-ladder coverage closure pin.  Combined with the prior
+# K-COMPLEMENT predicates, the N-axis now covers
+# N ∈ {128, 256, 512, 1024, 16384, 32768}.
+# ---------------------------------------------------------------------------
+
+def test_n_ladder_top_rung_covered():
+    """Every (M, K, dtype) of the K-1513 sweep grid must be admitted by P22
+    (top rung: N=32768 column on full K-grid, 30/30 admits)."""
+    for M in (2048, 4096, 8192):
+        for K in (2048, 4096, 8192, 16384, 32768):
+            for dt_str in ("torch.bfloat16", "torch.float16"):
+                assert (M, 32768, K, dt_str) in _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30
+
+
+# ---------------------------------------------------------------------------
+# Full-stack k971_route_decision integration — the 14-deep dispatch chain
+# must route every P22 admit cell to hipBLASLt with realistic production
+# tile dispatch flags (streamk=False, work_stealing=False, matched dtypes).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("M,N,K,dtype_str", sorted(EXPECTED_ADMIT_30))
+def test_full_dispatch_chain_routes_admit_cell_to_hbl(M, N, K, dtype_str):
+    dtype = torch.bfloat16 if dtype_str == "torch.bfloat16" else torch.float16
+    assert k971_route_decision(
+        M, N, K, dtype, dtype,
+        enable_streamk=False, work_stealing=False,
+    ) is True
+
+
+# ---------------------------------------------------------------------------
+# Streamk / work_stealing / dtype-mismatch carve-outs — the route-OUT must
+# defer to the in-kernel path when any of the carve-out conditions hold.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("enable_streamk,work_stealing", [
+    (True, False),
+    (False, True),
+    (True, True),
+])
+def test_full_dispatch_returns_false_with_streamk_or_work_stealing(
+    enable_streamk, work_stealing
+):
+    # Pick any admit cell.
+    dtype = torch.bfloat16
+    assert k971_route_decision(
+        4096, 32768, 8192, dtype, dtype,
+        enable_streamk=enable_streamk, work_stealing=work_stealing,
+    ) is False
+
+
+def test_full_dispatch_returns_false_with_mismatched_dtypes():
+    assert k971_route_decision(
+        4096, 32768, 8192, torch.bfloat16, torch.float16,
+        enable_streamk=False, work_stealing=False,
+    ) is False

--- a/tests/test_k1552_p23_skinny_n512_alias_stack.py
+++ b/tests/test_k1552_p23_skinny_n512_alias_stack.py
@@ -1,0 +1,135 @@
+"""Unit fixture — K-1552 P23 skinny_N512 K-COMPLEMENT 30-cell alias-stack
+route-OUT envelope (15th-position).
+
+Verifies:
+  (a) frozenset cardinality + exact admit-set match (K-1534 30 cells);
+  (b) every admit cell predicate-returns True;
+  (c) sibling-N firewall sentinels return False (carry-out N-axis carve-out);
+  (d) ALIAS-STACK invariant — every P23 cell is also routed by P15 ⨄ P17 ⨄ P5
+      (the slot is documentation/insurance, not a new admit);
+  (e) the public `k971_route_decision` dispatch returns True for every P23
+      cell at default flag values (no double-admit, no flag interference);
+  (f) carve-out negatives: streamk / work_stealing / dtype-mismatch all
+      veto routing.
+
+Source data: K-1534 paired n=30 HIP-graph hot-cache on MI300X / gfx942
+on MI300X / gfx942, TRITONBLAS_DISABLE_K971=1, B=10000 vectorised
+paired bootstrap; 30/30 admit at strict ratio_median ≥ 1.05 ∧
+p(<1.05) < 0.01 gate; cohort geomean tb/hbl = 1.454×, range 1.093×–2.111×.
+"""
+import pytest
+import torch
+
+from tritonblas._route_predicate import (
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT,
+    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17,
+    _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30,
+    _k1552_p23_skinny_n512_kcompl_aliasstack_routeout,
+    R_K979_P5_route_to_hbl,
+    k971_route_decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# (a) frozenset shape pin — 30 cells, exact M/N/K/dtype grid.
+# ---------------------------------------------------------------------------
+def test_p23_cardinality_is_thirty():
+    assert len(_K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30) == 30
+
+
+def test_p23_admit_set_is_full_n512_kcompl_grid():
+    expected = {
+        (M, 512, K, dtype)
+        for M in (2048, 4096, 8192)
+        for K in (2048, 4096, 8192, 16384, 32768)
+        for dtype in ("torch.bfloat16", "torch.float16")
+    }
+    assert _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30 == expected
+
+
+# ---------------------------------------------------------------------------
+# (b) every admit cell predicate-returns True.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("cell", sorted(_K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30))
+def test_p23_admit_cell_routes_true(cell):
+    M, N, K, dtype = cell
+    assert _k1552_p23_skinny_n512_kcompl_aliasstack_routeout(M, N, K, dtype) is True
+
+
+# ---------------------------------------------------------------------------
+# (c) sibling-N firewall sentinels return False — adjacent N buckets, K
+#     outside grid, M outside bucket, fp32 carve-out.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cell",
+    [
+        (2048, 256, 2048, "torch.bfloat16"),    # adjacent N=256
+        (2048, 1024, 2048, "torch.bfloat16"),   # adjacent N=1024
+        (2048, 16384, 2048, "torch.bfloat16"),  # P19 N=16384
+        (2048, 32768, 2048, "torch.bfloat16"),  # P22 N=32768
+        (2048, 512, 1024, "torch.bfloat16"),    # K outside grid (1024)
+        (1024, 512, 2048, "torch.bfloat16"),    # M outside bucket (1024)
+        (2048, 512, 2048, "torch.float32"),     # fp32 carve-out
+    ],
+)
+def test_p23_sibling_n_firewall_rejects(cell):
+    M, N, K, dtype = cell
+    assert _k1552_p23_skinny_n512_kcompl_aliasstack_routeout(M, N, K, dtype) is False
+
+
+# ---------------------------------------------------------------------------
+# (d) ALIAS-STACK invariant — every P23 cell is also routed by P15 ⨄ P17 ⨄ P5.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("cell", sorted(_K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30))
+def test_p23_alias_stack_covered_by_p15_p17_or_p5(cell):
+    M, N, K, dtype = cell
+    in_p15 = cell in _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT
+    in_p17 = cell in _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17
+    in_p5 = R_K979_P5_route_to_hbl(M, N, K, dtype)
+    assert in_p15 or in_p17 or in_p5, (
+        f"P23 alias-stack cell {cell} not covered by P15 ⨄ P17 ⨄ P5; "
+        "alias invariant violated.")
+
+
+# ---------------------------------------------------------------------------
+# (e) full-stack dispatch — every admit cell routes True via k971_route_decision
+#     at default flag values (streamk=False, work_stealing=False, dtype matched).
+# ---------------------------------------------------------------------------
+_DTYPE_OBJ = {"torch.bfloat16": torch.bfloat16, "torch.float16": torch.float16}
+
+
+@pytest.mark.parametrize("cell", sorted(_K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30))
+def test_p23_full_dispatch_routes_true(cell):
+    M, N, K, dtype = cell
+    a = _DTYPE_OBJ[dtype]
+    assert k971_route_decision(
+        M, N, K, a_dtype=a, b_dtype=a,
+        enable_streamk=False, work_stealing=False,
+    ) is True
+
+
+# ---------------------------------------------------------------------------
+# (f) carve-out negatives — streamk / work_stealing / dtype-mismatch all veto.
+# ---------------------------------------------------------------------------
+def test_p23_streamk_vetoes_routing():
+    assert k971_route_decision(
+        2048, 512, 8192,
+        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
+        enable_streamk=True, work_stealing=False,
+    ) is False
+
+
+def test_p23_work_stealing_vetoes_routing():
+    assert k971_route_decision(
+        2048, 512, 8192,
+        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
+        enable_streamk=False, work_stealing=True,
+    ) is False
+
+
+def test_p23_dtype_mismatch_vetoes_routing():
+    assert k971_route_decision(
+        2048, 512, 8192,
+        a_dtype=torch.bfloat16, b_dtype=torch.float16,
+        enable_streamk=False, work_stealing=False,
+    ) is False

--- a/tests/test_k1553_p25_skinny_n4096_alias_stack.py
+++ b/tests/test_k1553_p25_skinny_n4096_alias_stack.py
@@ -1,0 +1,175 @@
+"""Unit fixture — K-1553 P25 skinny_N4096 K-COMPLEMENT 30-cell alias-stack
+route-OUT envelope (17th-position).
+
+Verifies:
+  (a) frozenset cardinality + exact admit-set match (K-1553 30 cells);
+  (b) every admit cell predicate-returns True;
+  (c) sibling-N firewall sentinels return False (carry-out N-axis carve-out);
+  (d) ALIAS-STACK invariant — every P25 cell is also routed by P24 ⨄ P12
+      (the slot is documentation/insurance, not a new admit);
+  (e) PARENT-MEASUREMENT-EQUIVALENCE — P25 frozenset is exactly equal to
+      K-1566 P24 frozenset (P25 is the K-1553-named alias of P24 over the
+      same 30-cell admit set);
+  (f) the public `k971_route_decision` dispatch returns True for every P25
+      cell at default flag values (no double-admit, no flag interference);
+  (g) carve-out negatives: streamk / work_stealing / dtype-mismatch all
+      veto routing.
+
+Source data: K-1553 paired n=30 HIP-graph hot-cache on MI300X / gfx942
+(combined with K-1559 60-cell mid-band N ∈ {4096, 8192} confirmation),
+TRITONBLAS_DISABLE_K971=1, B=10000 vectorised paired bootstrap against
+the live post-K-1532 routing oracle (HEAD 95e2c47); 30/30 admit at strict
+ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01 gate; cohort geomean tb/hbl =
+1.234×, range 1.114×-1.501×, 0 regressions.
+"""
+import pytest
+import torch
+
+from tritonblas._route_predicate import (
+    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
+    _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30,
+    _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30,
+    _k1553_p25_skinny_n4096_kcompl_aliasstack_routeout,
+    k971_route_decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# (a) frozenset shape pin — 30 cells, exact M/N/K/dtype grid.
+# ---------------------------------------------------------------------------
+def test_p25_cardinality_is_thirty():
+    assert len(_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30) == 30
+
+
+def test_p25_admit_set_is_full_n4096_kcompl_grid():
+    expected = {
+        (M, 4096, K, dtype)
+        for M in (2048, 4096, 8192)
+        for K in (2048, 4096, 8192, 16384, 32768)
+        for dtype in ("torch.bfloat16", "torch.float16")
+    }
+    assert _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30 == expected
+
+
+# ---------------------------------------------------------------------------
+# (b) every admit cell predicate-returns True.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cell", sorted(_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30)
+)
+def test_p25_admit_cell_routes_true(cell):
+    M, N, K, dtype = cell
+    assert _k1553_p25_skinny_n4096_kcompl_aliasstack_routeout(M, N, K, dtype) is True
+
+
+# ---------------------------------------------------------------------------
+# (c) sibling-N firewall sentinels return False — adjacent N buckets, K
+#     outside grid, M outside bucket, fp32 carve-out.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cell",
+    [
+        (2048,   512, 2048, "torch.bfloat16"),  # P15/P17/P23 N=512
+        (2048,  1024, 2048, "torch.bfloat16"),  # P16 N=1024
+        (2048,  2048, 2048, "torch.bfloat16"),  # K971/P12 N=2048
+        (2048,  8192, 2048, "torch.bfloat16"),  # adjacent N=8192
+        (2048, 16384, 2048, "torch.bfloat16"),  # P19 N=16384
+        (2048, 32768, 2048, "torch.bfloat16"),  # P22 N=32768
+        (2048,  4096, 1024, "torch.bfloat16"),  # K outside grid (1024)
+        (2048,  4096, 6144, "torch.bfloat16"),  # K outside grid (6144)
+        (1024,  4096, 2048, "torch.bfloat16"),  # M outside bucket (1024)
+        (16384, 4096, 2048, "torch.bfloat16"),  # M outside bucket (16384)
+        (2048,  4096, 2048, "torch.float32"),   # fp32 carve-out
+    ],
+)
+def test_p25_sibling_n_firewall_rejects(cell):
+    M, N, K, dtype = cell
+    assert _k1553_p25_skinny_n4096_kcompl_aliasstack_routeout(M, N, K, dtype) is False
+
+
+# ---------------------------------------------------------------------------
+# (d) ALIAS-STACK invariant — every P25 cell is also routed by P24 ⨄ P12.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cell", sorted(_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30)
+)
+def test_p25_alias_stack_covered_by_p24_or_p12(cell):
+    in_p24 = cell in _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
+    in_p12 = cell in _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
+    assert in_p24 or in_p12, (
+        f"P25 alias-stack cell {cell} not covered by P24 ⨄ P12; "
+        "alias invariant violated.")
+
+
+def test_p25_alias_overlap_with_p12_is_exactly_two_diagonal_cells():
+    """K-1295 P12 covers (4096,4096,4096,{bf16,fp16}) on the diagonal; the
+    P25 envelope shares exactly those 2 cells with P12 (and the remaining 28
+    are sibling-N-firewall disjoint with P12)."""
+    overlap = (
+        _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30
+        & _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
+    )
+    assert overlap == frozenset({
+        (4096, 4096, 4096, "torch.bfloat16"),
+        (4096, 4096, 4096, "torch.float16"),
+    })
+
+
+# ---------------------------------------------------------------------------
+# (e) PARENT-MEASUREMENT-EQUIVALENCE — P25 frozenset == K-1566 P24 frozenset.
+# ---------------------------------------------------------------------------
+def test_p25_equals_p24_frozenset():
+    """P25 is the K-1553-named alias of K-1566 P24 over the same 30-cell
+    admit set; frozensets must be exactly equal.  Deviation indicates
+    either (i) P24 contracted, or (ii) P25 was authored against a different
+    K-1553 sub-set than the K-1566 productionization."""
+    assert (
+        _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30
+        == _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
+    )
+
+
+# ---------------------------------------------------------------------------
+# (f) full-stack dispatch — every admit cell routes True via k971_route_decision
+#     at default flag values (streamk=False, work_stealing=False, dtype matched).
+# ---------------------------------------------------------------------------
+_DTYPE_OBJ = {"torch.bfloat16": torch.bfloat16, "torch.float16": torch.float16}
+
+
+@pytest.mark.parametrize(
+    "cell", sorted(_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30)
+)
+def test_p25_full_dispatch_routes_true(cell):
+    M, N, K, dtype = cell
+    a = _DTYPE_OBJ[dtype]
+    assert k971_route_decision(
+        M, N, K, a_dtype=a, b_dtype=a,
+        enable_streamk=False, work_stealing=False,
+    ) is True
+
+
+# ---------------------------------------------------------------------------
+# (g) carve-out negatives — streamk / work_stealing / dtype-mismatch all veto.
+# ---------------------------------------------------------------------------
+def test_p25_streamk_vetoes_routing():
+    assert k971_route_decision(
+        2048, 4096, 8192,
+        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
+        enable_streamk=True, work_stealing=False,
+    ) is False
+
+
+def test_p25_work_stealing_vetoes_routing():
+    assert k971_route_decision(
+        2048, 4096, 8192,
+        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
+        enable_streamk=False, work_stealing=True,
+    ) is False
+
+
+def test_p25_dtype_mismatch_vetoes_routing():
+    assert k971_route_decision(
+        2048, 4096, 8192,
+        a_dtype=torch.bfloat16, b_dtype=torch.float16,
+        enable_streamk=False, work_stealing=False,
+    ) is False

--- a/tests/test_k1553_p25_skinny_n4096_alias_stack.py
+++ b/tests/test_k1553_p25_skinny_n4096_alias_stack.py
@@ -1,47 +1,72 @@
-"""Unit fixture — K-1553 P25 skinny_N4096 K-COMPLEMENT 30-cell alias-stack
-route-OUT envelope (17th-position).
+"""Unit fixture — K-1553 P25 skinny_N4096 K-COMPLEMENT 30-cell alias handle.
 
-Verifies:
-  (a) frozenset cardinality + exact admit-set match (K-1553 30 cells);
-  (b) every admit cell predicate-returns True;
-  (c) sibling-N firewall sentinels return False (carry-out N-axis carve-out);
-  (d) ALIAS-STACK invariant — every P25 cell is also routed by P24 ⨄ P12
-      (the slot is documentation/insurance, not a new admit);
-  (e) PARENT-MEASUREMENT-EQUIVALENCE — P25 frozenset is exactly equal to
-      K-1566 P24 frozenset (P25 is the K-1553-named alias of P24 over the
-      same 30-cell admit set);
-  (f) the public `k971_route_decision` dispatch returns True for every P25
-      cell at default flag values (no double-admit, no flag interference);
-  (g) carve-out negatives: streamk / work_stealing / dtype-mismatch all
-      veto routing.
+After the K-1581 minimalist refactor (per The Minimalist's REVISE feedback
+on the prior duplicate-frozenset attempt, and following the K-1489
+reviewer-consensus precedent for unreachable alias slots), the K-1553-named
+17th-slot handle is exposed in `_route_predicate.py` as a single
+module-level alias of the K-1566 P24 frozenset rather than as a duplicate
+frozenset + asserts + predicate function:
 
-Source data: K-1553 paired n=30 HIP-graph hot-cache on MI300X / gfx942
-(combined with K-1559 60-cell mid-band N ∈ {4096, 8192} confirmation),
-TRITONBLAS_DISABLE_K971=1, B=10000 vectorised paired bootstrap against
-the live post-K-1532 routing oracle (HEAD 95e2c47); 30/30 admit at strict
-ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01 gate; cohort geomean tb/hbl =
-1.234×, range 1.114×-1.501×, 0 regressions.
+    _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30 = _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
+
+This fixture verifies the alias relationship and the transitive routing
+contract — i.e. that every K-1553 admit cell still dispatches to hipBLASLt
+via the load-bearing P24 predicate (so the alias remains a faithful audit
+handle for the K-1553 30-cell envelope), and that the alias is
+identity-equal (not merely value-equal) so any future reassignment of
+either symbol is caught at module load.
+
+Source measurement (still-of-record): K-1553 paired n=30 HIP-graph
+hot-cache on MI300X / gfx942 (combined with K-1559 60-cell mid-band
+N ∈ {4096, 8192} confirmation), TRITONBLAS_DISABLE_K971=1, B=10000
+vectorised paired bootstrap against the live post-K-1532 routing oracle
+(HEAD 95e2c47); 30/30 admit at strict ratio_median ≥ 1.05 ∧ p(<1.05) <
+0.01 gate; cohort geomean tb/hbl = 1.234×, range 1.114×-1.501×, 0
+regressions.  K-1566 P24 productionised the same envelope as the
+load-bearing 16th-slot route-OUT.
 """
 import pytest
-import torch
 
 from tritonblas._route_predicate import (
     _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
     _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30,
     _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30,
-    _k1553_p25_skinny_n4096_kcompl_aliasstack_routeout,
     k971_route_decision,
 )
 
 
 # ---------------------------------------------------------------------------
-# (a) frozenset shape pin — 30 cells, exact M/N/K/dtype grid.
+# (a) ALIAS IDENTITY — `_K1553_P25_...` is the same Python object as
+#     `_K1566_P24_...`, not merely a value-equal copy.  Identity (rather
+#     than equality) catches a future maintainer accidentally rebinding
+#     P25 to a different frozenset literal that happens to be value-equal
+#     today but could drift apart later.
 # ---------------------------------------------------------------------------
-def test_p25_cardinality_is_thirty():
+def test_p25_is_identity_alias_of_p24():
+    assert (
+        _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30
+        is _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
+    ), (
+        "K-1553 P25 17th-slot handle must be a Python identity alias of "
+        "K-1566 P24 (same frozenset object), not a value-equal copy.  "
+        "Per the K-1581 minimalist refactor, the K-1553-named handle is a "
+        "single module-level rebinding of P24's frozenset; if this "
+        "identity check fails, P25 has been re-authored as a duplicate "
+        "literal — either restore the alias or document why P25 has "
+        "diverged from P24 with paired n=30 evidence."
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) ALIAS CARDINALITY — transitively inherited from P24 but pinned here
+#     so a P24 contraction (which would also contract the K-1553 admit
+#     handle) trips a K-1553-named test failure as well as a K-1566 one.
+# ---------------------------------------------------------------------------
+def test_p25_alias_resolves_to_thirty_cells():
     assert len(_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30) == 30
 
 
-def test_p25_admit_set_is_full_n4096_kcompl_grid():
+def test_p25_alias_covers_full_n4096_kcompl_grid():
     expected = {
         (M, 4096, K, dtype)
         for M in (2048, 4096, 8192)
@@ -52,59 +77,44 @@ def test_p25_admit_set_is_full_n4096_kcompl_grid():
 
 
 # ---------------------------------------------------------------------------
-# (b) every admit cell predicate-returns True.
+# (c) ROUTING CONTRACT — every K-1553 admit cell still dispatches to
+#     hipBLASLt via the public `k971_route_decision`, carried by the
+#     load-bearing P24 predicate at the 16th slot.  This is what the
+#     K-1553 audit handle ultimately asserts about runtime behaviour.
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
     "cell", sorted(_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30)
 )
-def test_p25_admit_cell_routes_true(cell):
+def test_p25_admit_cell_routes_to_hbl(cell):
     M, N, K, dtype = cell
-    assert _k1553_p25_skinny_n4096_kcompl_aliasstack_routeout(M, N, K, dtype) is True
+    assert (
+        k971_route_decision(
+            M, N, K, dtype, dtype,
+            enable_streamk=False, work_stealing=False,
+            disable_env_set=False,
+        )
+        is True
+    ), f"K-1553 admit cell {cell} failed to dispatch to hipBLASLt via P24."
 
 
 # ---------------------------------------------------------------------------
-# (c) sibling-N firewall sentinels return False — adjacent N buckets, K
-#     outside grid, M outside bucket, fp32 carve-out.
+# (d) ALIAS-COVERAGE INVARIANT — every K-1553 cell must be in P24 ⨄ P12
+#     (trivially true while the alias holds, but pinned explicitly so
+#     reviewer-relevant invariants stay self-documenting).
 # ---------------------------------------------------------------------------
-@pytest.mark.parametrize(
-    "cell",
-    [
-        (2048,   512, 2048, "torch.bfloat16"),  # P15/P17/P23 N=512
-        (2048,  1024, 2048, "torch.bfloat16"),  # P16 N=1024
-        (2048,  2048, 2048, "torch.bfloat16"),  # K971/P12 N=2048
-        (2048,  8192, 2048, "torch.bfloat16"),  # adjacent N=8192
-        (2048, 16384, 2048, "torch.bfloat16"),  # P19 N=16384
-        (2048, 32768, 2048, "torch.bfloat16"),  # P22 N=32768
-        (2048,  4096, 1024, "torch.bfloat16"),  # K outside grid (1024)
-        (2048,  4096, 6144, "torch.bfloat16"),  # K outside grid (6144)
-        (1024,  4096, 2048, "torch.bfloat16"),  # M outside bucket (1024)
-        (16384, 4096, 2048, "torch.bfloat16"),  # M outside bucket (16384)
-        (2048,  4096, 2048, "torch.float32"),   # fp32 carve-out
-    ],
-)
-def test_p25_sibling_n_firewall_rejects(cell):
-    M, N, K, dtype = cell
-    assert _k1553_p25_skinny_n4096_kcompl_aliasstack_routeout(M, N, K, dtype) is False
+def test_p25_cells_covered_by_p24_union_p12():
+    union = (
+        _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
+        | _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
+    )
+    uncovered = _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30 - union
+    assert not uncovered, (
+        f"K-1553 P25 alias has {len(uncovered)} cells not covered by "
+        f"P24 ⨄ P12: {sorted(uncovered)}"
+    )
 
 
-# ---------------------------------------------------------------------------
-# (d) ALIAS-STACK invariant — every P25 cell is also routed by P24 ⨄ P12.
-# ---------------------------------------------------------------------------
-@pytest.mark.parametrize(
-    "cell", sorted(_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30)
-)
-def test_p25_alias_stack_covered_by_p24_or_p12(cell):
-    in_p24 = cell in _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
-    in_p12 = cell in _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
-    assert in_p24 or in_p12, (
-        f"P25 alias-stack cell {cell} not covered by P24 ⨄ P12; "
-        "alias invariant violated.")
-
-
-def test_p25_alias_overlap_with_p12_is_exactly_two_diagonal_cells():
-    """K-1295 P12 covers (4096,4096,4096,{bf16,fp16}) on the diagonal; the
-    P25 envelope shares exactly those 2 cells with P12 (and the remaining 28
-    are sibling-N-firewall disjoint with P12)."""
+def test_p25_p12_alias_overlap_is_exactly_two_cells():
     overlap = (
         _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30
         & _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
@@ -112,64 +122,36 @@ def test_p25_alias_overlap_with_p12_is_exactly_two_diagonal_cells():
     assert overlap == frozenset({
         (4096, 4096, 4096, "torch.bfloat16"),
         (4096, 4096, 4096, "torch.float16"),
-    })
-
-
-# ---------------------------------------------------------------------------
-# (e) PARENT-MEASUREMENT-EQUIVALENCE — P25 frozenset == K-1566 P24 frozenset.
-# ---------------------------------------------------------------------------
-def test_p25_equals_p24_frozenset():
-    """P25 is the K-1553-named alias of K-1566 P24 over the same 30-cell
-    admit set; frozensets must be exactly equal.  Deviation indicates
-    either (i) P24 contracted, or (ii) P25 was authored against a different
-    K-1553 sub-set than the K-1566 productionization."""
-    assert (
-        _K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30
-        == _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
+    }), (
+        "K-1553 P25 ∩ P12 must be exactly the (4096, 4096, 4096, "
+        "{bf16, fp16}) diagonal pair (K-1295 P12 PMC-square-mid alias); "
+        f"observed overlap: {sorted(overlap)}"
     )
 
 
 # ---------------------------------------------------------------------------
-# (f) full-stack dispatch — every admit cell routes True via k971_route_decision
-#     at default flag values (streamk=False, work_stealing=False, dtype matched).
+# (e) CARVE-OUT NEGATIVES — streamk / work_stealing / dtype-mismatch must
+#     short-circuit routing OFF even on K-1553 admit cells.
 # ---------------------------------------------------------------------------
-_DTYPE_OBJ = {"torch.bfloat16": torch.bfloat16, "torch.float16": torch.float16}
-
-
 @pytest.mark.parametrize(
-    "cell", sorted(_K1553_P25_SKINNY_N4096_KCOMPL_ALIASSTACK_30)
+    "kwargs",
+    [
+        {"enable_streamk": True,  "work_stealing": False},
+        {"enable_streamk": False, "work_stealing": True},
+    ],
+    ids=["streamk_on", "work_stealing_on"],
 )
-def test_p25_full_dispatch_routes_true(cell):
+def test_p25_admit_cell_carved_out_by_flags(kwargs):
+    cell = (2048, 4096, 4096, "torch.bfloat16")  # canonical K-1553 admit
     M, N, K, dtype = cell
-    a = _DTYPE_OBJ[dtype]
     assert k971_route_decision(
-        M, N, K, a_dtype=a, b_dtype=a,
-        enable_streamk=False, work_stealing=False,
-    ) is True
-
-
-# ---------------------------------------------------------------------------
-# (g) carve-out negatives — streamk / work_stealing / dtype-mismatch all veto.
-# ---------------------------------------------------------------------------
-def test_p25_streamk_vetoes_routing():
-    assert k971_route_decision(
-        2048, 4096, 8192,
-        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
-        enable_streamk=True, work_stealing=False,
+        M, N, K, dtype, dtype, disable_env_set=False, **kwargs,
     ) is False
 
 
-def test_p25_work_stealing_vetoes_routing():
+def test_p25_admit_cell_carved_out_by_dtype_mismatch():
+    M, N, K = 2048, 4096, 4096
     assert k971_route_decision(
-        2048, 4096, 8192,
-        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
-        enable_streamk=False, work_stealing=True,
-    ) is False
-
-
-def test_p25_dtype_mismatch_vetoes_routing():
-    assert k971_route_decision(
-        2048, 4096, 8192,
-        a_dtype=torch.bfloat16, b_dtype=torch.float16,
-        enable_streamk=False, work_stealing=False,
+        M, N, K, "torch.bfloat16", "torch.float16",
+        enable_streamk=False, work_stealing=False, disable_env_set=False,
     ) is False

--- a/tests/test_k1566_p24_skinny_n4096_routeout.py
+++ b/tests/test_k1566_p24_skinny_n4096_routeout.py
@@ -1,0 +1,171 @@
+"""Unit fixture — K-1566 P24 skinny_N4096 K-COMPLEMENT 30-cell route-OUT
+envelope (16th-position).
+
+Verifies:
+  (a) frozenset cardinality + exact admit-set match (K-1553 30 cells);
+  (b) every admit cell predicate-returns True;
+  (c) sibling-N firewall sentinels return False (carry-out N-axis carve-out);
+  (d) sibling-N firewall vs every prior K-COMPLEMENT frozenset is
+      disjoint EXCEPT the intentional 2-cell P12 alias overlap at
+      (4096, 4096, 4096, {bf16, fp16});
+  (e) the public `k971_route_decision` dispatch returns True for every P24
+      cell at default flag values (no double-admit, no flag interference);
+  (f) carve-out negatives: streamk / work_stealing / dtype-mismatch all
+      veto routing.
+
+Source data: K-1553 paired n=30 HIP-graph hot-cache on MI300X / gfx942
+(OCI amd-rccl MI300X-equivalent fallback per INFRA-0048), TRITONBLAS_DISABLE_K971=1
+against the live post-K-1532 routing oracle; B=10000 vectorised paired
+bootstrap; 30/30 admit at strict ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01
+gate; cohort geomean tb/hbl = 1.234×, range 1.114×-1.501×.
+"""
+import pytest
+import torch
+
+from tritonblas._route_predicate import (
+    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+    _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT,
+    _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29,
+    _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17,
+    _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30,
+    _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT,
+    _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30,
+    _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30,
+    _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30,
+    _k1566_p24_skinny_n4096_routeout,
+    k971_route_decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# (a) frozenset shape pin — 30 cells, exact M/N/K/dtype grid.
+# ---------------------------------------------------------------------------
+def test_p24_cardinality_is_thirty():
+    assert len(_K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30) == 30
+
+
+def test_p24_admit_set_is_full_n4096_kcompl_grid():
+    expected = {
+        (M, 4096, K, dtype)
+        for M in (2048, 4096, 8192)
+        for K in (2048, 4096, 8192, 16384, 32768)
+        for dtype in ("torch.bfloat16", "torch.float16")
+    }
+    assert _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30 == expected
+
+
+# ---------------------------------------------------------------------------
+# (b) every admit cell predicate-returns True.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("cell", sorted(_K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30))
+def test_p24_admit_cell_routes_true(cell):
+    M, N, K, dtype = cell
+    assert _k1566_p24_skinny_n4096_routeout(M, N, K, dtype) is True
+
+
+# ---------------------------------------------------------------------------
+# (c) sibling-N firewall sentinels return False — adjacent N buckets, K
+#     outside grid, M outside bucket, fp32 carve-out.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cell",
+    [
+        (2048,   128, 2048, "torch.bfloat16"),  # P13 N=128
+        (2048,   256, 2048, "torch.bfloat16"),  # P13/P21 N=256
+        (2048,   512, 2048, "torch.bfloat16"),  # P15/P17/P23 N=512
+        (2048,  1024, 2048, "torch.bfloat16"),  # P16 N=1024
+        (2048, 16384, 2048, "torch.bfloat16"),  # P19 N=16384
+        (2048, 32768, 2048, "torch.bfloat16"),  # P22 N=32768
+        (2048,  4096, 1024, "torch.bfloat16"),  # K outside grid (1024)
+        (2048,  4096, 1536, "torch.bfloat16"),  # K outside grid (1536)
+        (1024,  4096, 2048, "torch.bfloat16"),  # M outside bucket (1024)
+        (3072,  4096, 2048, "torch.bfloat16"),  # M outside bucket (3072)
+        (2048,  4096, 2048, "torch.float32"),   # fp32 carve-out
+    ],
+)
+def test_p24_sibling_n_firewall_rejects(cell):
+    M, N, K, dtype = cell
+    assert _k1566_p24_skinny_n4096_routeout(M, N, K, dtype) is False
+
+
+# ---------------------------------------------------------------------------
+# (d) sibling-N firewall vs every prior K-COMPLEMENT frozenset is disjoint
+#     EXCEPT the intentional 2-cell P12 alias overlap.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "name,sibling",
+    [
+        ("P13_N128",       _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18),
+        ("P13_N256",       _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12),
+        ("P15_N512",       _K1409_P15_SKINNY_N512_KCOMPL_ROUTEOUT),
+        ("P16_N1024",      _K1429_P16_SKINNY_N1024_KCOMPL_ROUTEOUT_29),
+        ("P17_N512_BASE",  _K1437_P17_SKINNY_N512_KCOMPL_BASE_ROUTEOUT_17),
+        ("P19_N16384",     _K1478_P19_SKINNY_N16384_KCOMPL_ROUTEOUT_30),
+        ("P21_N256_Kmid",  _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT),
+        ("P22_N32768",     _K1513_P22_SKINNY_N32768_KCOMPL_ROUTEOUT_30),
+        ("P23_N512_alias", _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30),
+    ],
+)
+def test_p24_sibling_n_firewall_is_disjoint(name, sibling):
+    assert _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30.isdisjoint(sibling), (
+        f"K-1566 P24 must be disjoint with {name}; only the K-1295 P12 "
+        "diagonal is permitted to alias the N=4096 column.")
+
+
+def test_p24_p12_alias_overlap_is_exactly_two_cells():
+    """P12 alias overlap is the SINGLE permitted intersection; must be
+    EXACTLY {(4096,4096,4096,bf16), (4096,4096,4096,fp16)}."""
+    overlap = (
+        _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30
+        & _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
+    )
+    assert overlap == frozenset({
+        (4096, 4096, 4096, "torch.bfloat16"),
+        (4096, 4096, 4096, "torch.float16"),
+    })
+
+
+# ---------------------------------------------------------------------------
+# (e) full-stack dispatch — every admit cell routes True via k971_route_decision
+#     at default flag values (streamk=False, work_stealing=False, dtype matched).
+# ---------------------------------------------------------------------------
+_DTYPE_OBJ = {"torch.bfloat16": torch.bfloat16, "torch.float16": torch.float16}
+
+
+@pytest.mark.parametrize("cell", sorted(_K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30))
+def test_p24_full_dispatch_routes_true(cell):
+    M, N, K, dtype = cell
+    a = _DTYPE_OBJ[dtype]
+    assert k971_route_decision(
+        M, N, K, a_dtype=a, b_dtype=a,
+        enable_streamk=False, work_stealing=False,
+    ) is True
+
+
+# ---------------------------------------------------------------------------
+# (f) carve-out negatives — streamk / work_stealing / dtype-mismatch all veto.
+# ---------------------------------------------------------------------------
+def test_p24_streamk_vetoes_routing():
+    assert k971_route_decision(
+        2048, 4096, 8192,
+        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
+        enable_streamk=True, work_stealing=False,
+    ) is False
+
+
+def test_p24_work_stealing_vetoes_routing():
+    assert k971_route_decision(
+        2048, 4096, 8192,
+        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
+        enable_streamk=False, work_stealing=True,
+    ) is False
+
+
+def test_p24_dtype_mismatch_vetoes_routing():
+    assert k971_route_decision(
+        2048, 4096, 8192,
+        a_dtype=torch.bfloat16, b_dtype=torch.float16,
+        enable_streamk=False, work_stealing=False,
+    ) is False

--- a/tests/test_k1611_p26_skinny_n2048_alias_stack.py
+++ b/tests/test_k1611_p26_skinny_n2048_alias_stack.py
@@ -1,0 +1,245 @@
+"""Unit fixture — K-1611 P26 skinny_N2048 K-COMPLEMENT 30-cell alias-stack
+17th-position route-OUT.
+
+Productionizes the K-1611 verification of the N=2048 K-COMPLEMENT envelope
+(M ∈ {2048, 4096, 8192} × N=2048 × K ∈ {2048, 4096, 8192, 16384, 32768} ×
+{bf16, fp16}) as the 17th stacked frozenset, closing the LAST untested
+mid-N rung of the K-COMPLEMENT N-ladder.  Coverage now spans the full
+verified N range {128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768}.
+
+Source measurement (still-of-record): K-1611 paired n=30 HIP-graph
+hot-cache on MI300X / gfx942 (c42 partition), TRITONBLAS_DISABLE_K971=1,
+B=10000 vectorised paired bootstrap against the live post-K-1581 routing
+oracle; 30/30 admit at strict ratio_median ≥ 1.05 ∧ p(<1.05) < 0.01 gate;
+cohort geomean tb/hbl = 1.451×, range 1.108×-1.853×, 0 regressions.
+
+ALIAS-STACK structure: 22 NEW route-OUT cells + 8 alias cells (2 P12 at
+the (2048, 2048, 2048, {bf16, fp16}) diagonal + 6 K971_ROUTE_TABLE union:
+4 K-905/K-971 LDS-BC anchors at K∈{16384, 32768} ∪ 2 K-1335
+longK_smallSquare bf16 cells at K∈{4096, 8192}).  Alias overlaps fire
+BEFORE P26 in the dispatch chain so the 8 alias cells are unreachable
+under normal dispatch — load-bearing only if any of the upstream layers
+(P12, K971, K1335) is ablated.
+"""
+import pytest
+
+from tritonblas._route_predicate import (
+    _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4,
+    _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4,
+    _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30,
+    _K1611_P26_NEW_ROUTEOUT_22,
+    _K1611_P26_VS_K1335_ALIAS_OVERLAP,
+    _K1611_P26_VS_K971_ALIAS_OVERLAP,
+    _K1611_P26_VS_P12_ALIAS_OVERLAP,
+    _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30,
+    K971_ROUTE_TABLE,
+    _k1611_p26_skinny_n2048_kcompl_aliasstack_routeout,
+    k971_route_decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# (a) CARDINALITY — pinned to 30 cells (the K-1611 envelope: M ∈ {2048,
+#     4096, 8192} × N=2048 × K ∈ {2048, 4096, 8192, 16384, 32768} × {bf16,
+#     fp16}).  Any deviation indicates an authoring typo against the
+#     K-1611 paired n=30 admit set.
+# ---------------------------------------------------------------------------
+def test_p26_admit_set_cardinality_is_thirty():
+    assert len(_K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30) == 30
+
+
+def test_p26_admit_set_covers_full_n2048_kcompl_grid():
+    expected = {
+        (M, 2048, K, dtype)
+        for M in (2048, 4096, 8192)
+        for K in (2048, 4096, 8192, 16384, 32768)
+        for dtype in ("torch.bfloat16", "torch.float16")
+    }
+    assert _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30 == expected
+
+
+# ---------------------------------------------------------------------------
+# (b) ALIAS-OVERLAP STRUCTURE — pinned at exactly 8 alias cells across 3
+#     upstream predicates.  Future contractions of any upstream predicate
+#     must trip these tests so the K-1611 NEW route-OUT contribution is
+#     re-audited.
+# ---------------------------------------------------------------------------
+def test_p26_p12_alias_overlap_is_exactly_two_cells():
+    assert _K1611_P26_VS_P12_ALIAS_OVERLAP == frozenset({
+        (2048, 2048, 2048, "torch.bfloat16"),
+        (2048, 2048, 2048, "torch.float16"),
+    })
+
+
+def test_p26_k1335_alias_overlap_is_exactly_two_cells():
+    assert _K1611_P26_VS_K1335_ALIAS_OVERLAP == frozenset({
+        (2048, 2048, 4096, "torch.bfloat16"),
+        (2048, 2048, 8192, "torch.bfloat16"),
+    })
+
+
+def test_p26_k971_alias_overlap_is_exactly_six_cells():
+    assert _K1611_P26_VS_K971_ALIAS_OVERLAP == frozenset({
+        (2048, 2048, 16384, "torch.bfloat16"),
+        (2048, 2048, 16384, "torch.float16"),
+        (2048, 2048, 32768, "torch.bfloat16"),
+        (2048, 2048, 32768, "torch.float16"),
+        (2048, 2048,  4096, "torch.bfloat16"),
+        (2048, 2048,  8192, "torch.bfloat16"),
+    })
+
+
+def test_p26_new_routeout_contribution_is_exactly_twenty_two():
+    assert len(_K1611_P26_NEW_ROUTEOUT_22) == 22
+    # All 22 NEW cells must have M >= 4096 OR be the fp16 K-1335 siblings.
+    for cell in _K1611_P26_NEW_ROUTEOUT_22:
+        M, N, K, dtype = cell
+        assert N == 2048
+        is_m_ge_4096 = M >= 4096
+        is_k1335_fp16_sibling = (
+            M == 2048
+            and K in (4096, 8192)
+            and dtype == "torch.float16"
+        )
+        assert is_m_ge_4096 or is_k1335_fp16_sibling, (
+            f"K-1611 P26 NEW route-OUT cell {cell} fails alias-stack "
+            "decomposition: NEW cells must have M ∈ {4096, 8192} OR be "
+            "the (2048, 2048, K, fp16) pair for K ∈ {4096, 8192} that "
+            "K-1335 (bf16-only) does not cover."
+        )
+
+
+# ---------------------------------------------------------------------------
+# (c) SIBLING-N FIREWALL — P26 carries N=2048 only; must be disjoint from
+#     every K-COMPLEMENT predecessor (none of which carry N=2048 cells).
+# ---------------------------------------------------------------------------
+def test_p26_disjoint_from_p24_n4096():
+    assert _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30.isdisjoint(
+        _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30)
+
+
+def test_p26_n_axis_is_strictly_2048():
+    for cell in _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30:
+        _, N, _, _ = cell
+        assert N == 2048
+
+
+# ---------------------------------------------------------------------------
+# (d) ROUTING CONTRACT — every K-1611 admit cell dispatches to hipBLASLt
+#     via the public `k971_route_decision`.  For NEW cells (M ∈ {4096,
+#     8192} or the K-1335 fp16 siblings) the load-bearing path is the
+#     17th-position P26 predicate; for alias cells (M=2048 ∩ upstream)
+#     the load-bearing path is the upstream firing predicate (P12 / K1335
+#     / K971 LDS-BC anchors) but the runtime verdict is identical.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cell", sorted(_K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30)
+)
+def test_p26_admit_cell_routes_to_hbl(cell):
+    M, N, K, dtype = cell
+    assert (
+        k971_route_decision(
+            M, N, K, dtype, dtype,
+            enable_streamk=False, work_stealing=False,
+            disable_env_set=False,
+        )
+        is True
+    ), f"K-1611 P26 admit cell {cell} failed to dispatch to hipBLASLt."
+
+
+# ---------------------------------------------------------------------------
+# (e) PREDICATE FUNCTION SHAPE — the strict-equality membership predicate
+#     is True iff (M, N, K, str(dtype)) is in the admit set.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cell", sorted(_K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30)
+)
+def test_p26_predicate_fires_on_admit_cell(cell):
+    M, N, K, dtype = cell
+    assert _k1611_p26_skinny_n2048_kcompl_aliasstack_routeout(M, N, K, dtype)
+
+
+@pytest.mark.parametrize(
+    "cell",
+    [
+        # N != 2048 — sibling-N firewall negative.
+        (2048, 4096, 4096, "torch.bfloat16"),
+        (2048, 1024, 8192, "torch.float16"),
+        (4096, 8192, 2048, "torch.bfloat16"),
+        # M not in {2048, 4096, 8192} — outside the K-1611 envelope.
+        (1024, 2048, 4096, "torch.bfloat16"),
+        (3072, 2048, 8192, "torch.float16"),
+        (16384, 2048, 8192, "torch.bfloat16"),
+        # K not in {2048, 4096, 8192, 16384, 32768} — outside K-grid.
+        (4096, 2048, 1024, "torch.bfloat16"),
+        (8192, 2048, 65536, "torch.float16"),
+        # dtype not bf16/fp16.
+        (4096, 2048, 4096, "torch.float32"),
+    ],
+    ids=lambda c: f"{c[0]}x{c[1]}x{c[2]}_{c[3]}",
+)
+def test_p26_predicate_does_not_fire_outside_envelope(cell):
+    M, N, K, dtype = cell
+    assert (
+        _k1611_p26_skinny_n2048_kcompl_aliasstack_routeout(M, N, K, dtype)
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# (f) CARVE-OUT NEGATIVES — streamk / work_stealing / dtype-mismatch must
+#     short-circuit routing OFF even on K-1611 admit cells.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"enable_streamk": True,  "work_stealing": False},
+        {"enable_streamk": False, "work_stealing": True},
+    ],
+    ids=["streamk_on", "work_stealing_on"],
+)
+def test_p26_admit_cell_carved_out_by_flags(kwargs):
+    cell = (4096, 2048, 8192, "torch.bfloat16")  # canonical K-1611 NEW admit
+    M, N, K, dtype = cell
+    assert k971_route_decision(
+        M, N, K, dtype, dtype, disable_env_set=False, **kwargs,
+    ) is False
+
+
+def test_p26_admit_cell_carved_out_by_dtype_mismatch():
+    M, N, K = 4096, 2048, 8192
+    assert k971_route_decision(
+        M, N, K, "torch.bfloat16", "torch.float16",
+        enable_streamk=False, work_stealing=False, disable_env_set=False,
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# (g) ALIAS-COVERAGE INVARIANT — the 8 alias cells must remain covered by
+#     the upstream predicate union (P12 ∪ K971_ROUTE_TABLE).  If an
+#     upstream contraction silently breaks this, the K-1611 audit handle
+#     is no longer faithful and the alias cells become NEW route-OUT
+#     (which would change the cardinality of `_K1611_P26_NEW_ROUTEOUT_22`).
+# ---------------------------------------------------------------------------
+def test_p26_alias_cells_covered_by_upstream_union():
+    upstream_union = (
+        _K1295_P12_PMC_SQUARE_MID_ROUTEOUT_4
+        | K971_ROUTE_TABLE
+    )
+    alias_cells = (
+        _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30
+        - _K1611_P26_NEW_ROUTEOUT_22
+    )
+    assert len(alias_cells) == 8
+    uncovered = alias_cells - upstream_union
+    assert not uncovered, (
+        f"K-1611 P26 has {len(uncovered)} alias cells not covered by "
+        f"P12 ∪ K971_ROUTE_TABLE: {sorted(uncovered)}"
+    )
+
+
+def test_p26_k1335_subset_of_k971_route_table():
+    # K-1335 is unioned into K971_ROUTE_TABLE at module load; this pin
+    # guards against future re-decompositions that would break the
+    # K-1611 P26 alias-overlap structure.
+    assert _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4.issubset(K971_ROUTE_TABLE)

--- a/tests/test_k1633_p27_skinny_n512_alias_stack.py
+++ b/tests/test_k1633_p27_skinny_n512_alias_stack.py
@@ -1,0 +1,14 @@
+"""K-1633 P27 — alias of K-1552 P23.  Routing covered transitively."""
+from tritonblas._route_predicate import (
+    _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30 as _P23,
+    _K1633_P27_SKINNY_N512_KCOMPL_ALIASSTACK_30 as _P27,
+)
+
+
+def test_p27_is_identity_alias_of_p23():
+    # Identity catches a future rebind to a value-equal duplicate.
+    assert _P27 is _P23
+
+
+def test_p27_cardinality_30():
+    assert len(_P27) == 30

--- a/tests/test_k1673_p28_skinny_n128_alias_stack.py
+++ b/tests/test_k1673_p28_skinny_n128_alias_stack.py
@@ -1,0 +1,282 @@
+"""Unit fixture — K-1673 P28 skinny_N128 K-COMPLEMENT 30-cell alias-stack
+19th-position route-OUT.
+
+Productionizes the K-1673 verification of the N=128 K-COMPLEMENT envelope
+(M ∈ {2048, 4096, 8192} × N=128 × K ∈ {2048, 4096, 8192, 16384, 32768} ×
+{bf16, fp16}) as the 19th stacked frozenset, closing the LAST untested
+small-N rung (N=128) of the K-COMPLEMENT N-ladder at the dtype-mirror gap
+(fp16 K ∈ {2048, 32768}).  Coverage now spans the FULL N-ladder
+{128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768} on the M ∈ {2048,
+4096, 8192} rows for both bf16 AND fp16.
+
+Source measurement (still-of-record): K-1673 paired n=30 HIP-graph
+hot-cache on MI300X / gfx942 (OCI fallback amd-rccl partition) against
+the LIVE post-K-1647 P27 routing oracle
+(fork branch fix/K-1647 tip 8d010c6); 30/30 admit at strict ratio_median
+≥ 1.05 ∧ p(<1.05) < 0.01 gate; cohort geomean tb/hbl = 1.694×, range
+1.162×-2.890×, 0 regressions.
+
+ALIAS-STACK structure: 6 NEW route-OUT cells (all fp16 at K ∈ {2048,
+32768}) + 24 alias cells (15 bf16 via R-K979 P5 Clause-3 minMN ≤ 192 ∧
+K ≥ 2048 + 9 fp16 K-mid via K-1367 P13 N=128).  Alias overlaps fire
+BEFORE P28 in the dispatch chain so the 24 alias cells are unreachable
+under normal dispatch — load-bearing only if any of P5 / P13 is ablated.
+"""
+import pytest
+
+from tritonblas._route_predicate import (
+    R_K979_P5_route_to_hbl,
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+    _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30,
+    _K1673_P28_NEW_ROUTEOUT_6,
+    _K1673_P28_VS_P5_ALIAS_OVERLAP,
+    _K1673_P28_VS_P13_N128_ALIAS_OVERLAP,
+    _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30,
+    _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30,
+    _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30,
+    _K1633_P27_SKINNY_N512_KCOMPL_ALIASSTACK_30,
+    _k1673_p28_skinny_n128_kcompl_aliasstack_routeout,
+    k971_route_decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# (a) CARDINALITY — pinned to 30 cells (the K-1673 envelope: M ∈ {2048,
+#     4096, 8192} × N=128 × K ∈ {2048, 4096, 8192, 16384, 32768} × {bf16,
+#     fp16}).  Any deviation indicates an authoring typo against the
+#     K-1673 paired n=30 admit set.
+# ---------------------------------------------------------------------------
+def test_p28_admit_set_cardinality_is_thirty():
+    assert len(_K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30) == 30
+
+
+def test_p28_admit_set_covers_full_n128_kcompl_grid():
+    expected = {
+        (M, 128, K, dtype)
+        for M in (2048, 4096, 8192)
+        for K in (2048, 4096, 8192, 16384, 32768)
+        for dtype in ("torch.bfloat16", "torch.float16")
+    }
+    assert _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30 == expected
+
+
+# ---------------------------------------------------------------------------
+# (b) ALIAS-OVERLAP STRUCTURE — pinned at exactly 24 alias cells across 2
+#     upstream predicates (P5 bf16 + P13 N=128 fp16 K-mid).  Future
+#     contractions of any upstream predicate must trip these tests so the
+#     K-1673 NEW route-OUT contribution is re-audited.
+# ---------------------------------------------------------------------------
+def test_p28_p5_alias_overlap_is_exactly_fifteen_bf16_cells():
+    expected = frozenset({
+        (M, 128, K, "torch.bfloat16")
+        for M in (2048, 4096, 8192)
+        for K in (2048, 4096, 8192, 16384, 32768)
+    })
+    assert _K1673_P28_VS_P5_ALIAS_OVERLAP == expected
+
+
+def test_p28_p13_n128_alias_overlap_is_exactly_eighteen_cells():
+    expected = frozenset({
+        (M, 128, K, dtype)
+        for M in (2048, 4096, 8192)
+        for K in (4096, 8192, 16384)
+        for dtype in ("torch.bfloat16", "torch.float16")
+    })
+    assert _K1673_P28_VS_P13_N128_ALIAS_OVERLAP == expected
+
+
+def test_p28_new_routeout_contribution_is_exactly_six_fp16_cells():
+    expected = frozenset({
+        (M, 128, K, "torch.float16")
+        for M in (2048, 4096, 8192)
+        for K in (2048, 32768)
+    })
+    assert _K1673_P28_NEW_ROUTEOUT_6 == expected
+    assert len(_K1673_P28_NEW_ROUTEOUT_6) == 6
+
+
+def test_p28_alias_decomposition_is_partition():
+    # NEW ⊕ alias-union = full envelope; NEW ∩ alias-union = ∅.
+    alias_union = (
+        _K1673_P28_VS_P5_ALIAS_OVERLAP
+        | _K1673_P28_VS_P13_N128_ALIAS_OVERLAP
+    )
+    assert _K1673_P28_NEW_ROUTEOUT_6.isdisjoint(alias_union)
+    assert (
+        _K1673_P28_NEW_ROUTEOUT_6 | alias_union
+        == _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30
+    )
+    # Alias-union cardinality is 24 (15 bf16 from P5 + 18 from P13 N=128
+    # − 9 P5∩P13 overlap = 24).
+    assert len(alias_union) == 24
+
+
+# ---------------------------------------------------------------------------
+# (c) SIBLING-N FIREWALL — P28 carries N=128 only; must be disjoint from
+#     every K-COMPLEMENT predecessor that uses N != 128.  The K-1367 P13
+#     N=128 18-cell envelope is the only intentional N=128 overlap and is
+#     asserted in (b) above as the alias subset.
+# ---------------------------------------------------------------------------
+def test_p28_disjoint_from_p26_n2048():
+    assert _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30.isdisjoint(
+        _K1611_P26_SKINNY_N2048_KCOMPL_ALIASSTACK_30)
+
+
+def test_p28_disjoint_from_p24_n4096():
+    assert _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30.isdisjoint(
+        _K1566_P24_SKINNY_N4096_KCOMPL_ROUTEOUT_30)
+
+
+def test_p28_disjoint_from_p23_n512():
+    assert _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30.isdisjoint(
+        _K1552_P23_SKINNY_N512_KCOMPL_ALIASSTACK_30)
+
+
+def test_p28_disjoint_from_p27_n512_alias():
+    # K-1633 P27 is a module-level alias of K-1552 P23; assert the
+    # disjointness on the alias handle to catch any future P27 rebind.
+    assert _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30.isdisjoint(
+        _K1633_P27_SKINNY_N512_KCOMPL_ALIASSTACK_30)
+
+
+def test_p28_n_axis_is_strictly_128():
+    for cell in _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30:
+        _, N, _, _ = cell
+        assert N == 128
+
+
+# ---------------------------------------------------------------------------
+# (d) ROUTING CONTRACT — every K-1673 admit cell dispatches to hipBLASLt
+#     via the public `k971_route_decision`.  For NEW cells (the 6 fp16 at
+#     K ∈ {2048, 32768}) the load-bearing path is the 19th-position P28
+#     predicate; for alias cells the load-bearing path is the upstream
+#     firing predicate (R-K979 P5 / K-1367 P13) but the runtime verdict
+#     is identical.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cell", sorted(_K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30)
+)
+def test_p28_admit_cell_routes_to_hbl(cell):
+    M, N, K, dtype = cell
+    assert (
+        k971_route_decision(
+            M, N, K, dtype, dtype,
+            enable_streamk=False, work_stealing=False,
+            disable_env_set=False,
+        )
+        is True
+    ), f"K-1673 P28 admit cell {cell} failed to dispatch to hipBLASLt."
+
+
+# ---------------------------------------------------------------------------
+# (e) PREDICATE FUNCTION SHAPE — the strict-equality membership predicate
+#     is True iff (M, N, K, str(dtype)) is in the admit set.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cell", sorted(_K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30)
+)
+def test_p28_predicate_fires_on_admit_cell(cell):
+    M, N, K, dtype = cell
+    assert _k1673_p28_skinny_n128_kcompl_aliasstack_routeout(M, N, K, dtype)
+
+
+@pytest.mark.parametrize(
+    "cell",
+    [
+        # N != 128 — sibling-N firewall negative.
+        (2048, 256, 4096, "torch.bfloat16"),
+        (2048, 512, 8192, "torch.float16"),
+        (4096, 1024, 2048, "torch.bfloat16"),
+        # M not in {2048, 4096, 8192} — outside the K-1673 envelope.
+        (1024, 128, 4096, "torch.bfloat16"),
+        (3072, 128, 8192, "torch.float16"),
+        (16384, 128, 8192, "torch.bfloat16"),
+        # K not in {2048, 4096, 8192, 16384, 32768} — outside K-grid.
+        (4096, 128, 1024, "torch.bfloat16"),
+        (8192, 128, 65536, "torch.float16"),
+        # dtype not bf16/fp16.
+        (4096, 128, 4096, "torch.float32"),
+    ],
+    ids=lambda c: f"{c[0]}x{c[1]}x{c[2]}_{c[3]}",
+)
+def test_p28_predicate_does_not_fire_outside_envelope(cell):
+    M, N, K, dtype = cell
+    assert (
+        _k1673_p28_skinny_n128_kcompl_aliasstack_routeout(M, N, K, dtype)
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# (f) CARVE-OUT NEGATIVES — streamk / work_stealing / dtype-mismatch must
+#     short-circuit routing OFF even on K-1673 admit cells.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"enable_streamk": True,  "work_stealing": False},
+        {"enable_streamk": False, "work_stealing": True},
+    ],
+    ids=["streamk_on", "work_stealing_on"],
+)
+def test_p28_admit_cell_carved_out_by_flags(kwargs):
+    cell = (2048, 128, 32768, "torch.float16")  # canonical K-1673 NEW admit (max-ratio)
+    M, N, K, dtype = cell
+    assert k971_route_decision(
+        M, N, K, dtype, dtype, disable_env_set=False, **kwargs,
+    ) is False
+
+
+def test_p28_admit_cell_carved_out_by_dtype_mismatch():
+    M, N, K = 2048, 128, 32768
+    assert k971_route_decision(
+        M, N, K, "torch.bfloat16", "torch.float16",
+        enable_streamk=False, work_stealing=False, disable_env_set=False,
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# (g) ALIAS-COVERAGE INVARIANT — the 24 alias cells must remain covered
+#     by the upstream predicate union (P5 ∪ P13 N=128).  If an upstream
+#     contraction silently breaks this, the K-1673 audit handle is no
+#     longer faithful and the affected cells become NEW route-OUT (which
+#     would change the cardinality of `_K1673_P28_NEW_ROUTEOUT_6`).
+# ---------------------------------------------------------------------------
+def test_p28_alias_cells_covered_by_upstream_union():
+    alias_cells = (
+        _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30
+        - _K1673_P28_NEW_ROUTEOUT_6
+    )
+    assert len(alias_cells) == 24
+    # P5 catches all bf16 cells via the structural minMN ≤ 192 ∧ K ≥
+    # 2048 envelope; P13 catches the K-mid fp16 cells (K ∈ {4096, 8192,
+    # 16384}); union must cover every alias cell.
+    uncovered = []
+    for cell in alias_cells:
+        M, N, K, dtype = cell
+        in_p5 = R_K979_P5_route_to_hbl(M, N, K, dtype)
+        in_p13 = cell in _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18
+        if not (in_p5 or in_p13):
+            uncovered.append(cell)
+    assert not uncovered, (
+        f"K-1673 P28 has {len(uncovered)} alias cells not covered by "
+        f"R-K979 P5 ∪ K-1367 P13 N=128: {sorted(uncovered)}"
+    )
+
+
+def test_p28_p5_p13_overlap_is_exactly_nine_bf16_cells():
+    # The 9 cells (bf16, K ∈ {4096, 8192, 16384}) sit in BOTH P5 and P13;
+    # P5 fires first at the 5th slot.  This pin guards against a future
+    # P5 K-floor / minMN-ceiling contraction that would shift those 9
+    # cells into the P13-only alias bucket (still routed but via a
+    # different upstream predicate).
+    p5_p13_overlap = (
+        _K1673_P28_VS_P5_ALIAS_OVERLAP
+        & _K1673_P28_VS_P13_N128_ALIAS_OVERLAP
+    )
+    expected = frozenset({
+        (M, 128, K, "torch.bfloat16")
+        for M in (2048, 4096, 8192)
+        for K in (4096, 8192, 16384)
+    })
+    assert p5_p13_overlap == expected

--- a/tests/test_k1700_p29_skinny_n64_alias_stack.py
+++ b/tests/test_k1700_p29_skinny_n64_alias_stack.py
@@ -1,0 +1,73 @@
+"""K-1700 P29 — N=64 K-COMPLEMENT alias-stack 29-cell route-OUT.
+
+Minimal pin tests: cardinality, structure, sibling-N firewall (N != 64
+disjoint), the explicitly dropped bubble cell, P5 bf16 alias coverage,
+and adjacent-N regression (N=96 NOT in P29; N=128 still routes via P28).
+"""
+import pytest
+
+from tritonblas._route_predicate import (
+    _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29 as _P29,
+    _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30 as _P28,
+)
+
+
+def test_cardinality_29():
+    assert len(_P29) == 29
+
+
+def test_envelope_structure_minus_bubble():
+    # Full M×K×dtype grid at N=64 is 30 cells; the bubble cell
+    # (2048, 64, 4096, fp16) failed the strict 1.05 gate (CI95-lo=1.045)
+    # and is the only intentional omission.
+    full = {
+        (M, 64, K, dt)
+        for M in (2048, 4096, 8192)
+        for K in (2048, 4096, 8192, 16384, 32768)
+        for dt in ("torch.bfloat16", "torch.float16")
+    }
+    assert _P29 == full - {(2048, 64, 4096, "torch.float16")}
+
+
+def test_bubble_cell_explicitly_excluded():
+    assert (2048, 64, 4096, "torch.float16") not in _P29
+
+
+def test_all_cells_have_n64():
+    assert {N for (_, N, _, _) in _P29} == {64}
+
+
+def test_sibling_n_firewall_disjoint():
+    # No N != 64 cell may live in P29; this is the structural firewall.
+    assert all(N == 64 for (_, N, _, _) in _P29)
+    # And P29 must be fully disjoint from the sibling N=128 P28 set.
+    assert _P29.isdisjoint(_P28)
+
+
+def test_p5_bf16_alias_coverage():
+    # All 15 bf16 cells in P29 are also caught by the upstream R-K979 P5
+    # Clause-3 (minMN ≤ 192 ∧ K ≥ 2048, bf16-only).  P5 fires earlier in
+    # the dispatch chain, so the bf16 subset is documentation; the load-
+    # bearing portion is the 14 fp16 cells (15 fp16 minus the bubble).
+    bf16_cells = {c for c in _P29 if c[3] == "torch.bfloat16"}
+    fp16_cells = {c for c in _P29 if c[3] == "torch.float16"}
+    assert len(bf16_cells) == 15
+    assert len(fp16_cells) == 14  # 15 minus bubble
+
+
+@pytest.mark.parametrize("M", [2048, 4096, 8192])
+@pytest.mark.parametrize("K", [2048, 4096, 8192, 16384, 32768])
+def test_adjacent_n96_not_in_p29(M, K):
+    # Sibling-N firewall: adjacent N=96 must NOT be admitted.
+    assert (M, 96, K, "torch.bfloat16") not in _P29
+    assert (M, 96, K, "torch.float16") not in _P29
+
+
+@pytest.mark.parametrize("M", [2048, 4096, 8192])
+@pytest.mark.parametrize("K", [2048, 4096, 8192, 16384, 32768])
+def test_adjacent_n128_unaffected_by_p29(M, K):
+    # P28 (N=128 alias-stack) still owns its 30 cells; P29 must not have
+    # silently shadowed any of them.
+    for dt in ("torch.bfloat16", "torch.float16"):
+        assert (M, 128, K, dt) in _P28
+        assert (M, 128, K, dt) not in _P29

--- a/tests/test_k1748_p30_skinny_nmid_alias_stack.py
+++ b/tests/test_k1748_p30_skinny_nmid_alias_stack.py
@@ -14,7 +14,13 @@ the R-1532 / R-1720 minimalist-admit-set rule):
   3. Sibling-N firewall vs P29 (N=64): zero overlap.
   4. K-only members ∈ {2048, 8192, 32768}; M-only members ∈ {2048, 4096, 8192};
      dtype set is exactly {torch.bfloat16, torch.float16}.
-  5. Module-load assertion in `_route_predicate` is intact.
+  5. Per-shape dtype-mirror (bf16 ↔ fp16 admit sets coincide).
+
+The cardinality invariant lives in this file rather than as an import-time
+`assert` in `_route_predicate.py` per the minimalist split: source holds
+data, tests hold structural invariants (R-1532 / R-1720).  Dropping the
+runtime assert saves the cost on every `tritonblas` import without
+weakening the gate — `test_cardinality_is_34` below catches duplicates.
 """
 from __future__ import annotations
 

--- a/tests/test_k1748_p30_skinny_nmid_alias_stack.py
+++ b/tests/test_k1748_p30_skinny_nmid_alias_stack.py
@@ -1,0 +1,62 @@
+"""K-1748 (S-002) — 21st-slot alias-stack pinning tests.
+
+Audit closed by K-1748: the live post-K-1709 oracle had 0/34 cells of the
+K-1711 N-mid envelope active (K-1720's 20th-slot proposal was a parallel
+branch off K-1685 that never merged into the K-1709 lineage).  Ship the
+K-1711 envelope at the 21st alias-stack slot.
+
+Invariants pinned (all derived inline from the canonical frozenset to honor
+the R-1532 / R-1720 minimalist-admit-set rule):
+
+  1. Cardinality is exactly 34.
+  2. N ∈ {384, 768, 1536}; per-N admit shape matches K-1711's measured
+     CI95-gated 10 / 14 / 10 split.
+  3. Sibling-N firewall vs P29 (N=64): zero overlap.
+  4. K-only members ∈ {2048, 8192, 32768}; M-only members ∈ {2048, 4096, 8192};
+     dtype set is exactly {torch.bfloat16, torch.float16}.
+  5. Module-load assertion in `_route_predicate` is intact.
+"""
+from __future__ import annotations
+
+from tritonblas._route_predicate import (
+    _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29,
+    _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34,
+)
+
+
+FZ = _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34
+
+
+def test_cardinality_is_34():
+    assert len(FZ) == 34
+
+
+def test_n_axis_is_skinny_nmid():
+    assert {N for (_, N, _, _) in FZ} == {384, 768, 1536}
+
+
+def test_per_n_admit_shape_matches_k1711_csv():
+    by_n = {n: {(M, K, dt) for (M, N, K, dt) in FZ if N == n}
+            for n in (384, 768, 1536)}
+    assert len(by_n[384]) == 10
+    assert len(by_n[768]) == 14   # worst seam
+    assert len(by_n[1536]) == 10
+
+
+def test_sibling_n_firewall_vs_p29_n64():
+    assert FZ & _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29 == set()
+
+
+def test_m_k_dtype_axes_are_minimal():
+    assert {M for (M, _, _, _) in FZ} == {2048, 4096, 8192}
+    assert {K for (_, _, K, _) in FZ} <= {2048, 8192, 32768}
+    assert {dt for (_, _, _, dt) in FZ} == {"torch.bfloat16", "torch.float16"}
+
+
+def test_dtype_mirror_is_complete():
+    """Each shape (M, N, K) admitted under bf16 is also admitted under fp16
+    (and vice versa) — mirrors the K-1711 CSV where fp16 and bf16 share
+    the K-913 §3 LDS-bank-conflict mechanism."""
+    bf = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.bfloat16"}
+    fp = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.float16"}
+    assert bf == fp

--- a/tests/test_k971_route_predicate.py
+++ b/tests/test_k971_route_predicate.py
@@ -1,0 +1,1903 @@
+"""K-1003 R-K979 P5 Gate-0 admission predicate — integration tests.
+
+Verifies the closed-form predicate AND the full ``_k971_route_to_hbl``
+dispatch decision (predicate + strict-equality table + streamk /
+work-stealing / dtype-mismatch carve-outs) match the K-979 verification
+contract:
+
+  * On the K-984 + K-989 union (14 unique K-931 shapes), the predicate
+    must FIRE on all 14.
+  * On the K-950 9-cell LAND set, the predicate alone must NOT fire on
+    any (zero leakage from the closed-form), and the full dispatch must
+    only route the 3 K-905 anchor-collision tuples (a documented design
+    decision — K-905 measurements override the K-950 verdict on those
+    exact tuples).
+  * The streamk / work-stealing / mismatched-dtype carve-outs must
+    short-circuit to ``False`` regardless of the predicate verdict.
+
+These tests import the actual shipped predicate (`_route_predicate`) and
+the actual shipped dispatch helper (`matmul._k971_route_to_hbl`) so the
+*real* code path users hit is exercised — no exec/string-parse copies.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tritonblas._route_predicate import (
+    R_K979_P5_route_to_hbl,
+    R_K1037_P6_admit_wpeu1,
+    K971_ROUTE_TABLE,
+    _K905_K971_LDS_BC_ANCHORS_8,
+    _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4,
+    _K1109_P6_K1074_ALLOWLIST,
+    _K1109_P6_K1074_REGRESSION_EXCLUSIONS,
+    _K1109_P6_ALLOWLIST_ENV,
+    _p8_mfma_issue_stall_routeout,
+    _P8_MFMA_ISSUE_STALL_ROUTEOUT,
+    _K1121_P8_ANCHORS_13,
+    _K1131_P8_NEIGHBORS_12,
+    _K1161_E2_ADMITS_3,
+    _K1205_EN3_ADMITS_8,
+    _K1219_E3_NFLOOR256_ADMITS_7,
+    _K1283_A1_PERTURBATIONS_8,
+    R_K1142_E1_route_to_hbl,
+    K1142_E1_NS,
+    K1142_E1_KS,
+    K1142_E1_M_FLOOR,
+    K1142_E1_K_FLOOR,
+    k971_route_decision,
+)
+from tritonblas.matmul import _k971_route_to_hbl
+
+
+# ---------------------------------------------------------------------------
+# Cohorts (kept in sync with scripts/validate_p5_predicate.py).  bf16
+# everywhere because the K-984/K-989 ship cohort and K-931 measurement scope
+# are bf16; fp16 / fp32 / etc. exercise the bf16-only carve-out.
+# ---------------------------------------------------------------------------
+K984_K989_UNION = [
+    # (sid, M, N, K, source)
+    ("S04",  2304,   2048, 4800, "K984+K989"),
+    ("S05",   256,   1792, 2048, "K989"),
+    ("S06",   736,   1792,  736, "K989"),
+    ("S10",   512,    192, 2048, "K984"),
+    ("S17",   768,   1792, 5972, "K984+K989"),
+    ("S18",  5972,   1792,  768, "K984"),
+    ("S21",   768,   3072, 4480, "K989"),
+    ("S22",  1024,   2048, 6016, "K989"),
+    ("S23",  1024,   2048, 8064, "K989"),
+    ("S25",  6016,   2048, 1024, "K984"),
+    ("S27", 10112,   2048, 1024, "K984+K989"),
+    ("S28", 12160,   2048, 1024, "K984+K989"),
+    ("S36",    30, 786432,  200, "K984"),
+    ("S40",  1024,   2048, 1240, "K989"),
+]
+
+# K-950 9-cell LAND set (cells K-912 / K-883 deemed NO-LAND for guarded
+# overrides). Entries: (cid, M, N, K, dtype, cohort).
+K950_LAND_CELLS = [
+    ("L01", 1024, 1024,   512, torch.bfloat16, "harness-guarded-override"),
+    ("L02",  512,  512,  1024, torch.bfloat16, "harness-guarded-override"),
+    ("L03", 2048,  768,  1024, torch.bfloat16, "harness-guarded-override"),
+    ("L04",  768, 2048,  1024, torch.bfloat16, "harness-guarded-override"),
+    ("L05", 4096, 4096,  4096, torch.bfloat16, "harness-guarded-override"),
+    ("L06", 2048, 2048, 16384, torch.float16,  "harness-guarded-override"),
+    ("L07", 1024, 1024, 16384, torch.bfloat16, "C9-cohortA-longK-HBLroute"),
+    ("L08", 4096, 4096,  8192, torch.bfloat16, "C9-cohortA-longK-HBLroute"),
+    ("L09", 1024, 1024, 16384, torch.float16,  "C9-cohortA-longK-HBLroute"),
+]
+
+# Tuples where K-905 anchor table intentionally routes to hbl despite the
+# K-950 LAND verdict (K-905 measurement overrides — documented in the PR
+# description).
+K950_ANCHOR_COLLISIONS = frozenset({
+    (1024, 1024, 16384, "torch.bfloat16"),  # L07
+    (1024, 1024, 16384, "torch.float16"),   # L09
+    (2048, 2048, 16384, "torch.float16"),   # L06
+})
+
+
+# ---------------------------------------------------------------------------
+# Predicate-only checks
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("sid,M,N,K,src", K984_K989_UNION,
+                         ids=[c[0] for c in K984_K989_UNION])
+def test_p5_fires_on_k984_k989_union(sid, M, N, K, src):
+    """Every K-984+K-989 anchor shape must be caught by the closed-form
+    predicate (zero strict-equality fallback needed)."""
+    assert R_K979_P5_route_to_hbl(M, N, K, torch.bfloat16) is True, (
+        f"P5 missed shipped K-984+K-989 anchor {sid} ({M},{N},{K}) — "
+        f"strict-equality fallback would re-grow")
+
+
+@pytest.mark.parametrize("cid,M,N,K,dtype,cohort", K950_LAND_CELLS,
+                         ids=[c[0] for c in K950_LAND_CELLS])
+def test_p5_does_not_leak_on_k950_land(cid, M, N, K, dtype, cohort):
+    """The closed-form predicate alone must produce zero LAND leakage on
+    K-950's 9-cell training set. Strict-equality table collisions are
+    handled separately by ``test_full_dispatch_only_routes_known_anchors``."""
+    assert R_K979_P5_route_to_hbl(M, N, K, dtype) is False, (
+        f"P5 leaked into K-950 LAND cell {cid} ({M},{N},{K}) {dtype} "
+        f"cohort={cohort}")
+
+
+def test_p5_is_bf16_only():
+    """fp16 / fp32 / int8 must all short-circuit to False so K-905/K-971
+    fp16 anchors flow through the strict-equality table only."""
+    M, N, K = 2304, 2048, 4800  # S04 — would fire under bf16
+    assert R_K979_P5_route_to_hbl(M, N, K, torch.bfloat16) is True
+    assert R_K979_P5_route_to_hbl(M, N, K, torch.float16) is False
+    assert R_K979_P5_route_to_hbl(M, N, K, torch.float32) is False
+    assert R_K979_P5_route_to_hbl(M, N, K, torch.int8) is False
+
+
+# ---------------------------------------------------------------------------
+# Full-dispatch checks (predicate + strict-equality + carve-outs)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("sid,M,N,K,src", K984_K989_UNION,
+                         ids=[c[0] for c in K984_K989_UNION])
+def test_full_dispatch_fires_on_k984_k989_union(sid, M, N, K, src):
+    """End-to-end dispatch decision matches the predicate verdict for
+    K-984+K-989 anchors (no carve-out interference)."""
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True
+
+
+@pytest.mark.parametrize("cid,M,N,K,dtype,cohort", K950_LAND_CELLS,
+                         ids=[c[0] for c in K950_LAND_CELLS])
+def test_full_dispatch_only_routes_known_anchors(cid, M, N, K, dtype, cohort):
+    """Full dispatch may route K-950 LAND cells ONLY if they match a known
+    K-905/K-971 anchor in the strict-equality allowlist. Any other route is
+    a regression (predicate widened to leak, or new entry slipped into the
+    table)."""
+    routed = _k971_route_to_hbl(
+        M, N, K, dtype, dtype,
+        enable_streamk=False, work_stealing=False)
+    expected = (M, N, K, str(dtype)) in K950_ANCHOR_COLLISIONS
+    assert routed is expected, (
+        f"K-950 LAND cell {cid} ({M},{N},{K}) {dtype} routed={routed} "
+        f"expected={expected} (allowlist={K950_ANCHOR_COLLISIONS})")
+
+
+# Carve-outs: streamk / work-stealing / dtype-mismatch / kill-env must all
+# unconditionally veto routing — exercised on a cell P5 *would* otherwise
+# fire on (S04 = 2304x2048x4800 bf16).
+S04 = (2304, 2048, 4800)
+
+
+def test_streamk_carveout_overrides_predicate():
+    M, N, K = S04
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=True, work_stealing=False) is False
+
+
+def test_workstealing_carveout_overrides_predicate():
+    M, N, K = S04
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=True) is False
+
+
+def test_mixed_dtype_carveout_overrides_predicate():
+    M, N, K = S04
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.float16,
+        enable_streamk=False, work_stealing=False) is False
+
+
+def test_kill_env_overrides_predicate(monkeypatch):
+    monkeypatch.setenv("TRITONBLAS_DISABLE_K971", "1")
+    M, N, K = S04
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is False
+
+
+# ---------------------------------------------------------------------------
+# Coupling check — ensures the matmul.py copy and the helper module agree.
+# Catches the case where someone re-introduces a divergent inline copy.
+# ---------------------------------------------------------------------------
+def test_matmul_module_uses_helper_module_predicate():
+    # tritonblas/__init__.py does `from .matmul import matmul`, which makes
+    # `tritonblas.matmul` resolve to the *function*, not the submodule. Grab
+    # the actual submodule out of sys.modules so we can introspect it.
+    import sys
+    _m = sys.modules["tritonblas.matmul"]
+    assert _m._R_K979_P5_route_to_hbl is R_K979_P5_route_to_hbl
+    assert _m._K971_ROUTE_TABLE is K971_ROUTE_TABLE
+
+
+# ---------------------------------------------------------------------------
+# Public dispatch entry-point check — catches a missed call site.
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(not torch.cuda.is_available(),
+                    reason="public matmul entry-point needs a CUDA device "
+                           "for tensor allocation + torch.matmul fallback")
+def test_public_matmul_dispatches_via_predicate():
+    """Confirm the public dispatch entry-point (`tritonblas.matmul`) actually
+    consults `_k971_route_to_hbl` for every call and uses its verdict to
+    short-circuit to `torch.matmul`. Done by monkey-patching the helper
+    with a spy that returns True for a known shape and False otherwise —
+    this avoids touching real hipBLASLt timing while exercising the live
+    dispatch ordering inside `_matmul`."""
+    # tritonblas/__init__.py does `from .matmul import matmul`, which makes
+    # `tritonblas.matmul` resolve to the *function*, not the submodule. Grab
+    # the actual submodule out of sys.modules so we can introspect it.
+    import sys
+    _m = sys.modules["tritonblas.matmul"]
+    calls = []
+    original = _m._k971_route_to_hbl
+
+    def spy(M, N, K, a_dt, b_dt, sk, ws):
+        calls.append((int(M), int(N), int(K), str(a_dt), bool(sk), bool(ws)))
+        # Return True so _matmul takes the torch.matmul fallback (cheap +
+        # avoids exercising the heavy triton dispatch in this unit test).
+        return True
+
+    _m._k971_route_to_hbl = spy
+    try:
+        a = torch.randn(128, 64, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(64, 32, device="cuda", dtype=torch.bfloat16)
+        out = _m.matmul(a, b)
+        # If the dispatch site ignored the spy, it would not produce a
+        # valid bf16 result with these shapes (or it'd take much longer).
+        assert out.shape == (128, 32)
+        assert out.dtype == torch.bfloat16
+    finally:
+        _m._k971_route_to_hbl = original
+
+    assert calls, "_k971_route_to_hbl was not consulted by matmul()"
+    M, K_, N = 128, 64, 32
+    last = calls[-1]
+    assert (last[0], last[2], last[1]) == (M, K_, N), (
+        f"dispatch consulted with unexpected args: {last}")
+
+
+# ---------------------------------------------------------------------------
+# K-1089 R_K1037_P6_admit_wpeu1 — structural surrogate of K-1037 P6
+# MFMA-issue-stall classifier.  Pin tests cover (a) the 2 K-1017 P6+ cells
+# (S24, S29) admit, (b) every K-984/K-989 LAND anchor and the K-1017 OCC
+# negatives are NOT leaked, (c) bf16-only carve-out, (d) full-dispatch
+# composition: P6 admit short-circuits route-OUT to in-kernel.
+# ---------------------------------------------------------------------------
+P6_POSITIVES = [
+    # (cid, M, N, K)
+    ("S24",  4480, 3072,  768),  # MFMA-issue-stall, ratio 1.532
+    ("S29", 14208, 2048, 1024),  # MFMA-issue-stall, ratio 1.514
+]
+
+
+# K-1017 OCC + HBM negatives that must NOT admit (leak risk on Envelope A).
+# Wide-rect family near the M=14208 admit window:
+P6_NEGATIVES_K1017 = [
+    ("S26",  8064, 2048, 1024),  # OCC ratio 2.03
+    ("S30", 16256, 2048, 1024),  # OCC ratio 1.75 (just above admit ceil)
+    ("S31", 18304, 2048, 1024),  # OCC ratio 2.01
+    ("S07",  2048, 1792,  256),  # OCC shallow-K
+    ("S16",   256,  256, 2048),  # OCC small-mild-rect
+    ("S38",   384,  128,  200),  # HBM-bound, K=200 fails C2 floor
+]
+
+
+# K-1074 cohort-extension cells (S32, S33, S34, S35, S37, S39).  K-1109
+# independently re-derived K-1037 P6 on these 6 cells from the K-1037
+# primary-source PMC CSV (output/k1109_p6_audit.csv): all 6 fail load-
+# bearing C1 (waves_per_CU_ratio in [1.753, 2.740], above the 1.70x
+# MFMA-stall ceiling) and structurally cluster at the canonical occupancy
+# 2.0x signature.  K-1074 paired n=30 round-robin timing on c42/MI300X
+# confirmed 0/6 cells clear the K-901 +2% LAND margin and 2/6 (S32, S37)
+# are CI95 hi<0 confirmed regressions.  Pin tests below lock the K-1109
+# NULL-RESULT into the regression suite so any future relaxation of
+# Envelope A's M-band [13000, 14999] or its K=1024-only guard fails CI.
+# (S26, S30, S31 are already covered by P6_NEGATIVES_K1017 above.)
+P6_NEGATIVES_K1074 = [
+    ("S32", 20352, 2048, 1024),  # OCC ratio 2.254
+    ("S33", 22400, 2048, 1024),  # OCC ratio 2.378
+    ("S34", 24448, 2048, 1024),  # OCC ratio 1.753 — collides on C1 wall with S30
+    ("S35", 26496, 2048, 1024),  # OCC ratio 1.887
+    ("S37", 25600, 2048,  256),  # OCC ratio 2.740, K=256 fails C2 floor
+    ("S39", 49152, 2048,  256),  # OCC ratio 2.122, K=256 fails C2 floor
+]
+
+
+# K-1044 LAND anchors that K-1109 brief lists as 4-cell "no-regression"
+# witnesses.  S24/S29 are the K-1037 P6 positives (already in P6_POSITIVES);
+# S18 (= K-1044 B3a, 5972,1792,768) and S25 (= K-1044 B3b, 6016,2048,1024)
+# fire P6 by exact PMC but the structural surrogate correctly preserves
+# them as route-OUT LAND anchors via Envelope-A M>=13000 floor (B3b) and
+# Envelope-B minMN>=2048 floor (B3a).  K-989 measured 5.31x-5.63x routing
+# speedup on the structurally-equivalent S25/S27/S28 family — admitting
+# them to in-kernel would erase that gain.
+P6_NEGATIVES_K1044_ANCHORS = [
+    ("B3a_S18", 5972, 1792,  768),  # Env-B minMN floor (1792<2048) preserves anchor
+    ("B3b_S25", 6016, 2048, 1024),  # Env-A M-floor (6016<13000) preserves anchor
+]
+
+
+# K-984/K-989 LAND anchors that must NOT admit (route-OUT must be preserved).
+P6_LAND_ANCHORS = [
+    ("S25",  6016, 2048, 1024),  # K-984 anchor, M just below admit floor
+    ("S27", 10112, 2048, 1024),  # K-984+K-989 anchor
+    ("S28", 12160, 2048, 1024),  # K-984+K-989 anchor, just below admit floor
+    ("S04",  2304, 2048, 4800),  # K-984+K-989 anchor, K outside Envelope B
+    ("S18",  5972, 1792,  768),  # K-984 anchor, N=1792 not 2048
+    ("S40",  1024, 2048, 1240),  # K-989 anchor, minMN<2048
+]
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_POSITIVES, ids=[c[0] for c in P6_POSITIVES])
+def test_p6_admits_k1017_mfma_issue_stall_positives(cid, M, N, K):
+    """K-1017 P6+ cells (S24, S29) must admit so dispatch sets wpeu=1
+    in-kernel."""
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True, (
+        f"P6 surrogate missed K-1017 MFMA-issue-stall positive {cid} ({M},{N},{K})")
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_NEGATIVES_K1017,
+                         ids=[c[0] for c in P6_NEGATIVES_K1017])
+def test_p6_does_not_admit_k1017_negatives(cid, M, N, K):
+    """K-1017 OCC + HBM-bound cells must NOT admit (preserves K-1037
+    18/18 perfect agreement against ground truth)."""
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+        f"P6 surrogate false-positive on K-1017 negative {cid} ({M},{N},{K})")
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_LAND_ANCHORS,
+                         ids=[c[0] for c in P6_LAND_ANCHORS])
+def test_p6_does_not_leak_into_k984_k989_land_anchors(cid, M, N, K):
+    """K-984/K-989 LAND anchors gain 5.31x-5.63x via route-OUT; P6 admit
+    must NOT silence them by short-circuiting the route."""
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+        f"P6 LAND-leak into K-984/K-989 anchor {cid} ({M},{N},{K})")
+
+
+def test_p6_is_bf16_only():
+    """fp16 / fp32 must short-circuit (K-1037 ground truth scope is bf16)."""
+    M, N, K = 14208, 2048, 1024  # S29
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.float16) is False
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.float32) is False
+
+
+def test_p6_envelope_a_boundary():
+    """Pin Envelope A boundaries: M=12999 just below floor, M=15000 just
+    above ceiling. K-984/K-989 anchor S28 (M=12160) and OCC S30 (M=16256)
+    are the calibration witnesses for these floors."""
+    assert R_K1037_P6_admit_wpeu1(12999, 2048, 1024, torch.bfloat16) is False
+    assert R_K1037_P6_admit_wpeu1(13000, 2048, 1024, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(14999, 2048, 1024, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(15000, 2048, 1024, torch.bfloat16) is False
+
+
+def test_p6_envelope_b_boundary():
+    """Pin Envelope B boundaries: maxMN=4501 just above ceiling (preserves
+    K-984 S18 maxMN=5972, K-989 S25 maxMN=6016); minMN=2047 just below
+    floor (preserves K-989 S22 minMN=1024)."""
+    # On-boundary positive (S24 itself):
+    assert R_K1037_P6_admit_wpeu1(4480, 3072, 768, torch.bfloat16) is True
+    # maxMN ceiling
+    assert R_K1037_P6_admit_wpeu1(4500, 2048, 768, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(4501, 2048, 768, torch.bfloat16) is False
+    # minMN floor
+    assert R_K1037_P6_admit_wpeu1(2048, 2048, 768, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(2047, 2048, 768, torch.bfloat16) is False
+    # K floor (Surrogate-C2)
+    assert R_K1037_P6_admit_wpeu1(2048, 2048, 511, torch.bfloat16) is False
+    assert R_K1037_P6_admit_wpeu1(2048, 2048, 512, torch.bfloat16) is True
+    # K ceiling (Envelope B)
+    assert R_K1037_P6_admit_wpeu1(2048, 2048, 1024, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(2048, 2048, 1025, torch.bfloat16) is False
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_POSITIVES, ids=[c[0] for c in P6_POSITIVES])
+def test_p6_admit_overridden_by_p8_routeout(cid, M, N, K):
+    """K-1144 supersedes the original K-1089 P6 short-circuit assertion
+    on S24 and S29.  Both cells are inside K-1089's structural envelopes
+    (S24 inside Env-B, S29 inside Env-A) so ``R_K1037_P6_admit_wpeu1``
+    still returns True at the unit level (preserves the K-1037 18/18
+    confusion-matrix integrity).  But K-1074's paired n=30 LAND audit on
+    c42/MI300X showed 0/13 K-1051+K-1031 cohort cells clear the K-901
+    +2% margin under wpeu=1, falsifying the K-1089 admit on these cells.
+    K-1121 then measured paired n=30 HIP-graph hot-cache and reported
+    hipBLASLt wins on S24 (~1.20x) and S29 (~1.22x).  K-1144 P8 codifies
+    that correction by routing both cells OUT to hipBLASLt at the
+    dispatch level -- the unit-level P6 admit is unchanged, but the
+    composed dispatch decision flips to True (route-OUT) because P8 is
+    consulted BEFORE P6 in ``_k971_route_to_hbl``."""
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True, (
+        f"K-1144 P8 failed to override K-1089 P6 admit for {cid} "
+        f"({M},{N},{K}); P8 must be consulted before P6 to honour the "
+        f"K-1121 paired n=30 measurement evidence.")
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_LAND_ANCHORS,
+                         ids=[c[0] for c in P6_LAND_ANCHORS])
+def test_p6_admit_does_not_break_k984_k989_route_out_anchors(cid, M, N, K):
+    """K-984/K-989 anchors must continue to route-OUT after P6 wiring —
+    the new short-circuit must not regress the existing P5 LAND set."""
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True, (
+        f"P6 wiring regressed K-984/K-989 LAND anchor {cid} ({M},{N},{K})")
+
+
+# ---------------------------------------------------------------------------
+# K-1109 NULL-RESULT pin tests — locks K-1098 backtest verdict on the
+# K-1074 cohort-extension cells and the K-1044 LAND-anchor witnesses.
+# Re-derived independently from the K-1037 primary-source paired-PMC CSV
+# (see /home/ryaswann/mc2-workspaces/K-1109/output/k1109_p6_audit.csv).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("cid,M,N,K", P6_NEGATIVES_K1074,
+                         ids=[c[0] for c in P6_NEGATIVES_K1074])
+def test_p6_does_not_admit_k1074_cohort_extension(cid, M, N, K):
+    """K-1109 lock: 6 K-1074 cohort-extension cells must NOT admit.  Their
+    K-1037 paired-PMC waves_per_CU ratios cluster at the canonical OCC
+    2.0x signature (range 1.753-2.740) above C1's 1.70x ceiling; K-1074
+    paired n=30 timing showed 0/6 cells clear the K-901 +2% LAND margin
+    and 2/6 (S32, S37) are CI95-confirmed regressions.  Any future
+    relaxation of Envelope A's M-band [13000, 14999] or its K==1024 guard
+    must fail this test before re-enabling these cells."""
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+        f"P6 surrogate false-positive on K-1074 cohort-extension {cid} "
+        f"({M},{N},{K}); K-1098 paired-PMC verdict was NO_FIRE")
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_NEGATIVES_K1044_ANCHORS,
+                         ids=[c[0] for c in P6_NEGATIVES_K1044_ANCHORS])
+def test_p6_does_not_admit_k1044_land_anchors(cid, M, N, K):
+    """K-1109 lock: K-1044 B3a (S18) and B3b (S25) LAND anchors must NOT
+    admit despite firing the exact PMC P6 predicate.  The structural
+    surrogate is intentionally more conservative than the exact PMC
+    classifier here -- B3b sits below Envelope A's M>=13000 floor and B3a
+    sits below Envelope B's minMN>=2048 floor.  K-989 measured 5.31x-5.63x
+    routing speedup on the structurally-equivalent S25/S27/S28 family;
+    admitting these anchors to in-kernel would erase that gain."""
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+        f"P6 surrogate LAND-leak into K-1044 anchor {cid} ({M},{N},{K})")
+
+
+# ---------------------------------------------------------------------------
+# K-1109 brief deliverable (1) — strict-equality allowlist gate.  The
+# allowlist is consulted FIRST inside R_K1037_P6_admit_wpeu1 so it can admit
+# cells that fail the structural envelopes (the K-1074 cohort fails C1 by
+# design).  Default-OFF env gate: TRITONBLAS_K1109_P6_ALLOWLIST=1 to enable.
+#
+# Reviewer-consensus carve-out (4/4 REVISE votes on prior K-1109 attempt):
+# the original 8-cell K-1074 cohort had two cells with CI95-confirmed
+# regressions in the paired n=30 timing (S32, S37).  Those two are EXCLUDED
+# from the allowlist and pinned in K1074_REGRESSION_CARVE_OUT_PINS so any
+# silent re-add fails CI.  The shipped allowlist is therefore 6 cells.
+# ---------------------------------------------------------------------------
+K1074_COHORT_6 = [
+    ("S26",  8064, 2048, 1024),
+    ("S31", 18304, 2048, 1024),
+    ("S33", 22400, 2048, 1024),
+    ("S34", 24448, 2048, 1024),
+    ("S35", 26496, 2048, 1024),
+    ("S39", 49152, 2048,  256),
+]
+
+# Pinned regression evidence — keys are (cid, M, N, K, dtype),
+# values are the K-1074 paired n=30 timing measurements.  These cells must
+# stay OUT of the allowlist; if anybody re-adds them to
+# _K1109_P6_K1074_ALLOWLIST without first refuting this evidence with a
+# fresh paired backtest, K1074_REGRESSION_CARVE_OUT_PINS fails.
+K1074_REGRESSION_CARVE_OUT_PINS = [
+    # (cid,    M,  N,    K, dtype,            mean_pct, ci95_lo, ci95_hi)
+    ("S32", 20352, 2048, 1024, "torch.bfloat16",   -0.5101, -0.872,  -0.1481),
+    ("S37", 25600, 2048,  256, "torch.bfloat16",   -0.6806, -1.1294, -0.2318),
+]
+
+
+def test_p6_k1109_allowlist_contents_are_pinned():
+    """The allowlist content is part of the public contract of K-1109's
+    diff — pin the exact tuples so any silent edit fails CI."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16") for _cid, M, N, K in K1074_COHORT_6)
+    assert _K1109_P6_K1074_ALLOWLIST == expected
+
+
+def test_p6_k1109_allowlist_env_var_name_is_pinned():
+    """Pin the env var name (operators set this to enable; renaming silently
+    would break runbooks)."""
+    assert _K1109_P6_ALLOWLIST_ENV == "TRITONBLAS_K1109_P6_ALLOWLIST"
+
+
+def test_p6_k1109_regression_carve_out_pins():
+    """K-1109 reviewer-consensus regression-guard.  The two K-1074 cells
+    whose paired n=30 timing showed CI95 entirely below zero (S32, S37)
+    must NEVER appear in the allowlist.  Pinning the (M,N,K,dtype) tuples
+    here as the canonical exclusion set means a future contributor who
+    silently re-adds either cell will trip both this test AND the
+    contents-pinned test above; the docstring carries the exact CI95
+    evidence so the reviewer reading the diff sees WHY.
+
+    Source: workspace output/k1109_k1074_timing.json (derived from
+    K-1074/output/rr_summary.csv, c42/MI300X HIP-graph hot-cache, n=30
+    paired)."""
+    # 1) Exclusion frozenset is correctly populated.
+    expected_exclusions = frozenset(
+        (M, N, K, dtype) for _cid, M, N, K, dtype, *_ in
+        K1074_REGRESSION_CARVE_OUT_PINS)
+    assert _K1109_P6_K1074_REGRESSION_EXCLUSIONS == expected_exclusions
+    # 2) Exclusions and allowlist are disjoint (the contract).
+    assert _K1109_P6_K1074_REGRESSION_EXCLUSIONS.isdisjoint(
+        _K1109_P6_K1074_ALLOWLIST), (
+        "REGRESSION GUARD: a K-1074 cell with CI95-confirmed regression in "
+        "paired n=30 timing was re-added to _K1109_P6_K1074_ALLOWLIST. "
+        "See the docstring on _K1109_P6_K1074_ALLOWLIST in "
+        "include/tritonblas/_route_predicate.py for the timing evidence.")
+    # 3) For each excluded cell, the recorded CI95 upper bound is below
+    #    zero — i.e. the regression evidence pinned here is real.
+    for cid, M, N, K, dtype, mean_pct, ci_lo, ci_hi in \
+            K1074_REGRESSION_CARVE_OUT_PINS:
+        assert ci_hi < 0.0, (
+            f"REGRESSION-EVIDENCE PIN: {cid} ({M},{N},{K},{dtype}) "
+            f"CI95 upper bound is {ci_hi}, expected < 0 (i.e. confirmed "
+            f"regression).  If this assertion fails because the timing was "
+            f"re-measured, the cell should also be considered for re-add to "
+            f"the allowlist.")
+
+
+@pytest.mark.parametrize("cid,M,N,K,dtype,_mean,_lo,_hi",
+                         K1074_REGRESSION_CARVE_OUT_PINS,
+                         ids=[r[0] for r in K1074_REGRESSION_CARVE_OUT_PINS])
+def test_p6_k1109_regressing_cells_never_admit_even_when_env_set(
+        cid, M, N, K, dtype, _mean, _lo, _hi, monkeypatch):
+    """Hazard pin: even with the gate flipped ON, the two K-1074 cells with
+    CI95-confirmed regressions in paired n=30 timing must NOT admit (since
+    they are not in the allowlist; this test lives next to the carve-out
+    documentation so a contributor who re-adds them sees the failing test
+    cite this exact reason)."""
+    monkeypatch.setenv(_K1109_P6_ALLOWLIST_ENV, "1")
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+        f"REGRESSION HAZARD: K-1074 cell {cid} ({M},{N},{K}) admitted "
+        f"into wpeu=1 route despite CI95-confirmed regression in paired "
+        f"n=30 timing.  See _K1109_P6_K1074_REGRESSION_EXCLUSIONS in "
+        f"include/tritonblas/_route_predicate.py.")
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1074_COHORT_6,
+                         ids=[c[0] for c in K1074_COHORT_6])
+def test_p6_k1109_allowlist_inert_when_env_unset(cid, M, N, K, monkeypatch):
+    """Default-OFF: with the env gate unset, allowlisted cells must NOT
+    admit (preserves K-1037 18/18 + K-1109 24/24 confusion-matrix integrity
+    that the structural surrogate inherits).  Locks the K-1074 paired n=30
+    NULL-RESULT (0/6 cleared the K-901 +2% LAND margin) into CI as the
+    production default."""
+    monkeypatch.delenv(_K1109_P6_ALLOWLIST_ENV, raising=False)
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+        f"K-1109 allowlist leaked when env unset on {cid} ({M},{N},{K})")
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1074_COHORT_6,
+                         ids=[c[0] for c in K1074_COHORT_6])
+def test_p6_k1109_allowlist_admits_when_env_set(cid, M, N, K, monkeypatch):
+    """Gate-ON: with TRITONBLAS_K1109_P6_ALLOWLIST=1, the 6 non-regressing
+    K-1074 cells admit.  This is the brief's "strict-equality fallback for
+    the validated 8-cell set as a safety net" deliverable, with the two
+    regression-confirmed cells (S32, S37) carved out per reviewer
+    consensus.  A future fresh n=30 c42/MI300X backtest will determine
+    whether this gate flips on by default."""
+    monkeypatch.setenv(_K1109_P6_ALLOWLIST_ENV, "1")
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True, (
+        f"K-1109 allowlist failed to admit gated {cid} ({M},{N},{K})")
+
+
+def test_p6_k1109_allowlist_does_not_widen_to_negatives_when_set(monkeypatch):
+    """Gate-ON must NOT admit any held-out K-1017 negative (zero false
+    positive on the K-1037 calibration set even with the gate flipped)."""
+    monkeypatch.setenv(_K1109_P6_ALLOWLIST_ENV, "1")
+    # K-1017 OCC negatives that sit OUTSIDE the K-1074 cohort:
+    held_out = [
+        ("S30", 16256, 2048, 1024),  # OCC ratio 1.7530 — collinearity wall
+        ("S38",   384,  128,  200),  # HBM-bound, K=200
+        ("S07",  2048, 1792,  256),  # OCC shallow-K
+        ("S16",   256,  256, 2048),  # OCC small-mild-rect
+        ("S14",  1024, 1024, 1024),  # OCC square (K-1017 cohort)
+    ]
+    for cid, M, N, K in held_out:
+        assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is False, (
+            f"K-1109 allowlist false-positive on held-out NEG {cid} "
+            f"({M},{N},{K}) when env set")
+
+
+def test_p6_k1109_allowlist_only_admits_bf16_when_set(monkeypatch):
+    """Gate-ON must still respect the bf16-only carve-out (K-1037 ground
+    truth scope is bf16 only)."""
+    monkeypatch.setenv(_K1109_P6_ALLOWLIST_ENV, "1")
+    M, N, K = 8064, 2048, 1024  # S26 — bf16 entry in the allowlist
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.float16) is False
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.float32) is False
+
+
+def test_p6_c1_collinearity_wall_is_load_bearing():
+    """K-1109 lock: Envelope A's M=14999 ceiling exists because S30
+    (M=16256, ratio=1.7530, OCC) and S34 (M=24448, ratio=1.7530, OCC)
+    collide exactly on C1.  No structural-surrogate cutoff in the
+    waves_ratio interval (1.5320, 1.7530] can admit S34 without producing
+    a false positive on S30 -- so the M-band must be enforced via shape
+    coordinates rather than a 'tighten C1' relaxation.  This test pins
+    that S30 and S34 receive the same NO_FIRE verdict (both must remain
+    OUTSIDE Envelope A) and that the ceiling stops at M=14999."""
+    # S30 and S34 both NEG; S29 (between them, M=14208) is the only POS.
+    assert R_K1037_P6_admit_wpeu1(16256, 2048, 1024, torch.bfloat16) is False  # S30
+    assert R_K1037_P6_admit_wpeu1(24448, 2048, 1024, torch.bfloat16) is False  # S34
+    assert R_K1037_P6_admit_wpeu1(14208, 2048, 1024, torch.bfloat16) is True   # S29
+
+
+# ---------------------------------------------------------------------------
+# K-1144 P8 — MFMA-issue-stall direct hipBLASLt route-OUT.  Productionizes
+# K-1121 (13-cell anchor cohort) + K-1131 (12-cell held-out neighbor
+# envelope).  Pin tests cover (a) 25/25 envelope cells route-OUT at the
+# dispatch level, (b) bf16-only carve-out, (c) precedence-vs-K-1089:
+# overlap cells (S24, S29, N11) route-OUT despite P6 admit, (d) no-overlap
+# guarantee with the K-1062 K-floor=512 / K-1066 P5 / K-1109 allowlist
+# productionized predicates, (e) zero-leak vs the K-984/K-989 LAND anchors
+# and the K-950 LAND set, (f) provenance pins so the 25-cell envelope
+# can't silently drift.
+# ---------------------------------------------------------------------------
+K1121_P8_ANCHORS_13_LIST = [
+    # (cid,    M,  N,    K)  -- per K-1121 manifest, paired n=30 hot-cache
+    ("S24",  4480, 3072,  768),
+    ("S29", 14208, 2048, 1024),
+    ("S18",  5972, 1792,  768),
+    ("S25",  6016, 2048, 1024),
+    ("S30", 16256, 2048, 1024),
+    ("S26",  8064, 2048, 1024),
+    ("S31", 18304, 2048, 1024),
+    ("S32", 20352, 2048, 1024),
+    ("S33", 22400, 2048, 1024),
+    ("S34", 24448, 2048, 1024),
+    ("S35", 26496, 2048, 1024),
+    ("S37", 25600, 2048,  256),
+    ("S39", 49152, 2048,  256),
+]
+
+
+K1131_P8_NEIGHBORS_12_LIST = [
+    # (cid,    M,    N,    K, anchor, axis-direction)
+    ("N01", 20352, 2048,  512),  # S32 K/2
+    ("N02", 20352, 2048, 2048),  # S32 K*2
+    ("N03", 40704, 2048, 1024),  # S32 M*2
+    ("N04", 10176, 2048, 1024),  # S32 M/2  (envelope edge 1.604x)
+    ("N05", 20352, 4096, 1024),  # S32 N*2
+    ("N06", 20352, 1024, 1024),  # S32 N/2  (cohort MAX 1.657x)
+    ("N07", 49152, 2048,  128),  # S39 K/2
+    ("N08", 49152, 2048,  512),  # S39 K*2
+    ("N09",  5972,  896,  768),  # S18 N/2
+    ("N10",  5972, 3584,  768),  # S18 N*2
+    ("N11",  2240, 3072,  768),  # S24 M/2  (P6 Env-B overlap)
+    ("N12",  4480, 3072, 1536),  # S24 K*2
+]
+
+
+# K-931 control sample — 5 cells from the K-931 always-uncovered top-40
+# catalog that K-1127 confirmed are NOT in the K-1121 envelope.  Pinned
+# here as the "P8 must NOT leak into K-931 controls" no-false-positive
+# witness; mirrors K-1127's 0-FP adversarial backtest verdict.
+K931_CONTROL_CELLS_5 = [
+    ("K931_C01",   1024, 1024, 1240),  # K-989 LAND anchor (S40)
+    ("K931_C02",   2048, 1024, 1024),  # mid-square mid-K
+    ("K931_C03",  16384, 8192, 1024),  # extreme-M extreme-N
+    ("K931_C04",   2048, 2048, 4096),  # square mid-K
+    ("K931_C05",   4096, 4096, 2048),  # square mid-K
+]
+
+
+def test_k1322_p8_envelope_size_is_exactly_51_after_k1297_a1_extension():
+    """K-1322 unified composition: 13 K-1121 anchors + 12 K-1131 neighbors
+    + 3 K-1175/K-1161 E2 admits + 8 K-1205 E_N3 N=128 admits + 7 K-1219
+    E3 N=256 admits + 8 K-1283/K-1297 A1 perturbations = 51 cells.  Any
+    silent edit changes this count and trips this canary.
+
+    Provenance chain:
+      * K-1144 originally pinned 25.
+      * K-1175 extended by 3 K-1161-validated cells (E2_I4 K-interior
+        admit + 2 M-axis admits at K=1024) -> 28.
+      * K-1216 stacked E1 envelope after P8 (no envelope-size change).
+      * K-1231 / K-1205 extended by 8 N=128 cells (E_N3 cohort) -> 36
+        (productionised in K-1275 on top of K-1216 stacked dispatch).
+      * K-1219 / K-1240 extended by 7 N=256 cells (E3 cohort,
+        K-1131-style anchor projection at N-floor=256), validated
+        independently on commit f110d64 (fix/K-1219-n256).  +7 -> 43
+        (K-1303 unified composition).
+      * K-1283 / K-1297 extended by 8 A1 sub-cohort cells -- K-1131-style
+        +/-1-power-of-2 perturbations of A1 anchors that K-1131 itself
+        did NOT enumerate (S25 5/5 axes, S29 3/6 axes), validated
+        independently on commit f4cc5cf (fix/K-1283-A1).  +8 -> 51
+        (K-1322 unified composition).  The K-1297 cells overlap the
+        K-1131 / K-1121 N axis (N in {1024, 2048, 4096}) but always
+        differ on (M, K) by construction; disjointness asserted at
+        module load."""
+    assert len(_P8_MFMA_ISSUE_STALL_ROUTEOUT) == 51
+    assert len(_K1121_P8_ANCHORS_13) == 13
+    assert len(_K1131_P8_NEIGHBORS_12) == 12
+    assert len(_K1161_E2_ADMITS_3) == 3
+    assert len(_K1205_EN3_ADMITS_8) == 8
+    assert len(_K1219_E3_NFLOOR256_ADMITS_7) == 7
+    assert len(_K1283_A1_PERTURBATIONS_8) == 8
+    # K-1303 cross-band disjointness pin: K-1227 (N=128) vs K-1219 (N=256).
+    assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1205_EN3_ADMITS_8)
+    # K-1322 K-1297 cross-disjointness with all five prior sub-frozensets.
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1121_P8_ANCHORS_13)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1131_P8_NEIGHBORS_12)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1161_E2_ADMITS_3)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1205_EN3_ADMITS_8)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1219_E3_NFLOOR256_ADMITS_7)
+
+
+def test_k1144_p8_anchors_and_neighbors_are_disjoint():
+    """K-1131 neighbor generation rules require strict disjointness from
+    the 13 K-1121 anchors (perturbation moves AWAY from the anchor)."""
+    assert _K1121_P8_ANCHORS_13.isdisjoint(_K1131_P8_NEIGHBORS_12)
+
+
+def test_k1144_p8_envelope_contents_are_pinned_to_k1121_manifest():
+    """Pin the K-1121 13-anchor envelope to source-of-truth (the K-1121
+    manifest).  A silent edit to either constant trips here."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16") for _cid, M, N, K in K1121_P8_ANCHORS_13_LIST)
+    assert _K1121_P8_ANCHORS_13 == expected
+
+
+def test_k1144_p8_envelope_contents_are_pinned_to_k1131_manifest():
+    """Pin the K-1131 12-neighbor envelope to source-of-truth (the K-1131
+    manifest).  A silent edit to either constant trips here."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16") for _cid, M, N, K in K1131_P8_NEIGHBORS_12_LIST)
+    assert _K1131_P8_NEIGHBORS_12 == expected
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1121_P8_ANCHORS_13_LIST,
+                         ids=[c[0] for c in K1121_P8_ANCHORS_13_LIST])
+def test_k1144_p8_admits_all_13_k1121_anchors(cid, M, N, K):
+    """Every K-1121 anchor must fire the P8 strict-equality match.
+    These 13 cells were paired-n=30 measured at hbl/tb >= 1.10x mean
+    AND CI95-lo >= 1.05x (K-1007 admission floor) on rad-mi300x-1."""
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True, (
+        f"K-1121 anchor {cid} ({M},{N},{K}) missed P8 envelope")
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1131_P8_NEIGHBORS_12_LIST,
+                         ids=[c[0] for c in K1131_P8_NEIGHBORS_12_LIST])
+def test_k1144_p8_admits_all_12_k1131_neighbors(cid, M, N, K):
+    """Every K-1131 neighbor must fire the P8 strict-equality match.
+    These 12 cells classified IN_COHORT at the stricter generalization
+    gate (ratio >= 1.15x AND CI95-lo > 1.00) per K-1131 manifest."""
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True, (
+        f"K-1131 neighbor {cid} ({M},{N},{K}) missed P8 envelope")
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1121_P8_ANCHORS_13_LIST + K1131_P8_NEIGHBORS_12_LIST,
+                         ids=[c[0] for c in K1121_P8_ANCHORS_13_LIST + K1131_P8_NEIGHBORS_12_LIST])
+def test_k1144_p8_dispatch_routes_all_25_cells_out_to_hbl(cid, M, N, K):
+    """Integration pin: every P8 cell must dispatch to hipBLASLt at the
+    full ``_k971_route_to_hbl`` decision level (composition with P5/P6/
+    K-905-K-971 anchor table).  This is the load-bearing production
+    contract: K-1121 + K-1131 paired n=30 measurements show hipBLASLt
+    wins on every one of these 25 cells."""
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True, (
+        f"P8 cell {cid} ({M},{N},{K}) failed to route-OUT through "
+        f"_k971_route_to_hbl; check P8 precedence vs K-1089 P6 admit")
+
+
+def test_k1144_p8_is_bf16_only():
+    """K-1121 / K-1131 measurement scope is bf16; fp16 / fp32 must
+    short-circuit (fp16 parity is tracked separately on the K-1093 line)."""
+    M, N, K = 4480, 3072, 768  # S24
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.float16) is False
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.float32) is False
+
+
+def test_k1144_p8_string_dtype_compat_with_route_table():
+    """Like the K-905/K-971 anchor table, P8 accepts the literal string
+    ``"torch.bfloat16"`` (used in tests and in the dispatch site's
+    ``str(a_dtype)``) so the route table and the predicate share key
+    semantics."""
+    assert _p8_mfma_issue_stall_routeout(4480, 3072, 768, "torch.bfloat16") is True
+    assert _p8_mfma_issue_stall_routeout(4480, 3072, 768, "torch.float16") is False
+
+
+@pytest.mark.parametrize("cid,M,N,K", P6_POSITIVES, ids=[c[0] for c in P6_POSITIVES])
+def test_k1144_p8_overrides_k1089_p6_admit_on_overlap(cid, M, N, K):
+    """Precedence pin: S24 and S29 are inside K-1089 P6 envelopes (P6
+    admit returns True at the unit level) but K-1121's paired n=30
+    measurement falsified that admit.  P8 must override at the dispatch
+    level (return True from ``_k971_route_to_hbl``).  This is the load-
+    bearing composition rule -- if a future contributor reorders P8 to
+    AFTER P6, this test fails."""
+    # Unit-level: P6 still admits (preserves K-1037 18/18).
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True
+    # Unit-level: P8 also fires (cell is in the K-1121 envelope).
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True
+    # Composed-dispatch-level: P8 wins -> route to hipBLASLt.
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True
+
+
+def test_k1144_p8_overrides_k1089_p6_admit_on_n11_neighbor_overlap():
+    """N11 = (2240, 3072, 768) is the K-1131 neighbor that perturbs S24
+    along M/2.  It still sits inside K-1089 P6 Envelope B (minMN=2240
+    >= 2048; maxMN=3072 <= 4500; K=768 in [512, 1024]).  K-1131 measured
+    it IN_COHORT at the >= 1.15x gate, so P8 must override P6 here too --
+    same precedence rule as for the 13 anchors."""
+    M, N, K = 2240, 3072, 768
+    assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True
+
+
+@pytest.mark.parametrize("cid,M,N,K", K931_CONTROL_CELLS_5,
+                         ids=[c[0] for c in K931_CONTROL_CELLS_5])
+def test_k1144_p8_does_not_leak_into_k931_control_cells(cid, M, N, K):
+    """K-1127's adversarial backtest of K-1121 against the K-931 always-
+    uncovered top-40 catalog reported 0 false positives (FP rate 0.0%
+    < 5% productionisation gate).  Pin a 5-cell K-931 control sample as
+    a no-leak witness; P8 strict-equality must NOT match any control.
+    (P5 / K-905 / K-971 may legitimately route some controls -- this test
+    only proves P8 itself is non-leaky on the controls.)"""
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is False, (
+        f"P8 leaked into K-931 control {cid} ({M},{N},{K}) -- envelope "
+        f"must remain strictly the K-1121 + K-1131 25-cell set.")
+
+
+def test_k1144_p8_disjoint_from_k1109_allowlist_keys():
+    """K-1109's env-gated allowlist (default OFF) is a wpeu=1 admit list
+    -- it pulls cells BACK to in-kernel.  P8 is a route-OUT predicate.
+    The K-1109 allowlist contents and P8 contents OVERLAP by design
+    (K-1109 covers 6 of the K-1074 cohort cells: S26, S31, S33, S34,
+    S35, S39 -- all also in K-1121); the design intent is that P8's
+    BEFORE-P6 placement makes the K-1109 admit inert when its env is
+    set, so the production default behaviour is consistent regardless
+    of K-1109's gate state.  This test verifies that even with the
+    K-1109 env ON, every overlap cell still routes OUT through P8."""
+    overlap = _K1121_P8_ANCHORS_13 & _K1109_P6_K1074_ALLOWLIST
+    # K-1109 allowlist is 6 cells; all 6 are in the K-1121 13-anchor set.
+    assert len(overlap) == 6, (
+        f"Expected 6-cell overlap between K-1109 allowlist and K-1121 "
+        f"anchors (K-1109 documents this); got {len(overlap)}")
+
+
+def test_k1144_p8_overrides_k1109_allowlist_when_env_set(monkeypatch):
+    """With TRITONBLAS_K1109_P6_ALLOWLIST=1, K-1109 admits 6 cells back
+    to in-kernel (R_K1037_P6_admit_wpeu1 returns True via the allowlist
+    short-circuit).  P8's BEFORE-P6 placement must still route those
+    cells OUT to hipBLASLt -- the K-1121 paired n=30 evidence supersedes
+    the K-1109 default-OFF admit hypothesis."""
+    monkeypatch.setenv(_K1109_P6_ALLOWLIST_ENV, "1")
+    overlap_cells = [
+        ("S26",  8064, 2048, 1024),
+        ("S31", 18304, 2048, 1024),
+        ("S33", 22400, 2048, 1024),
+        ("S34", 24448, 2048, 1024),
+        ("S35", 26496, 2048, 1024),
+        ("S39", 49152, 2048,  256),
+    ]
+    for cid, M, N, K in overlap_cells:
+        # K-1109 allowlist admits at unit level (gate ON).
+        assert R_K1037_P6_admit_wpeu1(M, N, K, torch.bfloat16) is True, (
+            f"K-1109 allowlist failed to admit {cid} with env set")
+        # But P8 overrides at dispatch level -> route OUT.
+        assert _k971_route_to_hbl(
+            M, N, K, torch.bfloat16, torch.bfloat16,
+            enable_streamk=False, work_stealing=False) is True, (
+            f"P8 failed to override K-1109 allowlist on {cid} ({M},{N},{K}) "
+            f"with env set")
+
+
+def test_k1144_p8_does_not_overlap_k950_land_set():
+    """K-950 9-cell LAND set must remain non-routed by P8 (the LAND set
+    is the K-912/K-883 NO-LAND-for-guarded-overrides cohort).  P8 strict-
+    equality must NOT match any K-950 LAND cell; this preserves the
+    zero-leakage property the K-1003 P5 verification contract guarantees."""
+    for cid, M, N, K, dtype, _cohort in K950_LAND_CELLS:
+        assert _p8_mfma_issue_stall_routeout(M, N, K, dtype) is False, (
+            f"P8 leaked into K-950 LAND set on {cid} ({M},{N},{K},{dtype})")
+
+
+def test_k1144_p8_streamk_workstealing_dtype_mismatch_carve_outs_still_fire():
+    """Pin the existing dispatch-level carve-outs (streamk / work-stealing /
+    a_dtype != b_dtype) still short-circuit even when P8 would otherwise
+    fire.  P8 lives BELOW these carve-outs in ``_k971_route_to_hbl`` so
+    the operator-set escape hatches keep priority."""
+    M, N, K = 4480, 3072, 768  # S24 -- in P8 envelope
+    # streamk on -> no route
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=True, work_stealing=False) is False
+    # work-stealing on -> no route
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=True) is False
+    # dtype mismatch -> no route
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.float16,
+        enable_streamk=False, work_stealing=False) is False
+
+
+def test_k1144_p8_disable_env_var_short_circuits():
+    """The TRITONBLAS_DISABLE_K971 killswitch must continue to disable
+    P8 -- one disable lever per K-883 R1 (one cohort, one disable)."""
+    import os
+    M, N, K = 4480, 3072, 768  # S24
+    saved = os.environ.get("TRITONBLAS_DISABLE_K971")
+    try:
+        os.environ["TRITONBLAS_DISABLE_K971"] = "1"
+        assert _k971_route_to_hbl(
+            M, N, K, torch.bfloat16, torch.bfloat16,
+            enable_streamk=False, work_stealing=False) is False
+    finally:
+        if saved is None:
+            os.environ.pop("TRITONBLAS_DISABLE_K971", None)
+        else:
+            os.environ["TRITONBLAS_DISABLE_K971"] = saved
+
+
+def test_k1144_p8_does_not_match_perturbations_outside_envelope():
+    """Strict-equality discipline (R-1131): the cohort is a structural
+    pocket but the route table is strict-equality only.  Verify that
+    near-miss perturbations of the K-1121 anchors that K-1131 did NOT
+    sample do NOT match P8 -- specifically, +/-1 in a single dimension
+    away from any anchor that is NOT one of the 12 K-1131 neighbors."""
+    # S24 = (4480, 3072, 768).  K=767 / K=769 are not in the envelope
+    # (the K-1131 K-axis perturbations of S24 are K*2=1536 only; K/2 was
+    # not sampled because it would have hit the K=384 region below P5
+    # Clause-2's 256-or-1024 pin).
+    assert _p8_mfma_issue_stall_routeout(4480, 3072, 767, torch.bfloat16) is False
+    assert _p8_mfma_issue_stall_routeout(4480, 3072, 769, torch.bfloat16) is False
+    # M=4479 / M=4481 not in envelope.
+    assert _p8_mfma_issue_stall_routeout(4479, 3072, 768, torch.bfloat16) is False
+    assert _p8_mfma_issue_stall_routeout(4481, 3072, 768, torch.bfloat16) is False
+
+
+# ---------------------------------------------------------------------------
+# K-1175 / K-1161 E2 axis-extension pin tests.  K-1161 paired n=30 HIP-graph
+# hot-cache (B=10000 bootstrap CI95) on rad-mi300x-1 / MI300X / ROCm 7.2
+# returned NEGATIVE_AXIS_PIVOT for the K-floor=128 + K=512 interior axis
+# (3/8 = 37.5% admit, below 50% pivot threshold).  Three cells admit cleanly
+# and are staged here as strict-equality additions to P8:
+#   E2_I4  ( 736, 1792,  736)  hbl/tb=1.315x  CI95=[1.313, 1.317]
+#   E2_M1  (10112, 2048, 1024) hbl/tb=1.759x  CI95=[1.753, 1.770]
+#   E2_M2  (12160, 2048, 1024) hbl/tb=1.499x  CI95=[1.496, 1.504]
+#
+# Pin tests cover (a) 3/3 envelope cells route-OUT at the dispatch level,
+# (b) bf16-only carve-out, (c) disjointness with K-1121 anchors and K-1131
+# neighbors, (d) NO-LEAK guarantees: the 5 K-1161 cells classified as
+# route-IN-safe / ambiguous (E2_K1, E2_K2, E2_I1, E2_I2, E2_I3) MUST NOT
+# fire P8 -- staging them would cause production false-positives (TB-WIN
+# cells routed to slower hipBLASLt).  See the _K1161_E2_ADMITS_3 docstring
+# for the K-floor relaxation mechanism (R-1161 small-M Triton-favoured tail).
+# ---------------------------------------------------------------------------
+K1161_E2_ADMITS_3_LIST = [
+    # (cid,    M,    N,    K, hbl_tb_med, ci95_lo, ci95_hi)  per K-1161 manifest
+    ("E2_I4",   736, 1792,  736),  # K=736 K-interior single admit (hbl/tb=1.315x)
+    ("E2_M1", 10112, 2048, 1024),  # M-axis extension at K=1024 (hbl/tb=1.759x)
+    ("E2_M2", 12160, 2048, 1024),  # M-axis extension at K=1024 (hbl/tb=1.499x)
+]
+
+
+# K-1161 cells that K-1161 measured as route-IN-safe (TB strictly faster) or
+# ambiguous.  These cells are inside the E2 envelope but were REJECTED by
+# the paired n=30 measurement -- staging them as route-OUT would create
+# production FALSE POSITIVES (TB wins routed to slower hipBLASLt).  Pinned
+# here as a no-leak witness so any future contributor who tries to widen
+# the K-floor or the K=512 interior must trip these tests first.
+K1161_E2_REJECTED_5_LIST = [
+    # (cid,    M,    N,    K, hbl_tb_med, classification)  per K-1161 manifest
+    ("E2_K1",  512, 2048,   96),  # 0.810x  route-IN-safe (TB +23% faster)
+    ("E2_K2",  512, 2048,  192),  # 1.020x  ambiguous     (within noise floor)
+    ("E2_I1",  192, 2048,  512),  # 0.868x  route-IN-safe (TB +15% faster)
+    ("E2_I2",  156, 1792,  512),  # 0.914x  route-IN-safe (TB +9% faster)
+    ("E2_I3",  160, 3072,  512),  # 0.907x  route-IN-safe (TB +10% faster)
+]
+
+
+def test_k1175_e2_admits_envelope_size_is_exactly_3():
+    """K-1161 measured 8 E2 candidates (K-floor=128 + K=512/736 interior +
+    M-axis extension).  Exactly 3 admit route-OUT-safe (hbl/tb >= 1.05x AND
+    CI95-lo > 1.00).  Any silent edit changes this count and trips here."""
+    assert len(_K1161_E2_ADMITS_3) == 3
+
+
+def test_k1175_e2_admits_disjoint_from_k1121_and_k1131():
+    """K-1161 candidate generator (K-931 always-uncovered top-40 catalog
+    intersected with E2 envelope) excluded all K-1121 anchors and all
+    K-1131 neighbors by construction."""
+    assert _K1161_E2_ADMITS_3.isdisjoint(_K1121_P8_ANCHORS_13)
+    assert _K1161_E2_ADMITS_3.isdisjoint(_K1131_P8_NEIGHBORS_12)
+
+
+def test_k1175_e2_admits_envelope_contents_pinned_to_k1161_manifest():
+    """Pin the 3-cell E2 admit envelope to source-of-truth (the K-1161
+    paired n=30 manifest at workspace K-1161/output/k1161_per_cell.csv).
+    A silent edit to either constant trips here."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16") for _cid, M, N, K in K1161_E2_ADMITS_3_LIST)
+    assert _K1161_E2_ADMITS_3 == expected
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1161_E2_ADMITS_3_LIST,
+                         ids=[c[0] for c in K1161_E2_ADMITS_3_LIST])
+def test_k1175_p8_admits_all_3_k1161_e2_cells(cid, M, N, K):
+    """Every K-1161 E2 admit must fire the P8 strict-equality match.
+    These 3 cells were paired n=30 measured at hbl/tb >= 1.315x mean
+    AND CI95-lo > 1.05x (route-OUT-safe gate) on rad-mi300x-1."""
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True, (
+        f"K-1161 E2 admit {cid} ({M},{N},{K}) missed P8 envelope")
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1161_E2_ADMITS_3_LIST,
+                         ids=[c[0] for c in K1161_E2_ADMITS_3_LIST])
+def test_k1175_p8_dispatch_routes_all_3_k1161_e2_cells_out_to_hbl(cid, M, N, K):
+    """Integration pin: every K-1161 E2 admit must dispatch to hipBLASLt
+    at the full ``_k971_route_to_hbl`` decision level (composition with
+    P5/P6/K-905-K-971 anchor table).  K-1161's paired n=30 measurement
+    shows hipBLASLt wins on every one of these 3 cells at >= 1.315x."""
+    assert _k971_route_to_hbl(
+        M, N, K, torch.bfloat16, torch.bfloat16,
+        enable_streamk=False, work_stealing=False) is True, (
+        f"K-1161 E2 admit {cid} ({M},{N},{K}) failed to route-OUT through "
+        f"_k971_route_to_hbl; check P8 precedence vs K-1089 P6 admit")
+
+
+def test_k1175_p8_e2_admits_are_bf16_only():
+    """K-1161 measurement scope is bf16; fp16/fp32 must short-circuit."""
+    M, N, K = 736, 1792, 736  # E2_I4
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.float16) is False
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.float32) is False
+
+
+@pytest.mark.parametrize("cid,M,N,K", K1161_E2_REJECTED_5_LIST,
+                         ids=[c[0] for c in K1161_E2_REJECTED_5_LIST])
+def test_k1175_p8_does_not_leak_into_k1161_rejected_cells(cid, M, N, K):
+    """K-1161 NO-LEAK pin: the 5 E2 candidates that classified as
+    route-IN-safe (TB strictly faster) or ambiguous MUST NOT fire P8.
+
+    Staging any of these as route-OUT would create production FALSE
+    POSITIVES -- TB-WIN cells (M <= 512 small-M Triton-favoured tail
+    per R-1161) routed to a slower hipBLASLt path.  This is the load-
+    bearing K-floor=128 + K=512 NEGATIVE_AXIS_PIVOT contract: K-floor
+    must remain at K >= 256 and K=512 interior is not a hipBLASLt-favored
+    region for the small-M sub-cohort.  If a future contributor widens
+    the envelope to K-floor=128 or to K=512 with M < ~600, this test
+    fails and they must re-validate at paired n=30 first."""
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is False, (
+        f"K-1161 REJECTED cell {cid} ({M},{N},{K}) leaked into P8 -- "
+        f"this cell is TB-favoured (hbl/tb < 1.05x); routing it OUT "
+        f"would be a strict pessimisation per K-1161 paired n=30 evidence.")
+
+
+def test_k1175_p8_does_not_leak_into_k1142_fp_controls():
+    """K-1142 documented 2 false positives at K=256 small-M corner.
+    K-1161 re-confirmed both at n=30: FP1 (256, 2048, 256) hbl/tb=0.972x,
+    FP2 (2048, 1792, 256) hbl/tb=1.035x.  Both must remain OUT of P8."""
+    # FP1 — clear route-IN-safe
+    assert _p8_mfma_issue_stall_routeout(256, 2048, 256, torch.bfloat16) is False
+    # FP2 — ambiguous, drifted +0.020 between K-1142 and K-1161
+    assert _p8_mfma_issue_stall_routeout(2048, 1792, 256, torch.bfloat16) is False
+
+
+def test_k1175_p8_e2_admits_e2_i4_is_in_k_interior_upper_edge():
+    """Documentation pin: E2_I4 is the only K-interior cell that admitted.
+    It sits at K=736, on the upper edge of the K-axis extension (closer to
+    E1's existing K=768 anchor than to the K=512 interior gap or K=128
+    floor relaxation).  This is consistent with K-1161's R-1161 finding
+    that the small-K / small-M corner is Triton-favoured -- E2_I4 has
+    M=736 which is well above the small-M tail threshold (M <= 512)."""
+    M, N, K = 736, 1792, 736
+    assert (M, N, K, "torch.bfloat16") in _K1161_E2_ADMITS_3
+    assert M > 600   # outside small-M Triton-favoured tail
+    assert K >= 512  # K-interior, not K-floor
+    assert K < 768   # but below E1's K-floor anchor
+
+
+def test_k1175_p8_e2_admits_m_axis_cells_at_k1024_anchor_k():
+    """Documentation pin: E2_M1 and E2_M2 are at K=1024 (E1 anchor K) with
+    M values interior to the K-1121 anchor M-range (between S26 M=8064
+    and S29 M=14208).  These are NOT K-floor or K=512 cells -- they are
+    M-axis extension cells that K-1161 incidentally validated.  K-1127
+    classified both as EXT and they re-confirm at K-1161's measurement
+    context (hbl/tb 1.499x and 1.759x respectively)."""
+    for cid, M, N, K in (("E2_M1", 10112, 2048, 1024), ("E2_M2", 12160, 2048, 1024)):
+        assert (M, N, K, "torch.bfloat16") in _K1161_E2_ADMITS_3
+        assert K == 1024  # K-1121 anchor K, NOT K=512 / K=128
+        assert N == 2048  # K-1121 anchor N
+        # M is interior to the K-1121 anchor M-range:
+        assert 8064 < M < 14208
+
+
+# ===========================================================================
+# K-1209-stacked / K-1216 — E1 axis-aligned envelope pin tests.
+# E1 (R_K1142_E1_route_to_hbl) is stacked AFTER P8 28-cell strict-equality
+# in dispatch precedence; K-1209 ablation on K-931 always-uncovered top-40
+# confirmed E1 contributes 0 marginal cells beyond P8+K-1175 (16/40 union)
+# but E1 is retained as defense-in-depth for non-K-931 cohorts where the
+# audit chain has not converged. These tests pin (a) the K-1142 carve-out
+# floors holding against the 2 K-1142 inverse-predicate FPs, (b) E1
+# admitting all K-1121 anchors that lie inside its envelope, and (c) the
+# E2 K-floor=128 exclusion (K-1176 cross-arch failure: do NOT relax K_FLOOR
+# from 256 to 128 — 0/8 cells admit on MI325X/MI355X).
+# ===========================================================================
+
+
+def test_k1216_e1_envelope_constants_pinned():
+    """K-1209-stacked / K-1216: pin the K-1142 E1 envelope structural
+    constants. A future refactor that loosens these values silently
+    re-admits the K-1142 inverse-predicate FPs and breaks the 0-FP
+    composition guarantee K-1209 confirmed across 4 stacked configs.
+    """
+    assert K1142_E1_NS == frozenset({1792, 2048, 3072})
+    assert K1142_E1_KS == frozenset({256, 768, 1024})
+    assert K1142_E1_M_FLOOR == 4480  # K-1121 anchor S24's M (margin 0)
+    assert K1142_E1_K_FLOOR == 256   # K-1161 NEGATIVE_AXIS_PIVOT pin
+
+
+def test_k1216_e1_excludes_k1142_fp1_at_M_floor():
+    """K-1142 FP1 = (M=256, N=2048, K=256) bf16: hbl/tb=0.972x (TB-TIE).
+    Must be excluded by M >= 4480 carve-out. Re-admitting this cell
+    silently re-introduces K-1142's paired-n=30 false positive."""
+    assert R_K1142_E1_route_to_hbl(256, 2048, 256, torch.bfloat16) is False
+
+
+def test_k1216_e1_excludes_k1142_fp2_at_M_floor():
+    """K-1142 FP2 = (M=2048, N=1792, K=256) bf16: hbl/tb=1.035x (TB-TIE).
+    Must be excluded by M >= 4480 carve-out (M=2048 < 4480)."""
+    assert R_K1142_E1_route_to_hbl(2048, 1792, 256, torch.bfloat16) is False
+
+
+@pytest.mark.parametrize("cid,M,N,K", [
+    ("S24",  4480, 3072,  768),
+    ("S29", 14208, 2048, 1024),
+    ("S30", 16256, 2048, 1024),
+    ("S31", 18304, 2048, 1024),
+    ("S32", 20352, 2048, 1024),
+    ("S33", 22400, 2048, 1024),
+    ("S34", 24448, 2048, 1024),
+    ("S35", 26496, 2048, 1024),
+    ("S37", 25600, 2048,  256),
+    ("S39", 49152, 2048,  256),
+])
+def test_k1216_e1_admits_k1121_anchors_inside_envelope(cid, M, N, K):
+    """K-1121 anchors that lie inside E1 envelope must be admitted.
+    These overlap with P8 strict-equality (P8 wins by precedence) but
+    E1 must independently classify them correctly so the predicate is
+    self-consistent for downstream callers / non-K-931 cohorts."""
+    assert R_K1142_E1_route_to_hbl(M, N, K, torch.bfloat16) is True
+
+
+def test_k1216_e1_excludes_e2_kfloor_128_per_k1176_cross_arch_failure():
+    """K-1176 cross-arch port of E2 K-floor=128 relaxation FAILED on both
+    MI325X and MI355X (0/8 cells admit). The K_FLOOR=256 pin in E1 must
+    reject any cell with K < 256 to prevent re-introducing the K-1176-
+    rejected K-axis relaxation. This test pins E1's K-axis floor at 256
+    against a future relaxation attempt."""
+    # Sample E2 K-floor=128 candidate cells from K-1161 audit:
+    for M in (4480, 8192, 16256):
+        for N in (1792, 2048, 3072):
+            assert R_K1142_E1_route_to_hbl(M, N, 128, torch.bfloat16) is False
+            assert R_K1142_E1_route_to_hbl(M, N, 192, torch.bfloat16) is False
+
+
+def test_k1216_e1_is_bf16_only():
+    """E1 inherits K-1142's bf16-only audit scope (the K-1051/K-1031/K-1121
+    measurement chain is bf16). Non-bf16 dtypes must return False so the
+    fp16 anchor table (K-905/K-971) and fp16 envelope (K-1093/K-1125) own
+    fp16 dispatch decisions exclusively."""
+    for dt in (torch.float16, torch.float32, torch.float64):
+        assert R_K1142_E1_route_to_hbl(4480, 2048, 768, dt) is False
+
+
+def test_k1216_e1_dispatch_stacked_after_p8_no_double_route():
+    """K-1209 dominance check: every cell E1 admits inside P8's 28-cell
+    envelope is already routed True by P8, so E1's own True is harmless
+    (idempotent). For K-1121 anchors / K-1131 neighbors / K-1175 E2
+    admits that lie inside E1, the dispatch verdict is True regardless
+    of which predicate fires first — the brief's no-double-routing
+    guarantee holds at the verdict level."""
+    # Sample 5 P8-anchored cells inside E1 envelope (overlap region):
+    for M, N, K in [(4480, 3072, 768), (14208, 2048, 1024),
+                    (10112, 2048, 1024), (16256, 2048, 1024),
+                    (49152, 2048, 256)]:
+        p8_says = _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16)
+        e1_says = R_K1142_E1_route_to_hbl(M, N, K, torch.bfloat16)
+        assert p8_says is True
+        # E1 may or may not fire depending on whether cell is inside E1
+        # envelope; verdict is True iff either fires (dispatch is OR).
+        assert (p8_says or e1_says) is True
+
+
+# ---------------------------------------------------------------------------
+# K-1231 / K-1205 E_N3 N-axis P8 envelope extension pin tests (8 admit cells
+# at N=128 + 1 no-leak carve-out for the EN_K768_S24 false positive at the
+# K-1142 M-floor).  Layered on top of K-1216's stacked dispatch chain
+# (fix/K-1209-stacked @ fb9461f); K-1216 P8/E1 stacking semantics are
+# preserved unchanged -- E_N3 admits are pure data added to the P8 union
+# frozenset, so E1's defense-in-depth role and 0-marginal-coverage verdict
+# from K-1209 are not disturbed.
+#
+# Source: K-1205 paired n=30 HIP-graph hot-cache validation on rad-mi300x-1
+# (c42 SSH plane outage 6th->10th->11th recurrence; rad-mi300x-1 fallback
+# is now load-bearing infrastructure for the entire P8 envelope investigation
+# series per R-1205.RAD-MI300X-1-IS-LOAD-BEARING-INFRASTRUCTURE-FOR-P8-
+# ENVELOPE-WORK).  Brief decision threshold: >=75% landing => STAGE_DIFF;
+# K-1205 returned 8/9 = 88.9% admit at hbl/tb_med >= 1.05x AND CI95-lo > 1.00.
+# ---------------------------------------------------------------------------
+
+K1205_EN3_ADMITS_8_LIST = [
+    # (cid, M, N, K, hbl_tb_med, CI95_lo)
+    ("EN_K1024_S25",  6016,  128, 1024, 1.370, 1.362),
+    ("EN_K1024_S26",  8064,  128, 1024, 1.402, 1.396),
+    ("EN_K1024_S29", 14208,  128, 1024, 3.254, 3.234),  # cohort MAX
+    ("EN_K1024_S30", 16256,  128, 1024, 3.024, 3.011),
+    ("EN_K1024_S33", 22400,  128, 1024, 2.258, 2.234),
+    ("EN_K256_S37",  25600,  128,  256, 1.144, 1.140),  # cohort MIN admit
+    ("EN_K256_S39",  49152,  128,  256, 1.781, 1.768),
+    ("EN_K768_S18",   5972,  128,  768, 1.227, 1.226),
+]
+
+# K-1205 N-axis false-positive carve-out: EN_K768_S24 at M=4480 K=768 N=128
+# bf16 measured hbl/tb_med = 0.967x CI95=[0.94, 1.00] -- TB-favoured at
+# the K-1142 M-floor.  Carve-out is implicit (cell is omitted from the
+# strict-equality frozenset by construction); this list is the explicit
+# regression-trap counterpart per R-1175.PIN-REJECTED-CELLS-AS-NO-LEAK-
+# WITNESSES.  A future contributor who tries to widen E_N3 to a parametric
+# envelope along the M-axis must trip this pin and re-validate at paired
+# n=30 -- same discipline K-1175 applied to the K-1161 K-axis rejects.
+K1205_EN3_REJECTED_1_LIST = [
+    # (cid, M, N, K, hbl_tb_med, mechanism)
+    ("EN_K768_S24", 4480, 128, 768, 0.967,
+     "small-M Triton-favoured tail at the K-1142 M-floor "
+     "(R-1205.SMALL-M-TRITON-FAVOURED-TAIL-IS-AXIS-AGNOSTIC-AT-COHORT-M-FLOOR)"),
+]
+
+
+def test_k1205_en3_admits_envelope_size_is_exactly_8():
+    """Pin K-1205 E_N3 sub-frozenset cardinality. The K-1205 brief gated
+    landing at >=75% of 9 candidates; the 8/9 = 88.9% empirical result
+    drives this size.  Any silent edit changes the count and trips this
+    canary."""
+    assert len(_K1205_EN3_ADMITS_8) == 8
+
+
+def test_k1205_en3_admits_pairwise_disjoint_with_k1121_k1131_k1161():
+    """K-1205 E_N3 candidates have N=128 by construction; no K-1121 anchor,
+    K-1131 neighbor, or K-1161 E2 admit has N=128, so the 4-way union is
+    pairwise disjoint without manual exclusion lists.  This is the
+    structural disjointness invariant that the runtime asserts in
+    _route_predicate.py rely on."""
+    assert _K1205_EN3_ADMITS_8.isdisjoint(_K1121_P8_ANCHORS_13)
+    assert _K1205_EN3_ADMITS_8.isdisjoint(_K1131_P8_NEIGHBORS_12)
+    assert _K1205_EN3_ADMITS_8.isdisjoint(_K1161_E2_ADMITS_3)
+
+
+def test_k1205_en3_admits_envelope_contents_pinned_to_k1205_manifest():
+    """Pin the K-1205 8-admit envelope to source-of-truth (the K-1205
+    paired n=30 dataset summarised in K1205_EN3_ADMITS_8_LIST). A silent
+    edit to either constant trips here."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16")
+        for _cid, M, N, K, _hbl_tb, _ci_lo in K1205_EN3_ADMITS_8_LIST)
+    assert _K1205_EN3_ADMITS_8 == expected
+
+
+def test_k1205_en3_admits_all_have_n_equal_128():
+    """Structural axis-discipline invariant: K-1205 staged the N-axis
+    extension at N-floor=128 ONLY. K-1161/K-1176 already established
+    that K-floor relaxation past K=256 is NEGATIVE_AXIS_PIVOT (cross-
+    arch confirmed).  Any cell in E_N3 with N != 128 would be a silent
+    drift away from the staged axis and trips here."""
+    for (M, N, K, dtype) in _K1205_EN3_ADMITS_8:
+        assert N == 128, (
+            f"K-1205 E_N3 cell {(M, N, K, dtype)!r} has N={N} != 128; "
+            "K-1205 is N-axis-only at N-floor=128 by R-1205.")
+
+
+def test_k1205_en3_admits_k_in_k1144_k_set():
+    """Structural axis-discipline invariant: K-1205 held K fixed at the
+    K-1144 K-set {256, 768, 1024} (NOT a K-axis relaxation -- K-1161
+    rejected K-floor < 256 on adjacent cells).  Any K outside this set
+    would be a covert K-axis extension and trips here."""
+    for (M, N, K, dtype) in _K1205_EN3_ADMITS_8:
+        assert K in {256, 768, 1024}, (
+            f"K-1205 E_N3 cell {(M, N, K, dtype)!r} has K={K} outside "
+            "the K-1144 K-set {256, 768, 1024}; K-1205 is N-axis-only.")
+
+
+@pytest.mark.parametrize(
+    "cid,M,N,K,hbl_tb_med,ci95_lo", K1205_EN3_ADMITS_8_LIST,
+    ids=[c[0] for c in K1205_EN3_ADMITS_8_LIST])
+def test_k1205_p8_admits_all_8_en3_cells(cid, M, N, K, hbl_tb_med, ci95_lo):
+    """Every K-1205 E_N3 admit cell must fire the P8 strict-equality
+    match.  Each was paired-n=30 measured at hbl/tb_med >= 1.144x
+    AND CI95-lo > 1.00 (K-1007 admission floor exceeded with margin)
+    on rad-mi300x-1 under HIP-graph hot-cache."""
+    assert hbl_tb_med >= 1.05, (
+        f"{cid} hbl/tb_med {hbl_tb_med:.3f}x below K-1007 admission floor")
+    assert ci95_lo > 1.00, (
+        f"{cid} CI95-lo {ci95_lo:.3f} fails CI95-lo > 1.00 gate")
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True
+
+
+@pytest.mark.parametrize(
+    "cid,M,N,K,hbl_tb_med,ci95_lo", K1205_EN3_ADMITS_8_LIST,
+    ids=[c[0] for c in K1205_EN3_ADMITS_8_LIST])
+def test_k1205_dispatch_routes_all_8_en3_cells_out_to_hbl(
+        cid, M, N, K, hbl_tb_med, ci95_lo):
+    """End-to-end dispatch check: with default carve-outs disabled,
+    _k971_route_to_hbl must return True for every K-1205 E_N3 admit
+    so the cell is routed to hipBLASLt and silently picks up the
+    measured 1.14x-3.25x speedup."""
+    decision = _k971_route_to_hbl(
+        M, N, K,
+        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
+        enable_streamk=False, work_stealing=False)
+    assert decision is True, (
+        f"{cid} (M={M} N={N} K={K}) was not routed to hipBLASLt; "
+        f"expected True per K-1205 paired n=30 hbl/tb_med={hbl_tb_med:.3f}x")
+
+
+def test_k1205_p8_en3_admits_are_bf16_only():
+    """K-1205 measurement scope is bf16 only.  fp16 / fp32 with the same
+    (M, N, K) must NOT fire P8 -- fp16 dispatch is owned by the K-1093
+    / K-1125 mirror predicate line (none of which currently covers N=128;
+    a silent expansion of P8 to fp16 would invade that ownership and
+    trips here)."""
+    for (M, N, K, _dtype) in _K1205_EN3_ADMITS_8:
+        for fp_dtype in (torch.float16, torch.float32):
+            assert _p8_mfma_issue_stall_routeout(M, N, K, fp_dtype) is False, (
+                f"P8 fired on non-bf16 dtype {fp_dtype} for "
+                f"K-1205 cell {(M, N, K)}; K-1205 is bf16-only.")
+
+
+@pytest.mark.parametrize(
+    "cid,M,N,K,hbl_tb_med,mechanism", K1205_EN3_REJECTED_1_LIST,
+    ids=[c[0] for c in K1205_EN3_REJECTED_1_LIST])
+def test_k1205_p8_does_not_leak_into_en_k768_s24_carve_out(
+        cid, M, N, K, hbl_tb_med, mechanism):
+    """NO-LEAK pin (R-1175.PIN-REJECTED-CELLS-AS-NO-LEAK-WITNESSES extended
+    to the K-1205 N-axis):  EN_K768_S24 (M=4480 N=128 K=768 bf16) was
+    measured at hbl/tb_med = 0.967x (TB-favoured) -- it is the K-1205
+    N-axis FALSE-POSITIVE CARVE-OUT.  The strict-equality frozenset
+    excludes it by construction (omission); this test is the explicit
+    regression trap.
+
+    A future contributor who tries to widen E_N3 to a parametric envelope
+    along the M-axis -- e.g. ``N == 128 AND K in {256, 768, 1024} AND M
+    in K-1121-anchor-M-set`` without an M-floor strictly above 4480 --
+    will trip this test, forcing them to either (a) re-validate at paired
+    n=30 (the right thing) or (b) explicitly remove the pin (which makes
+    the deviation auditable and traceable to the K-1142 M-floor / R-1205
+    small-M Triton-favoured tail mechanism)."""
+    assert hbl_tb_med < 1.05, (
+        f"{cid} reject pin requires measured hbl/tb_med < 1.05 (got "
+        f"{hbl_tb_med:.3f}); update K1205_EN3_REJECTED_1_LIST if "
+        "K-1205 measurements were re-run with different verdict.")
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is False, (
+        f"P8 leaked admit into K-1205 N-axis carve-out {cid} "
+        f"(M={M} N={N} K={K}); reject mechanism: {mechanism}.")
+
+
+def test_k1205_en_k768_s24_dispatch_does_not_route_to_hbl():
+    """Carve-out validated through the FULL dispatch chain (P8 -> E1 ->
+    P6 -> P5 -> K-971 anchor table).  EN_K768_S24 must NOT be routed
+    to hipBLASLt by any layer; if it is, K-1205 ships a silent
+    pessimisation worth ~3% per call on this shape."""
+    M, N, K = 4480, 128, 768
+    decision = _k971_route_to_hbl(
+        M, N, K,
+        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
+        enable_streamk=False, work_stealing=False)
+    assert decision is False, (
+        f"EN_K768_S24 (M={M} N={N} K={K}) was routed to hipBLASLt by "
+        "the dispatch chain; this is the K-1205 N-axis false-positive "
+        "carve-out -- measured TB-WIN at hbl/tb_med=0.967x.")
+
+
+def test_k1205_p8_e1_stack_no_double_route_for_en3_admits():
+    """K-1216 stacked-dispatch invariant preserved: every K-1205 E_N3
+    admit fires P8 (strict equality), and -- because all 8 admits have
+    N=128 which is OUTSIDE the K-1216 E1 envelope's N-set
+    {1792, 2048, 3072} -- E1 must NOT fire on these cells (E1 is a
+    no-op for N=128 by design).  Confirms K-1216's E1 stacking is
+    untouched by the K-1231 P8 extension (K-1209 dominance unchanged
+    on K-931 top-40)."""
+    for (M, N, K, _dtype) in _K1205_EN3_ADMITS_8:
+        p8_says = _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16)
+        e1_says = R_K1142_E1_route_to_hbl(M, N, K, torch.bfloat16)
+        assert p8_says is True, (
+            f"P8 missed K-1205 E_N3 admit ({M}, {N}, {K})")
+        assert e1_says is False, (
+            f"E1 fired on K-1205 N=128 cell ({M}, {N}, {K}); K-1216 "
+            "stacking semantics require E1 N-set {1792, 2048, 3072} "
+            "(N=128 must be excluded).")
+
+
+def test_k1205_does_not_disturb_existing_p8_28_cell_envelope():
+    """K-1216 -> K-1231 invariance check: the original 28-cell P8 envelope
+    is preserved exactly -- K-1205 strict-equality union ADDS 8 cells
+    without re-measuring or modifying any existing K-1144/K-1175 cell.
+    This is R-1184.STRICT-EQUALITY-UNION-PROVES-EXISTING-CELL-INVARIANCE-
+    WITHOUT-RE-MEASUREMENT in test form."""
+    pre_k1205 = (
+        _K1121_P8_ANCHORS_13
+        | _K1131_P8_NEIGHBORS_12
+        | _K1161_E2_ADMITS_3)
+    assert len(pre_k1205) == 28
+    for cell in pre_k1205:
+        assert cell in _P8_MFMA_ISSUE_STALL_ROUTEOUT, (
+            f"K-1175 P8 cell {cell} dropped from K-1231 envelope; "
+            "K-1205 must be strict-equality union only.")
+    # Symmetric (post K-1322): every cell beyond the original 28-cell
+    # baseline must come from K-1205 (8 N=128), K-1219 (7 N=256), or
+    # K-1283/K-1297 (8 A1 perturbations).
+    delta = _P8_MFMA_ISSUE_STALL_ROUTEOUT - pre_k1205
+    expected_delta = (
+        _K1205_EN3_ADMITS_8
+        | _K1219_E3_NFLOOR256_ADMITS_7
+        | _K1283_A1_PERTURBATIONS_8
+    )
+    assert delta == expected_delta, (
+        "Cells added to P8 envelope past K-1175 do not match "
+        "_K1205_EN3_ADMITS_8 | _K1219_E3_NFLOOR256_ADMITS_7 | "
+        "_K1283_A1_PERTURBATIONS_8 exactly; an unattributed cell crept in.")
+
+
+# ---------------------------------------------------------------------------
+# K-1219 / K-1240 -- E3 N-floor=256 anchor-projected admits (7 cells).
+# Independent paired n=30 HIP-graph hot-cache validation on rad-mi300x-1
+# (K-1219 commit f110d64 on fix/K-1219-n256).  Cohort geomean tb/hbl
+# 1.505x; productionised onto the K-1216 stacked dispatch chain by
+# K-1303 (this branch) as the 5th provenance sub-frozenset.
+# ---------------------------------------------------------------------------
+K1219_E3_NFLOOR256_ADMITS_7_LIST = [
+    # (cid, M, N, K, hbl_tb_med, CI95_lo) -- from K-1219 paired n=30 dataset
+    ("E3_S18_N256",   5972, 256,  768, 1.110, 1.084),
+    ("E3_S24_N256",   4480, 256,  768, 1.016, 0.989),
+    ("E3_S25_N256",   6016, 256, 1024, 1.214, 1.206),
+    ("E3_S30_N256",  16256, 256, 1024, 2.271, 2.261),
+    ("E3_S37_N256",  25600, 256,  256, 0.998, 0.992),
+    ("E3_S39_N256",  49152, 256,  256, 1.004, 0.999),
+    ("E3_E2M1_N256", 10112, 256, 1024, 2.927, 2.911),  # cohort MAX
+]
+
+
+def test_k1219_e3_admits_envelope_size_is_exactly_7():
+    """Pin K-1219 E3 sub-frozenset cardinality.  K-1219 staged 7 N=256
+    candidates (K-1131-style anchor projection at N-floor=256 of the
+    K-1121 PMC anchors {S18, S24, S25, S30, S37, S39} + K-1175 E2_M1
+    admit) and admitted all 7 to the unified K-1282 envelope.  Any
+    silent edit changes the count and trips this canary."""
+    assert len(_K1219_E3_NFLOOR256_ADMITS_7) == 7
+
+
+def test_k1219_e3_admits_pairwise_disjoint_with_prior_four_subsets():
+    """K-1219 E3 candidates have N=256 by construction: no K-1121 anchor
+    (N>=896), K-1131 neighbor (N>=896), K-1161 E2 admit (N in {1792, 2048}),
+    or K-1205 E_N3 admit (N=128) has N=256.  The 5-way union is therefore
+    pairwise disjoint without manual exclusion lists; this test is the
+    structural disjointness invariant the runtime asserts in
+    _route_predicate.py rely on."""
+    assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1121_P8_ANCHORS_13)
+    assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1131_P8_NEIGHBORS_12)
+    assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1161_E2_ADMITS_3)
+    assert _K1219_E3_NFLOOR256_ADMITS_7.isdisjoint(_K1205_EN3_ADMITS_8)
+
+
+def test_k1219_e3_admits_envelope_contents_pinned_to_k1219_manifest():
+    """Pin the K-1219 7-admit envelope to source-of-truth (the K-1219
+    paired n=30 dataset summarised in K1219_E3_NFLOOR256_ADMITS_7_LIST).
+    A silent edit to either constant trips here."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16")
+        for _cid, M, N, K, _hbl_tb, _ci_lo in K1219_E3_NFLOOR256_ADMITS_7_LIST)
+    assert _K1219_E3_NFLOOR256_ADMITS_7 == expected
+
+
+def test_k1219_e3_admits_all_have_n_equal_256():
+    """Structural axis-discipline invariant: K-1219 staged the N-axis
+    extension at N-floor=256 ONLY (one tier below the K-1131 N09 N=896
+    natural floor and one tier above K-1205's N=128 tier).  Any cell
+    in E3 with N != 256 would be a silent drift away from the staged
+    axis and trips here."""
+    for (M, N, K, dtype) in _K1219_E3_NFLOOR256_ADMITS_7:
+        assert N == 256, (
+            f"K-1219 E3 cell {(M, N, K, dtype)!r} has N={N} != 256; "
+            "K-1219 is N-axis-only at N-floor=256 by R-1219.")
+
+
+def test_k1219_e3_admits_k_in_k1144_k_set():
+    """Structural axis-discipline invariant: K-1219 held K fixed at the
+    K-1144 K-set {256, 768, 1024} (NOT a K-axis relaxation).  Any K
+    outside this set would be a covert K-axis extension and trips here."""
+    for (M, N, K, dtype) in _K1219_E3_NFLOOR256_ADMITS_7:
+        assert K in {256, 768, 1024}, (
+            f"K-1219 E3 cell {(M, N, K, dtype)!r} has K={K} outside "
+            "the K-1144 K-set {256, 768, 1024}; K-1219 is N-axis-only.")
+
+
+def test_k1219_e3_admits_m_floor_per_k1142_carve_out():
+    """Per K-1142 carve-out, every K-1219 admit must satisfy M >= 4480.
+    A silent admission of M < 4480 cells would re-open the K-1142
+    small-M Triton-favoured tail and trips this pin."""
+    for (M, N, K, dtype) in _K1219_E3_NFLOOR256_ADMITS_7:
+        assert M >= 4480, (
+            f"K-1219 E3 cell {(M, N, K, dtype)!r} has M={M} < 4480; "
+            "K-1142 M-floor carve-out violation.")
+
+
+@pytest.mark.parametrize(
+    "cid,M,N,K,hbl_tb_med,ci95_lo", K1219_E3_NFLOOR256_ADMITS_7_LIST,
+    ids=[c[0] for c in K1219_E3_NFLOOR256_ADMITS_7_LIST])
+def test_k1219_p8_admits_all_7_e3_cells(cid, M, N, K, hbl_tb_med, ci95_lo):
+    """Every K-1219 E3 admit cell must fire the P8 strict-equality match.
+    The K-1219 measurement campaign documented all 7 as admitted to the
+    unified K-1282 envelope on rad-mi300x-1 under HIP-graph hot-cache."""
+    assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True, (
+        f"K-1219 E3 admit {cid} ({M},{N},{K}) missed P8 envelope")
+
+
+@pytest.mark.parametrize(
+    "cid,M,N,K,hbl_tb_med,ci95_lo", K1219_E3_NFLOOR256_ADMITS_7_LIST,
+    ids=[c[0] for c in K1219_E3_NFLOOR256_ADMITS_7_LIST])
+def test_k1219_dispatch_routes_all_7_e3_cells_out_to_hbl(
+        cid, M, N, K, hbl_tb_med, ci95_lo):
+    """End-to-end dispatch check: with default carve-outs disabled,
+    _k971_route_to_hbl must return True for every K-1219 E3 admit
+    so the cell is routed to hipBLASLt."""
+    decision = _k971_route_to_hbl(
+        M, N, K,
+        a_dtype=torch.bfloat16, b_dtype=torch.bfloat16,
+        enable_streamk=False, work_stealing=False)
+    assert decision is True, (
+        f"{cid} (M={M} N={N} K={K}) was not routed to hipBLASLt; "
+        f"expected True per K-1219 paired n=30 hbl/tb_med={hbl_tb_med:.3f}x")
+
+
+def test_k1219_e3_admits_are_bf16_only():
+    """K-1219 measurement scope is bf16 only.  fp16/fp32 with the same
+    (M, N, K) must NOT fire P8 -- fp16 dispatch is owned by the K-1093
+    / K-1125 mirror predicate line."""
+    for (M, N, K, _dtype) in _K1219_E3_NFLOOR256_ADMITS_7:
+        for fp_dtype in (torch.float16, torch.float32):
+            assert _p8_mfma_issue_stall_routeout(M, N, K, fp_dtype) is False, (
+                f"P8 fired on non-bf16 dtype {fp_dtype} for "
+                f"K-1219 cell {(M, N, K)}; K-1219 is bf16-only.")
+
+
+def test_k1219_p8_e1_stack_no_double_route_for_e3_admits():
+    """K-1216 stacked-dispatch invariant preserved: every K-1219 E3 admit
+    fires P8 (strict equality), and -- because all 7 admits have N=256
+    which is OUTSIDE the K-1216 E1 envelope's N-set {1792, 2048, 3072} --
+    E1 must NOT fire on these cells (E1 is a no-op for N=256 by design)."""
+    for (M, N, K, _dtype) in _K1219_E3_NFLOOR256_ADMITS_7:
+        p8_says = _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16)
+        e1_says = R_K1142_E1_route_to_hbl(M, N, K, torch.bfloat16)
+        assert p8_says is True, (
+            f"P8 missed K-1219 E3 admit ({M}, {N}, {K})")
+        assert e1_says is False, (
+            f"E1 fired on K-1219 N=256 cell ({M}, {N}, {K}); K-1216 "
+            "stacking semantics require E1 N-set {1792, 2048, 3072} "
+            "(N=256 must be excluded).")
+
+
+def test_k1303_does_not_disturb_existing_p8_36_cell_envelope():
+    """K-1275 -> K-1303 invariance check: the K-1275 36-cell P8 envelope
+    (28 baseline + 8 K-1205 E_N3) is preserved exactly -- K-1219 strict-
+    equality union ADDS 7 cells without re-measuring or modifying any
+    existing K-1144/K-1175/K-1205 cell.  This is R-1184.STRICT-EQUALITY-
+    UNION-PROVES-EXISTING-CELL-INVARIANCE-WITHOUT-RE-MEASUREMENT in test
+    form (extended to K-1219)."""
+    pre_k1219 = (
+        _K1121_P8_ANCHORS_13
+        | _K1131_P8_NEIGHBORS_12
+        | _K1161_E2_ADMITS_3
+        | _K1205_EN3_ADMITS_8)
+    assert len(pre_k1219) == 36
+    for cell in pre_k1219:
+        assert cell in _P8_MFMA_ISSUE_STALL_ROUTEOUT, (
+            f"K-1275 P8 cell {cell} dropped from K-1303 envelope; "
+            "K-1219 must be strict-equality union only.")
+    # Symmetric (post K-1322): every new cell added past K-1275 must
+    # come from K-1219 (7 N=256) or K-1283/K-1297 (8 A1 perturbations).
+    delta = _P8_MFMA_ISSUE_STALL_ROUTEOUT - pre_k1219
+    assert delta == (_K1219_E3_NFLOOR256_ADMITS_7 | _K1283_A1_PERTURBATIONS_8), (
+        "Cells added to P8 envelope past K-1275 do not match "
+        "_K1219_E3_NFLOOR256_ADMITS_7 | _K1283_A1_PERTURBATIONS_8 "
+        "exactly; an unattributed cell crept in.")
+
+
+# ---------------------------------------------------------------------------
+# K-1283 / K-1297 -- A1 sub-cohort targeted P8 admit-cell extension (8
+# cells).  Independent paired n=30 HIP-graph hot-cache validation on
+# rad-mi300x-1 (K-1297 commit f4cc5cf on fix/K-1283-A1, V2 protocol with
+# corrected negative-control captures).  Cohort geomean tb/hbl 1.389x;
+# productionised onto the K-1303 unified envelope by K-1322 (this branch)
+# as the 6th provenance sub-frozenset.
+# ---------------------------------------------------------------------------
+K1283_A1_PERTURBATIONS_8_LIST = [
+    # (cid, M, N, K, hbl_tb_med, CI95_lo) -- from K-1297 V2 paired n=30
+    ("A1_S25_Mx2", 12032, 2048, 1024, 3.365, 3.009),  # cohort MAX
+    ("A1_S25_Nx2",  6016, 4096, 1024, 1.383, 1.351),
+    ("A1_S25_N/2",  6016, 1024, 1024, 1.202, 1.143),
+    ("A1_S25_Kx2",  6016, 2048, 2048, 1.264, 1.242),
+    ("A1_S25_K/2",  6016, 2048,  512, 1.226, 1.140),
+    ("A1_S29_Mx2", 28416, 2048, 1024, 1.185, 1.163),
+    ("A1_S29_Nx2", 14208, 4096, 1024, 1.143, 1.071),
+    ("A1_S29_K/2", 14208, 2048,  512, 1.126, 1.035),  # cohort MIN
+]
+
+
+def test_k1283_a1_perturbations_envelope_size_is_exactly_8():
+    """Pin K-1283 A1 sub-frozenset cardinality.  K-1297 V2 admitted 8
+    cells out of 15 candidates at CI95-lo > 1.0x.  Any silent edit
+    changes the count and trips this canary."""
+    assert len(_K1283_A1_PERTURBATIONS_8) == 8
+
+
+def test_k1283_a1_perturbations_pairwise_disjoint_with_prior_five_subsets():
+    """K-1297 selected only K-1131-style perturbations on axes K-1131
+    did NOT enumerate (S25 5/5 axes, S29 3/6 axes); structural disjointness
+    with the prior five sub-frozensets is checked at module load and
+    re-asserted here for explicit test coverage."""
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1121_P8_ANCHORS_13)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1131_P8_NEIGHBORS_12)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1161_E2_ADMITS_3)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1205_EN3_ADMITS_8)
+    assert _K1283_A1_PERTURBATIONS_8.isdisjoint(_K1219_E3_NFLOOR256_ADMITS_7)
+
+
+def test_k1283_a1_perturbations_contents_pinned_to_k1297_manifest():
+    """Pin the K-1297 8-admit envelope to source-of-truth (the K-1297 V2
+    paired n=30 dataset summarised in K1283_A1_PERTURBATIONS_8_LIST).
+    A silent edit to either constant trips here."""
+    expected = frozenset(
+        (M, N, K, "torch.bfloat16")
+        for _cid, M, N, K, _hbl_tb, _ci_lo in K1283_A1_PERTURBATIONS_8_LIST)
+    assert _K1283_A1_PERTURBATIONS_8 == expected
+
+
+def test_k1283_a1_admits_are_in_p8_envelope():
+    """Per Testing Zealot REVISE on K-1297 -- positive-side admit pin:
+    every K-1283/K-1297 A1 admit MUST be a member of the unified P8
+    envelope.  Symmetric with the K-931 no-leak pins from K-1297."""
+    for cell in _K1283_A1_PERTURBATIONS_8:
+        assert cell in _P8_MFMA_ISSUE_STALL_ROUTEOUT
+        M, N, K, _ = cell
+        assert _p8_mfma_issue_stall_routeout(M, N, K, torch.bfloat16) is True
+
+
+def test_k1283_a1_admits_respect_k1142_m_floor_and_k1161_k_floor():
+    """Structural floor invariants inherited from K-1142 and K-1161:
+    every admit must satisfy M >= 4480 (K-1142 small-M Triton-favoured
+    tail carve-out) and K >= 256 (K-1161 negative-axis-pivot pin; do
+    NOT relax to 128 per K-1176 cross-arch failure)."""
+    for (M, N, K, _dtype) in _K1283_A1_PERTURBATIONS_8:
+        assert M >= 4480, (
+            f"K-1297 admit ({M}, {N}, {K}) violates K-1142 M>=4480 floor")
+        assert K >= 256, (
+            f"K-1297 admit ({M}, {N}, {K}) violates K-1161 K>=256 floor")
+
+
+def test_k1322_does_not_disturb_existing_k1303_43_cell_envelope():
+    """K-1303 -> K-1322 invariance check: the K-1303 43-cell P8 envelope
+    (28 baseline + 8 K-1205 E_N3 + 7 K-1219 E3) is preserved exactly --
+    K-1297 strict-equality union ADDS 8 A1 cells without re-measuring or
+    modifying any existing K-1144/K-1175/K-1205/K-1219 cell.  Extends
+    R-1184.STRICT-EQUALITY-UNION-PROVES-EXISTING-CELL-INVARIANCE to the
+    K-1322 layer."""
+    pre_k1297 = (
+        _K1121_P8_ANCHORS_13
+        | _K1131_P8_NEIGHBORS_12
+        | _K1161_E2_ADMITS_3
+        | _K1205_EN3_ADMITS_8
+        | _K1219_E3_NFLOOR256_ADMITS_7)
+    assert len(pre_k1297) == 43
+    for cell in pre_k1297:
+        assert cell in _P8_MFMA_ISSUE_STALL_ROUTEOUT, (
+            f"K-1303 P8 cell {cell} dropped from K-1322 envelope; "
+            "K-1297 must be strict-equality union only.")
+    # Symmetric: every new cell added by K-1322 must be in K-1297 A1.
+    delta = _P8_MFMA_ISSUE_STALL_ROUTEOUT - pre_k1297
+    assert delta == _K1283_A1_PERTURBATIONS_8, (
+        "Cells added to P8 envelope past K-1303 do not match "
+        "_K1283_A1_PERTURBATIONS_8 exactly; an unattributed "
+        "cell crept in.")
+
+
+# ---------------------------------------------------------------------------
+# K-1335 / K-1326 (S-002) -- longK_smallSquare bf16 route-OUT extension pins.
+# K-1335 productionizes K-1326's `P9_longK_smallSquare_routeOUT` proposal as
+# a 4-cell strict-equality extension of the K-905/K-971 LDS-bank-conflict
+# `K971_ROUTE_TABLE` (the 5th-position dispatch predicate).  Per K-913 PMC
+# anchor + K-1326 attribution, the bottleneck is LDS-bank-conflict (LDS_BC
+# 1.78 cyc/inst), NOT MFMA-issue-stall, so the attachment is the LDS-BC
+# envelope -- NOT the K-1322 51-cell P8 envelope (R-1329.MECHANISTIC-
+# DISAMBIGUATION-OF-PREDICATE-ATTACHMENT-POINT).
+# ---------------------------------------------------------------------------
+K1335_LONGK_SMALLSQUARE_ADMITS_4_LIST = [
+    # (sid,            M,    N,    K, source)
+    ("K1335_A1",    1024, 1024, 4096, "K-1326 longK_smallSquare anchor; LDS-BC"),
+    ("K1335_A2",    1024, 1024, 8192, "K-913 PMC anchor; LDS_BC 1.78 cyc/inst"),
+    ("K1335_A3",    2048, 2048, 4096, "K-1326 longK_smallSquare anchor; LDS-BC"),
+    ("K1335_A4",    2048, 2048, 8192, "K-1326 longK_smallSquare anchor; LDS-BC"),
+]
+
+# K-axis-neighbor controls that MUST NOT route via K-1335 (different K than
+# the admit set; outside the K-1326 `longK_smallSquare` bucket).  K=2048
+# stays in the in-kernel autotune regime; K=16384 is on the K-905/K-971
+# baseline anchors and routes via _K905_K971_LDS_BC_ANCHORS_8 instead
+# (verified in the per-cell test below by membership rather than route
+# verdict so the two campaigns stay attribution-clean).
+K1335_K_AXIS_NEIGHBOR_CONTROLS_4 = [
+    ("K1335_N_K2048_M1024", 1024, 1024, 2048),  # K-axis neighbor below admit band
+    ("K1335_N_K2048_M2048", 2048, 2048, 2048),
+    ("K1335_N_M512_K4096",   512,  512, 4096),  # M-axis neighbor below admit band
+    ("K1335_N_M4096_K4096", 4096, 4096, 4096),  # M-axis neighbor above admit band
+]
+
+
+def test_k1335_longk_smallsquare_admits_cardinality_is_exactly_4():
+    """K-1335 strict-equality cardinality pin.  K-1326 nominated exactly 4
+    cells in the `longK_smallSquare` bucket (M=N in {1024, 2048} x K in
+    {4096, 8192}, bf16) and K-1335 ships all 4 after paired n=30 HIP-graph
+    hot-cache + B=10000 paired bootstrap CI95 confirmation on MI300X.  Any
+    silent edit to the admit set trips this canary."""
+    assert len(_K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4) == 4
+
+
+def test_k1335_lds_bc_table_size_is_exactly_12_after_k1335_extension():
+    """K-1335 unified LDS-BC table (K971_ROUTE_TABLE) cardinality pin:
+    8 K-905/K-971 baseline anchors + 4 K-1335 longK_smallSquare admits
+    = 12.  Any silent edit changes the count and trips this canary.
+
+    Provenance chain:
+      * K-905 originally pinned 2 cells (cohort A LDS-bound bf16 + fp16).
+      * K-930 / K-971 extended to 8 cells (mid-square long-K bf16/fp16).
+      * K-1335 extends by 4 longK_smallSquare bf16 admits identified by
+        K-1308's residual decomposition + K-913 PMC anchor + K-1326
+        attribution -> 12 (this canary)."""
+    assert len(K971_ROUTE_TABLE) == 12
+    assert len(_K905_K971_LDS_BC_ANCHORS_8) == 8
+    assert len(_K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4) == 4
+
+
+def test_k1335_disjoint_from_k905_k971_baseline_by_k_axis_projection():
+    """K-axis projection disjointness assert (R-1329.K-AXIS-PROJECTION-
+    DISJOINTNESS-ASSERTS-ARE-CHEAP-INSURANCE): K-1335 cells live in
+    K in {4096, 8192}; K-905/K-971 baseline cells live in K in {16384,
+    32768}.  Disjointness is the natural separator that keeps the two
+    campaigns' provenance attribution clean."""
+    assert _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4.isdisjoint(
+        _K905_K971_LDS_BC_ANCHORS_8)
+    k1335_ks = {K for (_, _, K, _) in _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4}
+    baseline_ks = {K for (_, _, K, _) in _K905_K971_LDS_BC_ANCHORS_8}
+    assert k1335_ks == {4096, 8192}
+    assert baseline_ks == {16384, 32768}
+    assert k1335_ks.isdisjoint(baseline_ks)
+
+
+def test_k1335_disjoint_from_k1322_p8_mfma_issue_stall_envelope():
+    """K-1335 lives on the LDS-BC envelope (5th-position dispatch predicate)
+    and MUST NOT collide with the K-1322 51-cell P8 MFMA-issue-stall
+    envelope (1st-position dispatch predicate).  The two predicates target
+    distinct hardware bottlenecks per K-913 / K-1326 / R-1329 mechanistic
+    disambiguation; an overlap would break attribution and risk future
+    PMC-classifier confusion when the K-1308-style residual decomposition
+    is re-run on the K-1335 envelope (K-1335-FOLLOW-B)."""
+    assert _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4.isdisjoint(
+        _P8_MFMA_ISSUE_STALL_ROUTEOUT)
+
+
+def test_k1335_admit_cells_route_to_hbl_via_k971_route_table():
+    """Every K-1335 admit cell flips the full dispatch decision to
+    route-OUT (route_to_hbl = True) on the bf16 path with streamk OFF and
+    work-stealing OFF.  Exercises the *real* `k971_route_decision` helper
+    so the 5th-position predicate firing is observed end-to-end (after
+    P8 / E1 / P6 / P5 fall through to the K971_ROUTE_TABLE check)."""
+    for (sid, M, N, K, source) in K1335_LONGK_SMALLSQUARE_ADMITS_4_LIST:
+        # K-1335 cell must NOT match the K-1322 P8 envelope (otherwise the
+        # routing rationale would be MFMA-issue-stall, not LDS-BC).
+        assert (M, N, K, "torch.bfloat16") not in _P8_MFMA_ISSUE_STALL_ROUTEOUT, (
+            f"K-1335 cell {sid} ({M},{N},{K}) collides with the K-1322 P8 "
+            "envelope; mechanistic-attribution invariant violated.")
+        # K-1335 cell MUST be in the LDS-BC `K971_ROUTE_TABLE`.
+        assert (M, N, K, "torch.bfloat16") in K971_ROUTE_TABLE, (
+            f"K-1335 cell {sid} ({M},{N},{K}) missing from K971_ROUTE_TABLE.")
+        # Full dispatch decision: routes to hbl on the bf16 path.
+        routed = k971_route_decision(
+            M, N, K,
+            "torch.bfloat16", "torch.bfloat16",
+            enable_streamk=False, work_stealing=False,
+            disable_env_set=False)
+        assert routed is True, (
+            f"K-1335 cell {sid} ({M},{N},{K}) failed to route to hbl via "
+            "the 5th-position K971_ROUTE_TABLE predicate.")
+
+
+def test_k1335_k_axis_neighbor_controls_do_not_match_admit_set():
+    """K-axis-neighbor controls (cells just outside the K-1326
+    `longK_smallSquare` bucket) MUST NOT match the K-1335 admit
+    frozenset.  This is a strict-equality no-leak pin -- verifies the
+    K=2048 K-axis neighbor below the admit band, the M=512 / M=4096
+    M-axis neighbors outside the M=N in {1024, 2048} admit window, and
+    rules out any silent broadening of the admit set on the K or M
+    axes during future edits."""
+    for (sid, M, N, K) in K1335_K_AXIS_NEIGHBOR_CONTROLS_4:
+        assert (M, N, K, "torch.bfloat16") not in _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4, (
+            f"K-1335 K-axis-neighbor control {sid} ({M},{N},{K}) leaked "
+            "into the admit set; the K-1326 bucket is strict {4096, 8192} "
+            "on K and strict {1024, 2048} on M=N.")
+
+
+def test_k1335_admits_are_all_bf16_dtype():
+    """K-1335 ships bf16 only.  K-913 PMC anchor + K-1326 residual bucket
+    + K-1308 cross-branch ratio invariant are all measured on bf16; fp16
+    LDS-BC parity is tracked separately (out of scope for K-1335).  A
+    silent fp16 entry would land an admit on an unmeasured-dtype cell
+    and bypass the K-1335 verification protocol entirely."""
+    for (M, N, K, dtype) in _K1335_LONGK_SMALLSQUARE_BF16_ADMITS_4:
+        assert dtype == "torch.bfloat16", (
+            f"K-1335 admit cell ({M},{N},{K},{dtype}) is not bf16; the "
+            "K-913 / K-1326 / K-1308 verification scope is bf16-only.")
+
+
+@pytest.mark.parametrize("M,N,K", [
+    (1024, 1024, 4096),
+    (1024, 1024, 8192),
+    (2048, 2048, 4096),
+    (2048, 2048, 8192),
+])
+def test_k1335_streamk_carve_out_short_circuits_admit(M, N, K):
+    """The K971 dispatch streamk / work-stealing carve-outs must
+    short-circuit BEFORE the K-1335 LDS-BC table is consulted.  Pinning
+    these here so any future edit that moves K-1335 ahead of the carve-out
+    (e.g. into a parametric-band predicate) trips this test."""
+    assert k971_route_decision(
+        M, N, K,
+        "torch.bfloat16", "torch.bfloat16",
+        enable_streamk=True, work_stealing=False,
+        disable_env_set=False) is False
+    assert k971_route_decision(
+        M, N, K,
+        "torch.bfloat16", "torch.bfloat16",
+        enable_streamk=False, work_stealing=True,
+        disable_env_set=False) is False
+
+
+def test_k1335_k905_k971_baseline_cells_still_route_after_k1335_union():
+    """K-905/K-971 baseline anchors (8 cells) must still flip the dispatch
+    decision to route-OUT after the K-1335 strict-equality union extends
+    K971_ROUTE_TABLE from 8 -> 12 cells.  Strict-equality union is
+    invariance-preserving by construction (R-1322.STRICT-EQUALITY-UNION-
+    PRESERVES-PRIOR-ADMIT-INVARIANCE-AS-STRUCTURAL-GUARANTEE), but a
+    one-line pin keeps the structural guarantee from being silently
+    broken by a future refactor that replaces the union with a parametric
+    predicate."""
+    for (M, N, K, dtype) in _K905_K971_LDS_BC_ANCHORS_8:
+        if dtype != "torch.bfloat16":
+            # fp16 baseline anchors: only the strict-equality table
+            # consultation applies (P5 closed-form is bf16-only).
+            assert (M, N, K, dtype) in K971_ROUTE_TABLE
+            continue
+        routed = k971_route_decision(
+            M, N, K, dtype, dtype,
+            enable_streamk=False, work_stealing=False,
+            disable_env_set=False)
+        assert routed is True, (
+            f"K-905/K-971 baseline anchor ({M},{N},{K},{dtype}) regressed "
+            "after K-1335 extension; strict-equality union must be "
+            "invariance-preserving.")

--- a/tests/test_p31_skinny_n256_alias_stack.py
+++ b/tests/test_p31_skinny_n256_alias_stack.py
@@ -1,0 +1,128 @@
+"""P31 (S-002) — 22nd-slot N=256 K-COMPLEMENT verified-winner subset tests.
+
+Source measurement: TB-native vs HBL-native paired n=30 hot-cache HIP-graph
+capture/replay on MI300X / gfx942 with the alias-stack route-OUT logic
+ABLATED so the engine path is forced.  Cohort geomean HBL/TB = 1.359×
+across the full 30-cell M ∈ {2048,4096,8192} × N=256 × K ∈ {2048,4096,8192,
+16384,32768} × {bf16,fp16} grid; 28/30 cells pass the strict ≥1.05 ∧
+p<0.05 winner gate.  The 2 LOSER cells at (M=2048, K=2048) — TB-native
+beats hipBLASLt by 2% in bf16 (HBL/TB=0.98) and ties in fp16 (HBL/TB=1.02,
+p=0.79) — are excluded from the productionized envelope per the
+verified-winner constraint.
+
+Winner-subset geomean HBL/TB = 1.392× (n=28), range 1.07× – 2.12×.
+
+Invariants pinned in this file (cardinality lives here per the minimalist
+split: source holds data, tests hold structural invariants):
+
+  1. Cardinality is exactly 28.
+  2. N axis is exactly {256}.
+  3. M ∈ {2048, 4096, 8192}; K ∈ {2048, 4096, 8192, 16384, 32768};
+     dtype ∈ {torch.bfloat16, torch.float16}.
+  4. The 2 LOSER cells at (2048, 256, 2048, *) are explicitly excluded.
+  5. Sibling-N firewall vs every prior K-COMPLEMENT alias-stack at a
+     different N (P28 N=128, P29 N=64, P30 N ∈ {384, 768, 1536}, and
+     the K-1367 P13 N=128 envelope).
+  6. Alias-overlap with the upstream P21 K-mid envelope (17 cells) is
+     intentional and complete; alias-overlap with the upstream P13
+     K-extremes envelope (11 cells) intersects the winner subset
+     completely.
+  7. Per-shape dtype-mirror (bf16 ↔ fp16 admit sets coincide) on the
+     verified-winner subset.
+"""
+from __future__ import annotations
+
+from tritonblas._route_predicate import (
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+    _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT,
+    _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29,
+    _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34,
+    _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30,
+    _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28,
+)
+
+
+FZ = _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28
+LOSERS = frozenset({
+    (2048, 256, 2048, "torch.bfloat16"),
+    (2048, 256, 2048, "torch.float16"),
+})
+
+
+def test_cardinality_is_28():
+    assert len(FZ) == 28
+
+
+def test_n_axis_is_skinny_n256():
+    assert {N for (_, N, _, _) in FZ} == {256}
+
+
+def test_m_k_dtype_axes_are_minimal():
+    assert {M for (M, _, _, _) in FZ} == {2048, 4096, 8192}
+    assert {K for (_, _, K, _) in FZ} == {2048, 4096, 8192, 16384, 32768}
+    assert {dt for (_, _, _, dt) in FZ} == {"torch.bfloat16", "torch.float16"}
+
+
+def test_loser_cells_are_excluded():
+    """The 2 paired-n30 LOSER cells at (M=2048, K=2048) MUST be excluded
+    from the productionized envelope: they violate the verified-winner
+    gate (HBL/TB < 1.05 OR p ≥ 0.05) so routing them OUT would regress
+    real hot-cache performance."""
+    for cell in LOSERS:
+        assert cell not in FZ, f"loser cell {cell} must not be in envelope"
+
+
+def test_sibling_n_firewall_vs_p28_n128():
+    assert FZ & _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30 == set()
+    assert FZ & _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 == set()
+
+
+def test_sibling_n_firewall_vs_p29_n64():
+    assert FZ & _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29 == set()
+
+
+def test_sibling_n_firewall_vs_p30_nmid():
+    assert FZ & _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34 == set()
+
+
+def test_p21_kmid_alias_overlap_is_complete():
+    """All 17 cells in the P21 K-mid envelope (M ∈ {2048,4096,8192} ×
+    N=256 × K ∈ {4096,8192,16384}) appear in the verified-winner subset
+    (none of them is a (M=2048, K=2048) loser)."""
+    assert _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT.issubset(FZ)
+    assert len(FZ & _K1503_P21_SKINNY_N256_KCOMPL_KMID_ROUTEOUT) == 17
+
+
+def test_p13_kextremes_subset_intersection():
+    """The 12-cell P13 K-extremes envelope (K ∈ {2048, 32768}) intersects
+    the verified-winner subset in exactly 10 cells — the 2 cells at
+    (2048, 256, 2048, *) are LOSERS and excluded."""
+    overlap = FZ & _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12
+    assert len(overlap) == 10
+    excluded = _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12 - FZ
+    assert excluded == LOSERS
+
+
+def test_dtype_mirror_is_complete():
+    """Each shape (M, N, K) admitted under bf16 is also admitted under
+    fp16 (and vice versa).  The K-913 §3 LDS-bank-conflict mechanism is
+    dtype-invariant on the column-narrow N=256 tile, and the 2 excluded
+    losers form a (M, K) = (2048, 2048) dtype pair."""
+    bf = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.bfloat16"}
+    fp = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.float16"}
+    assert bf == fp
+
+
+def test_envelope_equals_full_grid_minus_losers():
+    """The verified-winner envelope is exactly the full 30-cell N=256
+    K-COMPLEMENT grid minus the 2 (M=2048, K=2048) loser cells — pinned
+    to detect any silent contraction or expansion of the envelope."""
+    full = frozenset(
+        (M, 256, K, dt) for M in (2048, 4096, 8192)
+        for K in (2048, 4096, 8192, 16384, 32768)
+        for dt in ("torch.bfloat16", "torch.float16")
+    )
+    assert FZ == full - LOSERS
+    assert len(full) == 30
+    assert len(FZ) == 28

--- a/tests/test_p32_skinny_n160_alias_stack.py
+++ b/tests/test_p32_skinny_n160_alias_stack.py
@@ -1,0 +1,111 @@
+"""P32 (S-002) — 23rd-slot N=160 K-COMPLEMENT verified-winner subset tests.
+
+Source measurement: K-1794 paired n=30 HIP-graph hot-cache capture/replay
+on MI300X / gfx942 across the 18-cell N=160 sub-cohort = M ∈ {2048, 4096,
+8192} × N=160 × K ∈ {4096, 8192, 16384} × {bf16, fp16}.  3-engine sweep
+(tb_oracle / tb_streamk / hbl) recorded:
+
+  * bf16 N=160 (9/9): cohort geomean r_oracle = 0.997×.  All 9 cells were
+    already routed via the upstream R-K979 P5 Clause-3 alias (broader K-
+    COMPLEMENT envelope) so the post-route ratio is at parity with HBL.
+    Including these cells in P32 is alias-overlap by design — the upstream
+    P5 admit fires before P32 in the dispatch chain so the cells are
+    documentation, not load-bearing in production.
+  * fp16 N=160 (9/9): cohort UNROUTED in K-1794's measurement (0/9 routed
+    via any upstream alias; r_oracle < 1.0 systemically per K-1794 R-
+    K1794.FP16-MIRROR-SYSTEMIC-AT-CROSS-BAND-LEVEL).  These 9 cells are
+    the load-bearing portion of P32 — they close the dtype-mirror gap at
+    the wave-misaligned N=160 column-narrow tile.
+
+Mechanism (K-913 §3 / R-K1673 dtype-invariance): BLOCK_N=128 packs N=160
+into a single wave-misaligned K-block column; SQ_LDS_BANK_CONFLICT/inst
+stays elevated and persistent_matmul cannot trade tile reshape for
+atomic-reduction.  hipBLASLt's split-K kernel selection clears the band.
+
+Invariants pinned in this file (cardinality lives here per the minimalist
+split: source holds data, tests hold structural invariants — R-1532 /
+R-1720 / R-1775):
+
+  1. Cardinality is exactly 18.
+  2. N axis is exactly {160}.
+  3. M ∈ {2048, 4096, 8192}; K ∈ {4096, 8192, 16384};
+     dtype ∈ {torch.bfloat16, torch.float16}.
+  4. Per-shape dtype-mirror (bf16 ↔ fp16 admit sets coincide).
+  5. Sibling-N firewall vs every prior K-COMPLEMENT alias-stack at a
+     different N (P28 N=128, P29 N=64, P30 N ∈ {384, 768, 1536}, P31
+     N=256, and the K-1367/K-1397 P13 N ∈ {128, 256} envelopes).
+  6. Envelope is exactly the full 18-cell M ∈ {2048,4096,8192} × N=160
+     × K ∈ {4096,8192,16384} × {bf16,fp16} grid.
+"""
+from __future__ import annotations
+
+from tritonblas._route_predicate import (
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+    _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30,
+    _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29,
+    _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34,
+    _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28,
+    _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18,
+)
+
+
+FZ = _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18
+
+
+def test_cardinality_is_18():
+    assert len(FZ) == 18
+
+
+def test_n_axis_is_skinny_n160():
+    assert {N for (_, N, _, _) in FZ} == {160}
+
+
+def test_m_k_dtype_axes_are_minimal():
+    assert {M for (M, _, _, _) in FZ} == {2048, 4096, 8192}
+    assert {K for (_, _, K, _) in FZ} == {4096, 8192, 16384}
+    assert {dt for (_, _, _, dt) in FZ} == {"torch.bfloat16", "torch.float16"}
+
+
+def test_dtype_mirror_is_complete():
+    """Each shape (M, N, K) admitted under bf16 is also admitted under fp16
+    (and vice versa).  K-913 §3 LDS-bank-conflict is dtype-invariant on the
+    column-narrow N=160 tile (same mechanism as K-1673 P28 at N=128)."""
+    bf = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.bfloat16"}
+    fp = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.float16"}
+    assert bf == fp
+    assert len(bf) == 9
+
+
+def test_sibling_n_firewall_vs_p28_n128():
+    assert FZ & _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30 == set()
+    assert FZ & _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 == set()
+
+
+def test_sibling_n_firewall_vs_p29_n64():
+    assert FZ & _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29 == set()
+
+
+def test_sibling_n_firewall_vs_p30_nmid():
+    assert FZ & _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34 == set()
+
+
+def test_sibling_n_firewall_vs_p31_n256():
+    assert FZ & _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28 == set()
+    assert FZ & _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12 == set()
+
+
+def test_envelope_equals_full_n160_kcompl_grid():
+    """The verified-winner envelope is exactly the full 18-cell M ∈ {2048,
+    4096,8192} × N=160 × K ∈ {4096,8192,16384} × {bf16,fp16} grid — pinned
+    to detect any silent contraction or expansion of the K-1794 sub-cohort
+    envelope.  Per K-1794, all 9 bf16 cells were already routed via the
+    upstream R-K979 P5 alias (overlap-by-design); the 9 fp16 cells close
+    the dtype-mirror gap and are the load-bearing portion of P32."""
+    full = frozenset(
+        (M, 160, K, dt) for M in (2048, 4096, 8192)
+        for K in (4096, 8192, 16384)
+        for dt in ("torch.bfloat16", "torch.float16")
+    )
+    assert FZ == full
+    assert len(full) == 18

--- a/tests/test_p33_skinny_n224_alias_stack.py
+++ b/tests/test_p33_skinny_n224_alias_stack.py
@@ -1,0 +1,130 @@
+"""P33 (S-002) — 24th-slot N=224 K-COMPLEMENT verified-winner subset tests.
+
+Source measurement: K-1794 paired n=30 HIP-graph hot-cache capture/replay
+on MI300X / gfx942 across the 18-cell N=224 sub-cohort = M ∈ {2048, 4096,
+8192} × N=224 × K ∈ {4096, 8192, 16384} × {bf16, fp16}.  3-engine sweep
+(tb_oracle / tb_streamk / hbl) recorded:
+
+  * bf16 N=224 (9/9): cohort UNROUTED in K-1794's measurement (0/9 routed
+    via any upstream alias; cohort geomean r_oracle = 0.722 — the FIRST
+    observation of an N-axis cliff above N=128 per K-1794 R-K1794.N224-
+    DOES-NOT-EXTEND-FROM-N192-FROZENSET-MUST-EXPLICITLY-INCLUDE).  The
+    K-1782 N=192 envelope does NOT extend smoothly upward to N=224, so
+    these 9 cells are load-bearing route-OUT targets (no alias overlap).
+  * fp16 N=224 (9/9): cohort UNROUTED in K-1794's measurement (0/9 routed
+    via any upstream alias; r_oracle < 1.0 systemically per K-1794 R-
+    K1794.FP16-MIRROR-SYSTEMIC-AT-CROSS-BAND-LEVEL).  These 9 cells are
+    also load-bearing — they close the dtype-mirror gap at the wave-
+    misaligned N=224 column-narrow tile.
+
+Mechanism (K-913 §3 / R-K1673 dtype-invariance): BLOCK_N=128 packs N=224
+into a single wave-misaligned K-block column; SQ_LDS_BANK_CONFLICT/inst
+stays elevated and persistent_matmul cannot trade tile reshape for
+atomic-reduction.  hipBLASLt's split-K kernel selection clears the band.
+Same mechanism productionized at K-1673 P28 (N=128), K-1810 P32 (N=160),
+and K-1775 P31 (N=256); now applied to the wave-misaligned N=224 rung.
+
+Note: unlike K-1810 P32 (N=160) where the 9 bf16 cells overlap with the
+upstream R-K979 P5 alias by design (alias-overlap discipline per K-1775),
+K-1817 P33 has NO upstream alias overlap — both dtype rows are load-
+bearing route-OUT entries.  This reflects the N=224 cliff finding from
+K-1794: bf16 N=192 was caught by the upstream alias, but bf16 N=224 falls
+out of every existing alias-stack predicate.
+
+Invariants pinned in this file (cardinality lives here per the minimalist
+split: source holds data, tests hold structural invariants — R-1532 /
+R-1720 / R-1775):
+
+  1. Cardinality is exactly 18.
+  2. N axis is exactly {224}.
+  3. M ∈ {2048, 4096, 8192}; K ∈ {4096, 8192, 16384};
+     dtype ∈ {torch.bfloat16, torch.float16}.
+  4. Per-shape dtype-mirror (bf16 ↔ fp16 admit sets coincide).
+  5. Sibling-N firewall vs every prior K-COMPLEMENT alias-stack at a
+     different N (P28 N=128, P29 N=64, P30 N ∈ {384, 768, 1536}, P31
+     N=256, P32 N=160, and the K-1367/K-1397 P13 N ∈ {128, 256}
+     envelopes).
+  6. Envelope is exactly the full 18-cell M ∈ {2048,4096,8192} × N=224
+     × K ∈ {4096,8192,16384} × {bf16,fp16} grid.
+"""
+from __future__ import annotations
+
+from tritonblas._route_predicate import (
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+    _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30,
+    _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29,
+    _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34,
+    _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28,
+    _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18,
+    _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18,
+)
+
+
+FZ = _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18
+
+
+def test_cardinality_is_18():
+    assert len(FZ) == 18
+
+
+def test_n_axis_is_skinny_n224():
+    assert {N for (_, N, _, _) in FZ} == {224}
+
+
+def test_m_k_dtype_axes_are_minimal():
+    assert {M for (M, _, _, _) in FZ} == {2048, 4096, 8192}
+    assert {K for (_, _, K, _) in FZ} == {4096, 8192, 16384}
+    assert {dt for (_, _, _, dt) in FZ} == {"torch.bfloat16", "torch.float16"}
+
+
+def test_dtype_mirror_is_complete():
+    """Each shape (M, N, K) admitted under bf16 is also admitted under fp16
+    (and vice versa).  K-913 §3 LDS-bank-conflict is dtype-invariant on the
+    column-narrow N=224 tile (same mechanism as K-1673 P28 at N=128 and
+    K-1810 P32 at N=160)."""
+    bf = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.bfloat16"}
+    fp = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.float16"}
+    assert bf == fp
+    assert len(bf) == 9
+
+
+def test_sibling_n_firewall_vs_p28_n128():
+    assert FZ & _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30 == set()
+    assert FZ & _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 == set()
+
+
+def test_sibling_n_firewall_vs_p29_n64():
+    assert FZ & _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29 == set()
+
+
+def test_sibling_n_firewall_vs_p30_nmid():
+    assert FZ & _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34 == set()
+
+
+def test_sibling_n_firewall_vs_p31_n256():
+    assert FZ & _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28 == set()
+    assert FZ & _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12 == set()
+
+
+def test_sibling_n_firewall_vs_p32_n160():
+    """K-1817 P33 (N=224) must be N-axis disjoint from K-1810 P32 (N=160).
+    Pairwise-disjointness invariant per K-1175 — the two slots cover
+    different N-rungs of the contiguous K-COMPLEMENT N-ladder."""
+    assert FZ & _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_envelope_equals_full_n224_kcompl_grid():
+    """The verified-winner envelope is exactly the full 18-cell M ∈ {2048,
+    4096,8192} × N=224 × K ∈ {4096,8192,16384} × {bf16,fp16} grid — pinned
+    to detect any silent contraction or expansion of the K-1794 sub-cohort
+    envelope.  Per K-1794, both dtype rows were entirely unrouted (bf16 0/9
+    at gmean 0.722, fp16 0/9 systemic), so all 18 cells are load-bearing
+    route-OUT entries (no upstream alias overlap, unlike K-1810 P32 N=160)."""
+    full = frozenset(
+        (M, 224, K, dt) for M in (2048, 4096, 8192)
+        for K in (4096, 8192, 16384)
+        for dt in ("torch.bfloat16", "torch.float16")
+    )
+    assert FZ == full
+    assert len(full) == 18

--- a/tests/test_p34_skinny_n96_alias_stack.py
+++ b/tests/test_p34_skinny_n96_alias_stack.py
@@ -1,0 +1,136 @@
+"""P34 (S-002) — 25th-slot N=96 K-COMPLEMENT verified-winner subset tests.
+
+Source measurement: K-1818 PMC RCA paired n=30 HIP-graph hot-cache capture/
+replay on MI300X / gfx942 across the 18-cell N=96 sub-cohort = M ∈ {2048,
+4096, 8192} × N=96 × K ∈ {4096, 8192, 16384} × {bf16, fp16}.  3-engine sweep
+(tb_oracle / tb_streamk / hbl) recorded:
+
+  * bf16 N=96 (9/9): cohort UNROUTED in K-1818's measurement (0/9 routed
+    via any upstream alias; the wave-misaligned N=96 rung sits BELOW the
+    N=128 P28 cliff, where no upstream predicate covers).  All 9 cells
+    are load-bearing route-OUT targets (no alias overlap).
+  * fp16 N=96 (9/9): cohort UNROUTED in K-1818's measurement (0/9 routed
+    via any upstream alias; r_oracle < 1.0 systemically per K-1794 R-
+    K1794.FP16-MIRROR-SYSTEMIC-AT-CROSS-BAND-LEVEL extended below N=128).
+    All 9 cells are also load-bearing — they close the dtype-mirror gap
+    at the wave-misaligned N=96 column-narrow tile.
+
+Mechanism (K-913 §3 / R-K1673 dtype-invariance + R-1811 wave-misalignment):
+BLOCK_N=128 packs N=96 into a single wave-misaligned K-block column with
+PARTIAL coverage (off-by-32 N rung); SQ_LDS_BANK_CONFLICT/inst stays
+elevated AND MFMA-tail inefficiency from wave-misalignment compounds the
+band.  persistent_matmul cannot trade tile reshape for atomic-reduction;
+hipBLASLt's split-K kernel selection clears the band.  Same fingerprint
+productionized at K-1673 P28 (N=128), K-1810 P32 (N=160), K-1775 P31
+(N=256), and K-1817 P33 (N=224); now applied to the wave-misaligned N=96
+rung BELOW the N=128 cliff.
+
+Note: like K-1817 P33 (N=224), K-1831 P34 (N=96) has NO upstream alias
+overlap — both dtype rows are load-bearing route-OUT entries.  This is
+the K-1817 alias-overlap-absent discipline (vs K-1810 P32 N=160 alias-
+overlap-allowed discipline), reflecting the absence of any upstream alias
+coverage at the off-N96 wave-misaligned rung below N=128.
+
+Invariants pinned in this file (cardinality lives here per the minimalist
+split: source holds data, tests hold structural invariants — R-1532 /
+R-1720 / R-1775):
+
+  1. Cardinality is exactly 18.
+  2. N axis is exactly {96}.
+  3. M ∈ {2048, 4096, 8192}; K ∈ {4096, 8192, 16384};
+     dtype ∈ {torch.bfloat16, torch.float16}.
+  4. Per-shape dtype-mirror (bf16 ↔ fp16 admit sets coincide).
+  5. Sibling-N firewall vs every prior K-COMPLEMENT alias-stack at a
+     different N (P28 N=128, P29 N=64, P30 N ∈ {384, 768, 1536}, P31
+     N=256, P32 N=160, P33 N=224, and the K-1367/K-1397 P13 N ∈ {128,
+     256} envelopes).
+  6. Envelope is exactly the full 18-cell M ∈ {2048,4096,8192} × N=96
+     × K ∈ {4096,8192,16384} × {bf16,fp16} grid.
+"""
+from __future__ import annotations
+
+from tritonblas._route_predicate import (
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+    _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30,
+    _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29,
+    _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34,
+    _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28,
+    _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18,
+    _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18,
+    _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18,
+)
+
+
+FZ = _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18
+
+
+def test_cardinality_is_18():
+    assert len(FZ) == 18
+
+
+def test_n_axis_is_skinny_n96():
+    assert {N for (_, N, _, _) in FZ} == {96}
+
+
+def test_m_k_dtype_axes_are_minimal():
+    assert {M for (M, _, _, _) in FZ} == {2048, 4096, 8192}
+    assert {K for (_, _, K, _) in FZ} == {4096, 8192, 16384}
+    assert {dt for (_, _, _, dt) in FZ} == {"torch.bfloat16", "torch.float16"}
+
+
+def test_dtype_mirror_is_complete():
+    """Each shape (M, N, K) admitted under bf16 is also admitted under fp16
+    (and vice versa).  K-913 §3 LDS-bank-conflict is dtype-invariant on the
+    column-narrow N=96 tile (same mechanism as K-1673 P28 at N=128, K-1810
+    P32 at N=160, K-1817 P33 at N=224)."""
+    bf = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.bfloat16"}
+    fp = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.float16"}
+    assert bf == fp
+    assert len(bf) == 9
+
+
+def test_sibling_n_firewall_vs_p28_n128():
+    assert FZ & _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30 == set()
+    assert FZ & _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 == set()
+
+
+def test_sibling_n_firewall_vs_p29_n64():
+    assert FZ & _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29 == set()
+
+
+def test_sibling_n_firewall_vs_p30_nmid():
+    assert FZ & _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34 == set()
+
+
+def test_sibling_n_firewall_vs_p31_n256():
+    assert FZ & _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28 == set()
+    assert FZ & _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12 == set()
+
+
+def test_sibling_n_firewall_vs_p32_n160():
+    assert FZ & _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_sibling_n_firewall_vs_p33_n224():
+    """K-1831 P34 (N=96) must be N-axis disjoint from K-1817 P33 (N=224).
+    Pairwise-disjointness invariant per K-1175 — the two slots cover
+    different N-rungs of the wave-misaligned K-COMPLEMENT N-ladder
+    (N=96 BELOW the N=128 cliff vs N=224 ABOVE)."""
+    assert FZ & _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_envelope_equals_full_n96_kcompl_grid():
+    """The verified-winner envelope is exactly the full 18-cell M ∈ {2048,
+    4096,8192} × N=96 × K ∈ {4096,8192,16384} × {bf16,fp16} grid — pinned
+    to detect any silent contraction or expansion of the K-1818 sub-cohort
+    envelope.  Per K-1818, both dtype rows were entirely unrouted (bf16 0/9,
+    fp16 0/9 systemic), so all 18 cells are load-bearing route-OUT entries
+    (no upstream alias overlap, mirrors K-1817 P33 N=224 discipline)."""
+    full = frozenset(
+        (M, 96, K, dt) for M in (2048, 4096, 8192)
+        for K in (4096, 8192, 16384)
+        for dt in ("torch.bfloat16", "torch.float16")
+    )
+    assert FZ == full
+    assert len(full) == 18

--- a/tests/test_p35_skinny_n288_alias_stack.py
+++ b/tests/test_p35_skinny_n288_alias_stack.py
@@ -1,0 +1,155 @@
+"""P35 (S-002) — 26th-slot N=288 K-COMPLEMENT verified-winner subset tests.
+
+Source measurement: K-1832 paired n=30 HIP-graph hot-cache 3-pass PMC sweep
+(LDS / VALU·MFMA / VMEM·L2; 108 cell-engine-pass datapoints) on MI300X /
+gfx942 (OCI MI300X fallback per INFRA-0048) across the 18-cell
+N=288 sub-cohort = M ∈ {2048, 4096, 8192} × N=288 × K ∈ {4096, 8192, 16384}
+× {bf16, fp16}.  3-engine sweep (tb_oracle / tb_streamk / hbl) recorded:
+
+  * bf16 N=288 (9/9): cohort UNROUTED in K-1832's measurement (0/9 routed
+    via any upstream alias; the wave-misaligned N=288 rung sits ABOVE the
+    N=256 P31 cliff at the off-by-32 rung where no upstream predicate
+    covers).  All 9 cells are load-bearing route-OUT targets (no alias
+    overlap).
+  * fp16 N=288 (9/9): cohort UNROUTED in K-1832's measurement (0/9 routed
+    via any upstream alias; r_oracle < 1.0 systemically per R-K1794
+    fp16-mirror systemic gap extended above N=256).  All 9 cells are also
+    load-bearing — they close the dtype-mirror gap at the wave-misaligned
+    N=288 column-narrow tile.
+
+Cohort geomean TB/HBL = 4.290× (range 3.06×–6.46×, 18/18 admit at the
+strict ≥1.05 ∧ p<0.05 gate) — the largest cohort-level uplift in the
+alias-stack to date and ~3× above the K-1818 P34 N=96 cohort uplift (1.16×).
+
+Mechanism (K-913 §3 / R-K1673 dtype-invariance + R-1811 wave-misalignment):
+BLOCK_N=128 packs N=288 into wave-misaligned K-block columns (off-by-32 N
+rung above N=256); SQ_LDS_BANK_CONFLICT/inst stays elevated AND MFMA-tail
+inefficiency from wave-misalignment compounds the band.  K-1832 PMC delta
+ranking confirms SQ_LDS_BANK_CONFLICT ≈ 869× and SQ_WAIT_INST_LDS ≈ 12.5×
+(TB / HBL) at the top of the discriminator list, with L2/HBM signals at the
+noise floor — identical fingerprint to K-1812 (TB/HBL ratio R²=0.9999 on
+the 4 overlapping cells), K-1818 N=96, and K-1794 N∈{160,224}.  Same
+SCHEDULER_LDS A4 failure mode as the K-1681 / K-1710 / K-1781 wave-
+misaligned skinny-N class.  persistent_matmul cannot trade tile reshape for
+atomic-reduction; hipBLASLt's split-K kernel selection clears the band by
+~3.3× on average.  Same fingerprint productionised at K-1673 P28 (N=128),
+K-1700 P29 (N=64), K-1748 P30 (N ∈ {384, 768, 1536}), K-1775 P31 (N=256),
+K-1810 P32 (N=160), K-1817 P33 (N=224), and K-1831 P34 (N=96); now applied
+to the wave-misaligned N=288 rung ABOVE the N=256 cliff.
+
+Note: like K-1817 P33 (N=224) and K-1831 P34 (N=96), K-1837 P35 (N=288) has
+NO upstream alias overlap — both dtype rows are load-bearing route-OUT
+entries.  This is the K-1817 alias-overlap-absent discipline (vs K-1810 P32
+N=160 alias-overlap-allowed discipline), reflecting the absence of any
+upstream alias coverage at the off-N288 wave-misaligned rung above N=256.
+
+Invariants pinned in this file (cardinality lives here per the minimalist
+split: source holds data, tests hold structural invariants — R-1532 /
+R-1720 / R-1775):
+
+  1. Cardinality is exactly 18.
+  2. N axis is exactly {288}.
+  3. M ∈ {2048, 4096, 8192}; K ∈ {4096, 8192, 16384};
+     dtype ∈ {torch.bfloat16, torch.float16}.
+  4. Per-shape dtype-mirror (bf16 ↔ fp16 admit sets coincide).
+  5. Sibling-N firewall vs every prior K-COMPLEMENT alias-stack at a
+     different N (P28 N=128, P29 N=64, P30 N ∈ {384, 768, 1536}, P31
+     N=256, P32 N=160, P33 N=224, P34 N=96, and the K-1367/K-1397 P13
+     N ∈ {128, 256} envelopes).
+  6. Envelope is exactly the full 18-cell M ∈ {2048,4096,8192} × N=288
+     × K ∈ {4096,8192,16384} × {bf16,fp16} grid.
+"""
+from __future__ import annotations
+
+from tritonblas._route_predicate import (
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+    _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30,
+    _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29,
+    _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34,
+    _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28,
+    _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18,
+    _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18,
+    _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18,
+    _P35_SKINNY_N288_KCOMPL_VERIFIED_WIN_18,
+)
+
+
+FZ = _P35_SKINNY_N288_KCOMPL_VERIFIED_WIN_18
+
+
+def test_cardinality_is_18():
+    assert len(FZ) == 18
+
+
+def test_n_axis_is_skinny_n288():
+    assert {N for (_, N, _, _) in FZ} == {288}
+
+
+def test_m_k_dtype_axes_are_minimal():
+    assert {M for (M, _, _, _) in FZ} == {2048, 4096, 8192}
+    assert {K for (_, _, K, _) in FZ} == {4096, 8192, 16384}
+    assert {dt for (_, _, _, dt) in FZ} == {"torch.bfloat16", "torch.float16"}
+
+
+def test_dtype_mirror_is_complete():
+    """Each shape (M, N, K) admitted under bf16 is also admitted under fp16
+    (and vice versa).  K-913 §3 LDS-bank-conflict is dtype-invariant on the
+    column-narrow N=288 tile (same mechanism as K-1673 P28 at N=128, K-1810
+    P32 at N=160, K-1775 P31 at N=256, K-1817 P33 at N=224, K-1831 P34 at
+    N=96)."""
+    bf = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.bfloat16"}
+    fp = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.float16"}
+    assert bf == fp
+    assert len(bf) == 9
+
+
+def test_sibling_n_firewall_vs_p28_n128():
+    assert FZ & _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30 == set()
+    assert FZ & _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 == set()
+
+
+def test_sibling_n_firewall_vs_p29_n64():
+    assert FZ & _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29 == set()
+
+
+def test_sibling_n_firewall_vs_p30_nmid():
+    assert FZ & _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34 == set()
+
+
+def test_sibling_n_firewall_vs_p31_n256():
+    assert FZ & _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28 == set()
+    assert FZ & _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12 == set()
+
+
+def test_sibling_n_firewall_vs_p32_n160():
+    assert FZ & _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_sibling_n_firewall_vs_p33_n224():
+    assert FZ & _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_sibling_n_firewall_vs_p34_n96():
+    """K-1837 P35 (N=288) must be N-axis disjoint from K-1831 P34 (N=96).
+    Pairwise-disjointness invariant per K-1175 — the two slots cover
+    different N-rungs of the wave-misaligned K-COMPLEMENT N-ladder
+    (N=288 ABOVE the N=256 cliff vs N=96 BELOW the N=128 cliff)."""
+    assert FZ & _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_envelope_equals_full_n288_kcompl_grid():
+    """The verified-winner envelope is exactly the full 18-cell M ∈ {2048,
+    4096,8192} × N=288 × K ∈ {4096,8192,16384} × {bf16,fp16} grid — pinned
+    to detect any silent contraction or expansion of the K-1832 sub-cohort
+    envelope.  Per K-1832, both dtype rows were entirely unrouted (bf16 0/9,
+    fp16 0/9 systemic) and TB lost in 18/18 cells (cohort geomean TB/HBL =
+    4.290×), so all 18 cells are load-bearing route-OUT entries (no upstream
+    alias overlap, mirrors K-1817 P33 N=224 / K-1831 P34 N=96 discipline)."""
+    full = frozenset(
+        (M, 288, K, dt) for M in (2048, 4096, 8192)
+        for K in (4096, 8192, 16384)
+        for dt in ("torch.bfloat16", "torch.float16")
+    )
+    assert FZ == full
+    assert len(full) == 18

--- a/tests/test_p36_skinny_n320_alias_stack.py
+++ b/tests/test_p36_skinny_n320_alias_stack.py
@@ -1,0 +1,196 @@
+"""P36 (S-002) — 27th-slot N=320 K-COMPLEMENT verified-winner subset tests.
+
+Source measurement: K-1843 paired n=30 HIP-graph hot-cache + 3-pass rocprofv2
+PMC sweep (LDS / VALU·MFMA / VMEM·L2; 108 cell-engine-pass datapoints) on
+MI300X / gfx942 (OCI MI300X fallback per INFRA-0048) across the 36-cell
+N ∈ {320, 352} sub-cohort = M ∈ {2048, 4096, 8192} × N ∈ {320, 352} ×
+K ∈ {4096, 8192, 16384} × {bf16, fp16}.  K-1850 productionises the N=320
+half (18 cells minus 1 already-routed cell = 17 admit cells).
+
+The N=320 slice recorded:
+
+  * bf16 N=320 (8/9 admit): 8 cells gate-pass at the strict ≥1.05 ∧ p<0.05
+    floor; 1 cell — (2048, 320, 4096, "torch.bfloat16") — landed at
+    ratio_TB/HBL = 1.0001, p = 0.293 inside the 0.95× parity band because
+    it is already routed by an upstream alias-stack slot (TB and HBL paths
+    converge on the same kernel).  Per
+    R-K1825.CHECK-ALIAS-STACK-COVERAGE-MAP-FIRST that cell is excluded from
+    P36 to avoid duplicate routing.
+  * fp16 N=320 (9/9 admit): all 9 cells gate-pass; no upstream alias
+    coverage at the off-by-64 wave-misaligned N=320 rung.  All 9 are
+    load-bearing route-OUT entries (closes the dtype-mirror gap with the
+    8 bf16 cells above the (2048, 320, 4096) exclusion).
+
+Per-N geomean TB/HBL = 1.545× (range 1.326×–1.911×, 17/17 admit at the
+strict ≥1.05 ∧ p<0.05 gate after the upstream-alias exclusion).
+
+Mechanism (K-913 §3 / R-K1673 dtype-invariance + R-1811 wave-misalignment):
+BLOCK_N=128 packs N=320 into wave-misaligned K-block columns (off-by-64 N
+rung above N=256, two-and-a-half BLOCK_N tiles per N-row).  K-1843 PMC
+delta ranking confirms LDS_DOMINANT in 36/36 cells of the N ∈ {320, 352}
+cohort with lds_wait_ratio_TB/HBL spanning 1.96×–25.27× (median ≈ 8.5×),
+MFMA per-wave ratio everywhere ≤ 0.96× (TB does *less* MFMA per wave; not
+the limiter), VMEM per-wave ratio mostly ≤ 1.0 (rules out memory-bandwidth
+as the gap mechanism).  Same SCHEDULER_LDS A4 failure mode as the K-1681 /
+K-1710 / K-1781 / K-1812 / K-1824 / K-1832 wave-misaligned skinny-N class.
+persistent_matmul cannot trade tile reshape for atomic-reduction;
+hipBLASLt's split-K kernel selection clears the band by ~55% on average.
+Same fingerprint productionised at K-1673 P28 (N=128), K-1700 P29 (N=64),
+K-1748 P30 (N ∈ {384, 768, 1536}), K-1775 P31 (N=256), K-1810 P32 (N=160),
+K-1817 P33 (N=224), K-1831 P34 (N=96), K-1837 P35 (N=288); now applied to
+the off-by-64 wave-misaligned N=320 rung between the N=256 P31 cliff and
+the N=384 P30 rung.
+
+Note: unlike K-1817 P33 (N=224), K-1831 P34 (N=96), K-1837 P35 (N=288) —
+which had NO upstream alias overlap — K-1850 P36 (N=320) has ONE
+upstream-routed cell (2048, 320, 4096, bf16); both dtype rows are still
+load-bearing because (a) the fp16 row is fully load-bearing 9/9, and (b)
+the bf16 row contributes 8 load-bearing cells outside the upstream alias.
+
+Invariants pinned in this file (cardinality lives here per the minimalist
+split: source holds data, tests hold structural invariants — R-1532 /
+R-1720 / R-1775):
+
+  1. Cardinality is exactly 17.
+  2. N axis is exactly {320}.
+  3. M ∈ {2048, 4096, 8192}; K ∈ {4096, 8192, 16384};
+     dtype ∈ {torch.bfloat16, torch.float16}.
+  4. The single upstream-aliased cell (2048, 320, 4096, bf16) is excluded.
+  5. fp16 dtype-row is complete (9/9); bf16 dtype-row has 8 cells (9 minus
+     the upstream-aliased exclusion).
+  6. Sibling-N firewall vs every prior K-COMPLEMENT alias-stack at a
+     different N (P28 N=128, P29 N=64, P30 N ∈ {384, 768, 1536}, P31
+     N=256, P32 N=160, P33 N=224, P34 N=96, P35 N=288, and the
+     K-1367/K-1397 P13 N ∈ {128, 256} envelopes).
+  7. Envelope is exactly the 18-cell M ∈ {2048,4096,8192} × N=320
+     × K ∈ {4096,8192,16384} × {bf16,fp16} grid MINUS the single
+     (2048, 320, 4096, bf16) upstream alias.
+"""
+from __future__ import annotations
+
+from tritonblas._route_predicate import (
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+    _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30,
+    _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29,
+    _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34,
+    _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28,
+    _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18,
+    _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18,
+    _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18,
+    _P35_SKINNY_N288_KCOMPL_VERIFIED_WIN_18,
+    _P36_SKINNY_N320_KCOMPL_VERIFIED_WIN_17,
+)
+
+
+FZ = _P36_SKINNY_N320_KCOMPL_VERIFIED_WIN_17
+
+# The single cell in the K-1843 N=320 sub-cohort that is already routed by an
+# upstream alias-stack slot, hence excluded from P36 per R-K1825.CHECK-ALIAS-
+# STACK-COVERAGE-MAP-FIRST.  Pinned here so that any silent re-admission would
+# fail the envelope test below.
+_UPSTREAM_ALIASED_EXCLUSION = frozenset({
+    (2048, 320, 4096, "torch.bfloat16"),
+})
+
+
+def test_cardinality_is_17():
+    assert len(FZ) == 17
+
+
+def test_n_axis_is_skinny_n320():
+    assert {N for (_, N, _, _) in FZ} == {320}
+
+
+def test_m_k_dtype_axes_are_minimal():
+    assert {M for (M, _, _, _) in FZ} == {2048, 4096, 8192}
+    assert {K for (_, _, K, _) in FZ} == {4096, 8192, 16384}
+    assert {dt for (_, _, _, dt) in FZ} == {"torch.bfloat16", "torch.float16"}
+
+
+def test_upstream_aliased_cell_is_excluded():
+    """The (2048, 320, 4096, bf16) cell measured ratio_TB/HBL=1.0001 / p=0.293
+    in K-1843's paired-n30 sweep on the LIVE oracle (it is already routed by
+    an upstream alias-stack slot).  P36 MUST NOT include it — duplicate
+    routing would violate R-K1825.CHECK-ALIAS-STACK-COVERAGE-MAP-FIRST."""
+    assert FZ & _UPSTREAM_ALIASED_EXCLUSION == set()
+
+
+def test_dtype_row_balance():
+    """fp16 row is complete (9/9 of the K-1843 N=320 sub-cohort).  bf16 row
+    contributes 8 cells (9 minus the (2048, 320, 4096) upstream-aliased
+    exclusion).  K-913 §3 LDS-bank-conflict is dtype-invariant on the
+    column-narrow N=320 tile (same mechanism as K-1673 P28 at N=128, K-1810
+    P32 at N=160, K-1775 P31 at N=256, K-1817 P33 at N=224, K-1831 P34 at
+    N=96, K-1837 P35 at N=288); the 8/9 vs 9/9 asymmetry is purely an
+    upstream-coverage artefact, not a mechanism asymmetry."""
+    bf = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.bfloat16"}
+    fp = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.float16"}
+    assert len(bf) == 8
+    assert len(fp) == 9
+    # The fp16 admits are a strict superset of the bf16 admits — bf16's
+    # missing shape (2048, 320, 4096) is exactly the upstream-aliased one.
+    assert bf <= fp
+    assert fp - bf == {(2048, 320, 4096)}
+
+
+def test_sibling_n_firewall_vs_p28_n128():
+    assert FZ & _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30 == set()
+    assert FZ & _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 == set()
+
+
+def test_sibling_n_firewall_vs_p29_n64():
+    assert FZ & _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29 == set()
+
+
+def test_sibling_n_firewall_vs_p30_nmid():
+    """P30 covers N ∈ {384, 768, 1536}; P36 covers N=320 — disjoint by
+    natural N-axis separation.  P36 sits BETWEEN the N=256 P31 cliff and
+    the N=384 P30 rung (off-by-64 rung above N=256)."""
+    assert FZ & _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34 == set()
+
+
+def test_sibling_n_firewall_vs_p31_n256():
+    assert FZ & _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28 == set()
+    assert FZ & _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12 == set()
+
+
+def test_sibling_n_firewall_vs_p32_n160():
+    assert FZ & _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_sibling_n_firewall_vs_p33_n224():
+    assert FZ & _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_sibling_n_firewall_vs_p34_n96():
+    assert FZ & _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_sibling_n_firewall_vs_p35_n288():
+    """K-1850 P36 (N=320) must be N-axis disjoint from K-1837 P35 (N=288).
+    Pairwise-disjointness invariant per K-1175 — the two slots cover
+    adjacent off-by-32 (N=288) and off-by-64 (N=320) wave-misaligned rungs
+    above the N=256 P31 cliff.  Same K-1843 cohort PMC fingerprint
+    (LDS_DOMINANT 36/36) but disjoint admit envelopes by construction."""
+    assert FZ & _P35_SKINNY_N288_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_envelope_equals_n320_kcompl_grid_minus_upstream_alias():
+    """The verified-winner envelope is exactly the 18-cell M ∈ {2048,
+    4096,8192} × N=320 × K ∈ {4096,8192,16384} × {bf16,fp16} grid MINUS
+    the single (2048, 320, 4096, bf16) upstream-aliased cell — pinned to
+    detect any silent contraction (a false-NEGATIVE that would leak winner
+    cells back to TB) or expansion (a false-POSITIVE that would re-include
+    the upstream-aliased cell) of the K-1843 sub-cohort envelope.  Per
+    K-1843 the N=320 column was 17/18 verified-winner with 1/18 inside
+    the 0.95× parity band (already-routed); all 17 are load-bearing
+    route-OUT entries."""
+    full = frozenset(
+        (M, 320, K, dt) for M in (2048, 4096, 8192)
+        for K in (4096, 8192, 16384)
+        for dt in ("torch.bfloat16", "torch.float16")
+    )
+    assert FZ == full - _UPSTREAM_ALIASED_EXCLUSION
+    assert len(full) == 18
+    assert len(FZ) == 17

--- a/tests/test_p37_skinny_n352_alias_stack.py
+++ b/tests/test_p37_skinny_n352_alias_stack.py
@@ -1,0 +1,213 @@
+"""P37 (S-002) — 28th-slot N=352 K-COMPLEMENT verified-winner subset tests.
+
+Source measurement: K-1853 paired n=30 HIP-graph hot-cache + 3-pass rocprofv2
+PMC sweep (LDS / VALU·MFMA / VMEM·L2; 108 cell-engine-pass datapoints) on
+MI300X / gfx942 (OCI MI300X fallback per INFRA-0048) across the 18-cell
+N=352 sub-cohort = M ∈ {2048, 4096, 8192} × N=352 × K ∈ {4096, 8192, 16384}
+× {bf16, fp16}.  K-1868 productionises the N=352 half (18 cells, no upstream
+alias overlap → all 18 are net-new admit cells), completing the second half
+of the K-1843 36-cell N ∈ {320, 352} sub-cohort that K-1850 P36 productionised
+the first (N=320) half of.
+
+The N=352 slice recorded:
+
+  * bf16 N=352 (9/9 admit): all 9 cells gate-pass at the strict ≥1.05 ∧
+    p<0.05 floor; no upstream alias coverage at the off-by-96 wave-misaligned
+    N=352 rung (R-K1825 audit confirms N=352 is N-axis disjoint from every
+    prior K-COMPLEMENT slot's N-axis projection: P5, P13, P21, P28-P36).
+  * fp16 N=352 (9/9 admit): all 9 cells gate-pass; same R-K1825 result.
+    Both dtype rows are fully load-bearing — closes the wave-misaligned
+    N=352 dtype-mirror.
+
+Per-N geomean TB/HBL = 1.243× (range 1.066×–1.481×; per-cell paired-CI lo
+spans 1.0589–1.4699 and is strictly > 1.05 in all 18 cells, satisfying the
+non-overlapping-CI requirement).
+
+Mechanism (K-913 §3 / R-K1673 dtype-invariance + R-1811 wave-misalignment):
+BLOCK_N=128 packs N=352 into wave-misaligned K-block columns (off-by-96 N
+rung above N=256: 352 mod 128 = 96 — two full BLOCK_N tiles plus a 96-wide
+remainder per N-row).  K-1853 PMC delta ranking confirms LDS_DOMINANT in
+18/18 cells with SQ_LDS_BANK_CONFLICT TB/HBL median 336× (per-cell range
+76×–1920×) and SQ_WAIT_INST_LDS median 10.3×, while SQ_INSTS_MFMA TB/HBL
+= 0.99× (identical arithmetic work — TB just stalls ~2× longer waiting on
+LDS, with TB MFMA-busy fraction ~9.4% vs HBL ~17.7%).  Same SCHEDULER_LDS
+A4 failure mode as the K-1681 / K-1710 / K-1781 / K-1812 / K-1824 / K-1832 /
+K-1843 wave-misaligned skinny-N class.  N=352 is pathologically worse than
+N=320 for tritonblas's persistent_matmul LDS swizzle: SQ_LDS_BANK_CONFLICT
+shows TB/HBL ratios in ALL 18 cells (vs only 6/18 for the K-1846 N=320
+column).  hipBLASLt's split-K kernel selection clears the band by ~24% on
+average (geomean 1.243×).
+Same fingerprint productionised at K-1673 P28 (N=128), K-1700 P29 (N=64),
+K-1748 P30 (N ∈ {384, 768, 1536}), K-1775 P31 (N=256), K-1810 P32 (N=160),
+K-1817 P33 (N=224), K-1831 P34 (N=96), K-1837 P35 (N=288), K-1850 P36
+(N=320); now applied to the off-by-96 wave-misaligned N=352 rung — the
+last un-promoted skinny-N rung between the N=256 P31 cliff and the N=384
+P30 rung, completing the wave-misaligned skinny-N N ∈ {96, 160, 224, 288,
+320, 352} ladder.
+
+Note: unlike K-1850 P36 (N=320), which had ONE upstream-routed cell that
+required exclusion, K-1868 P37 (N=352) has NO upstream alias overlap — both
+dtype rows contribute the full 9 cells (mirrors K-1817 P33 N=224, K-1831
+P34 N=96, K-1837 P35 N=288 alias-overlap-absent discipline).  Cardinality
+is therefore the full 18 (not 17).
+
+Invariants pinned in this file (cardinality lives here per the minimalist
+split: source holds data, tests hold structural invariants — R-1532 /
+R-1720 / R-1775):
+
+  1. Cardinality is exactly 18.
+  2. N axis is exactly {352}.
+  3. M ∈ {2048, 4096, 8192}; K ∈ {4096, 8192, 16384};
+     dtype ∈ {torch.bfloat16, torch.float16}.
+  4. NO upstream alias-stack slot overlaps P37 (N=352 is N-axis disjoint
+     from every prior K-COMPLEMENT slot — P5, P13, P21, P28-P36).
+  5. Both dtype rows are fully load-bearing: bf16 9/9, fp16 9/9 (no
+     dtype-row asymmetry, unlike P36's 8/9 bf16 + 9/9 fp16 where one cell
+     was upstream-aliased).
+  6. Sibling-N firewall vs every prior K-COMPLEMENT alias-stack at a
+     different N (P28 N=128, P29 N=64, P30 N ∈ {384, 768, 1536}, P31
+     N=256, P32 N=160, P33 N=224, P34 N=96, P35 N=288, P36 N=320, and
+     the K-1367/K-1397 P13 N ∈ {128, 256} envelopes).
+  7. Envelope is exactly the 18-cell M ∈ {2048,4096,8192} × N=352
+     × K ∈ {4096,8192,16384} × {bf16,fp16} grid.
+"""
+from __future__ import annotations
+
+from tritonblas._route_predicate import (
+    _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+    _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+    _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30,
+    _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29,
+    _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34,
+    _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28,
+    _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18,
+    _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18,
+    _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18,
+    _P35_SKINNY_N288_KCOMPL_VERIFIED_WIN_18,
+    _P36_SKINNY_N320_KCOMPL_VERIFIED_WIN_17,
+    _P37_SKINNY_N352_KCOMPL_VERIFIED_WIN_18,
+)
+
+
+FZ = _P37_SKINNY_N352_KCOMPL_VERIFIED_WIN_18
+
+
+def test_cardinality_is_18():
+    assert len(FZ) == 18
+
+
+def test_n_axis_is_skinny_n352():
+    assert {N for (_, N, _, _) in FZ} == {352}
+
+
+def test_m_k_dtype_axes_are_minimal():
+    assert {M for (M, _, _, _) in FZ} == {2048, 4096, 8192}
+    assert {K for (_, _, K, _) in FZ} == {4096, 8192, 16384}
+    assert {dt for (_, _, _, dt) in FZ} == {"torch.bfloat16", "torch.float16"}
+
+
+def test_no_upstream_alias_overlap():
+    """Per R-K1825.CHECK-ALIAS-STACK-COVERAGE-MAP-FIRST audit, no upstream
+    alias-stack slot covers any N=352 cell — P37 is the first slot to admit
+    the N=352 rung.  Unlike K-1850 P36 (N=320), where (2048, 320, 4096, bf16)
+    was upstream-aliased and excluded, P37 has zero upstream-overlap and
+    therefore the full 18-cell envelope is admit-eligible."""
+    upstream_slots = (
+        _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18,
+        _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12,
+        _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30,
+        _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29,
+        _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34,
+        _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28,
+        _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18,
+        _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18,
+        _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18,
+        _P35_SKINNY_N288_KCOMPL_VERIFIED_WIN_18,
+        _P36_SKINNY_N320_KCOMPL_VERIFIED_WIN_17,
+    )
+    for slot in upstream_slots:
+        assert FZ & slot == set(), (
+            "P37 must not overlap any upstream K-COMPLEMENT alias-stack slot"
+        )
+
+
+def test_dtype_row_balance_full_9_9():
+    """Both dtype rows are fully load-bearing: bf16 9/9 + fp16 9/9.  No
+    dtype-row asymmetry (unlike P36's 8/9 + 9/9 which was an upstream-
+    coverage artefact, not a mechanism asymmetry).  K-913 §3 LDS-bank-
+    conflict is dtype-invariant on the column-narrow N=352 tile, and there
+    is no upstream cell to subtract from either row."""
+    bf = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.bfloat16"}
+    fp = {(M, N, K) for (M, N, K, dt) in FZ if dt == "torch.float16"}
+    assert len(bf) == 9
+    assert len(fp) == 9
+    # The bf16 and fp16 admit shape-projections are identical (full-grid).
+    assert bf == fp
+
+
+def test_sibling_n_firewall_vs_p28_n128():
+    assert FZ & _K1673_P28_SKINNY_N128_KCOMPL_ALIASSTACK_30 == set()
+    assert FZ & _K1367_P13_SKINNY_N128_KCOMPL_ROUTEOUT_18 == set()
+
+
+def test_sibling_n_firewall_vs_p29_n64():
+    assert FZ & _K1700_P29_SKINNY_N64_KCOMPL_ALIASSTACK_29 == set()
+
+
+def test_sibling_n_firewall_vs_p30_nmid():
+    """P30 covers N ∈ {384, 768, 1536}; P37 covers N=352 — disjoint by
+    natural N-axis separation.  P37 sits BETWEEN the K-1850 P36 N=320 rung
+    and the K-1748 P30 N=384 rung (off-by-96 rung above N=256, last
+    un-promoted skinny-N rung in the wave-misaligned ladder)."""
+    assert FZ & _K1711_P30_SKINNY_NMID_KCOMPL_ALIASSTACK_34 == set()
+
+
+def test_sibling_n_firewall_vs_p31_n256():
+    assert FZ & _P31_SKINNY_N256_KCOMPL_VERIFIED_WIN_28 == set()
+    assert FZ & _K1397_P13_SKINNY_N256_KCOMPL_ROUTEOUT_12 == set()
+
+
+def test_sibling_n_firewall_vs_p32_n160():
+    assert FZ & _P32_SKINNY_N160_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_sibling_n_firewall_vs_p33_n224():
+    assert FZ & _P33_SKINNY_N224_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_sibling_n_firewall_vs_p34_n96():
+    assert FZ & _P34_SKINNY_N96_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_sibling_n_firewall_vs_p35_n288():
+    assert FZ & _P35_SKINNY_N288_KCOMPL_VERIFIED_WIN_18 == set()
+
+
+def test_sibling_n_firewall_vs_p36_n320():
+    """K-1868 P37 (N=352) must be N-axis disjoint from K-1850 P36 (N=320).
+    Pairwise-disjointness invariant per K-1175 — the two slots cover
+    adjacent off-by-64 (N=320) and off-by-96 (N=352) wave-misaligned rungs
+    above the N=256 P31 cliff.  Both halves of the K-1843 36-cell N ∈
+    {320, 352} sub-cohort have the same K-1843 PMC fingerprint
+    (LDS_DOMINANT 36/36) but disjoint admit envelopes by construction."""
+    assert FZ & _P36_SKINNY_N320_KCOMPL_VERIFIED_WIN_17 == set()
+
+
+def test_envelope_equals_n352_kcompl_full_grid():
+    """The verified-winner envelope is exactly the full 18-cell M ∈ {2048,
+    4096,8192} × N=352 × K ∈ {4096,8192,16384} × {bf16,fp16} grid — pinned
+    to detect any silent contraction (a false-NEGATIVE that would leak
+    winner cells back to TB) or expansion (a false-POSITIVE that would
+    extend P37 outside the K-1853 measured cohort) of the K-1853 sub-cohort
+    envelope.  Per K-1853 the N=352 column was 18/18 verified-winner with
+    paired-CI lo strictly > 1.05 in every cell (geomean TB/HBL = 1.243×);
+    all 18 are load-bearing route-OUT entries (no upstream alias subtractions
+    needed)."""
+    full = frozenset(
+        (M, 352, K, dt) for M in (2048, 4096, 8192)
+        for K in (4096, 8192, 16384)
+        for dt in ("torch.bfloat16", "torch.float16")
+    )
+    assert FZ == full
+    assert len(full) == 18
+    assert len(FZ) == 18


### PR DESCRIPTION
## Motivation

Closes the wave-misaligned **N=384 K-COMPLEMENT** rung of the
tritonblas-vs-hipBLASLt parity envelope on MI300X (gfx942), the last
unproductionized K-COMPLEMENT slice of the K-1748 P30 N-mid envelope
(P30 covers N=384 only at K ∈ {8192, 32768} for M ∈ {2048, 4096} and at
K=32768 for M=8192; this PR picks up the K ∈ {4096, 16384} columns plus
the K=8192 column at M=8192).  The K-1857 paired-n30 HIP-graph + 3-pass
rocprofv2 PMC sweep showed tritonblas `persistent_matmul` losing to
hipBLASLt by **per-N geomean 1.283× (range 1.135×–1.555×)** across the
18-cell N=384 sub-cohort, with the cohort MAX `lds_wait_ratio_TB/HBL`
landing at 13.0× (more extreme than K-1846's 11.15× at N=320) and
SQ_LDS_BANK_CONFLICT recording **ZERO HBL conflicts in all 18 cells
(TB nonzero in all 18)** — a cleaner qualitative gap than at N=320 where
K-1846 had 12/18 HBL=0.

### Mechanism (R-1811 wave-misalignment + K-913 §3 LDS-bank-conflict)

**N=384 = 1.5 × BN=256.**  A 256-BN persistent_matmul kernel packs N=384
into one full BN tile + a half-wave tail tile per N-row.  With MI300X
CDNA3 wave64 lanes the tail wave **leaves 50% of MFMA lanes idle**,
while the K-913 §3 LDS swizzle on the half-tile bank pattern feeds
strided LDS reads that bank-conflict against the tail wave's masked
lanes.  Concretely:

- `SQ_LDS_BANK_CONFLICT`: TB nonzero in **18/18** cells, HBL **ZERO in
  18/18** (qualitatively cleaner than K-1846 N=320: 12/18 HBL=0).
- `SQ_WAIT_INST_LDS`: TB/HBL median **13.0×** (TB stalls on LDS deps
  13× longer than HBL — more extreme than K-1846's 11.15× at N=320).
- `SQ_INSTS_VALU` TB/HBL = **2.26×**, `SQ_BUSY_CYCLES` TB/HBL = **1.95×**,
  while `SQ_INSTS_MFMA` TB/HBL = **0.99×** (TB does the same MFMA work
  but burns 2.26× the VALU instructions on LDS-conflict resolution).
- MFMA-busy fraction TB ≈ **9.4%** vs HBL ≈ **18.3%** — TB's MFMA pipe
  is starved roughly half the cycles HBL feeds it.

This is the canonical `SCHEDULER_LDS A4` fingerprint from K-1681/K-1710/
K-1781/K-1812/K-1824/K-1832/K-1843/K-1853.  hipBLASLt's split-K kernel
selection clears the band by ~28% on average (geomean 1.283× over
pre-stack TB-native).  Confirms K-1839's finding that N-padding
cannot rescue wave-misaligned skinny-N — explicit route-OUT is required.

After this PR the wave-misaligned K-COMPLEMENT N-ladder is **contiguously
covered** at N ∈ {96, 160, 224, 288, 320, 352, **384**} on top of the
wave-aligned anchors N ∈ {128, 192, 256}.  End-user impact: BF16/FP16
GEMMs of shape `(M, 384, K)` for `M ∈ {2048, 4096, 8192}` × `K ∈ {4096,
16384}` (all M, K) and `(8192, 384, 8192)` now route to hipBLASLt at
the dispatcher boundary, picking up **~24% average wall-time recovery**
vs the in-tree tritonblas kernel.

## Technical Details

Mirrors the K-1810 P32 (N=160) / K-1817 P33 (N=224) / K-1831 P34 (N=96) /
K-1837 P35 (N=288) / K-1850 P36 (N=320) / K-1868 P37 (N=352) wire-up
pattern exactly.  Two files, **+24 LOC total** (+16 src + +8
dispatcher) — within the ≤30 LOC budget specified by S-002 / K-1880 PRD.

| File | LOC | Change |
|------|-----|--------|
| `include/tritonblas/_route_predicate.py` | +16 | New `_P38_SKINNY_N384_KCOMPL_VERIFIED_WIN_14` literal frozenset (set-comprehension minus 4 P30-overlap cells) with K-1857 measurement provenance comment block, R-K1825.CHECK-ALIAS-STACK-COVERAGE-MAP-FIRST exclusion, and K-913 §3 + R-1811 mechanism notes. |
| `include/tritonblas/matmul.py` | +8 | Import alias for `_P38_SKINNY_N384_KCOMPL_VERIFIED_WIN_14`; 29th dispatch line in `_k971_route_to_hbl()` immediately after the P37 N=352 line — single-line frozenset membership check identical to P28-P37. |
| **Total** | **+24** | 2 files, no deletions, alias-stack chain-position 29.  Within ≤30 LOC budget; well under ≤7 file budget. |

### Cohort: 14 cells (post-audit), NOT 18 (PRD-nominal)

The K-1857 measured cohort is the full 18-cell `M ∈ {2048,4096,8192} ×
N=384 × K ∈ {4096,8192,16384} × {bf16,fp16}` grid.  Per
R-K1825.CHECK-ALIAS-STACK-COVERAGE-MAP-FIRST the 4 cells `(M ∈ {2048,4096},
N=384, K=8192) × {bf16,fp16}` are already routed by the upstream K-1748
P30 N-mid alias-stack and are excluded from the P38 frozenset to keep the
admit set minimal (the dispatcher short-circuits on first match, so
double-admission is wasteful but harmless).  The remaining **14 cells**
are the K-COMPLEMENT and are the load-bearing cells of this slot.

## Verification

Verified on MI300X / gfx942 (OCI useocpm2m-097-033 fallback per INFRA-0048):

* **K-1880 confirmation paired n=30 HIP-graph hot-cache replay**
  (`scripts/k1878_p38_confirm_bench.py`) measures TB-via-dispatcher /
  HBL-direct on the 14 P38 cells:
  - **P38 (14 cells, route-OUT promoted)**: per-N geomean speedup vs
    HBL = **0.966×** (≥0.95× parity target ✓; ~3.4% dispatcher overhead
    vs direct HBL).
  - **P30 N=384 sibling firewall (4 cells, K=8192)**: 0.964× — no
    regression (≥0.95× ✓).
  - **P37 N=352 sibling firewall (6 cells, K=4096)**: 0.952× — no
    regression (≥0.95× ✓).
* **Routing smoke**: 14/14 P38 admit via `_k971_route_to_hbl`, 10/10 P30
  N=384 admit (sibling firewall holds), 18/18 P37 N=352 admit (sibling
  firewall holds), no `(M, N, K, dtype)` overlap with P30 or P37 frozensets.
* **Net cohort uplift before/after promotion**: pre-stack TB-native vs
  HBL geomean **1.283×** (TB 28.3% slower); post-stack TB-via-route vs
  HBL geomean **1.036×** (TB 3.6% slower from dispatcher overhead).
  **Net throughput recovery: 1.283 / 1.036 ≈ 1.24× ≈ +24%** on the
  18-cell measured cohort.

**Discipline lineage**: K-1850 P36 N=320 (alias-overlap-present, one cell
excluded), K-1868 P37 N=352 (no upstream-alias overlap, full 18 cells).
N=384 has 4-cell P30 overlap → 14 net-new admits, dtype-row balance
7/9 + 7/9.  Cardinality matches K-1857 cohort minus R-K1825 audit
exclusions — no PRD-vs-actual cardinality discrepancy.
