### PR TITLE
stages: default load cache_modifier to None (compiler default) instead of .cg

### DIFF
--- a/include/tritonblas/kernels/stages/gemm_context.py
+++ b/include/tritonblas/kernels/stages/gemm_context.py
@@ -96,8 +96,8 @@ class GemmContext:
         num_xcds=1,
         group_size_m=8,
         chunk_size=1,
-        cache_modifier_a=".cg",
-        cache_modifier_b=".cg",
+        cache_modifier_a=None,
+        cache_modifier_b=None,
         acc_dtype=tl.float32,
         allow_tf32=True,
         even_k=True,
@@ -114,8 +114,8 @@ class GemmContext:
             num_xcds: Number of XCDs for chiplet transform (default: 1)
             group_size_m: Group size for tile scheduling (default: 8)
             chunk_size: Chunk size for chiplet scheduling (default: 1)
-            cache_modifier_a: Cache modifier for A loads (default: ".cg")
-            cache_modifier_b: Cache modifier for B loads (default: ".cg")
+            cache_modifier_a: Cache modifier for A loads (default: None = compiler default)
+            cache_modifier_b: Cache modifier for B loads (default: None = compiler default)
             acc_dtype: Accumulator dtype (default: tl.float32)
             allow_tf32: Allow TF32 for matmul (default: True)
             even_k: Whether K is evenly divisible by BLOCK_K (default: True)

--- a/include/tritonblas/kernels/stages/matrix_view.py
+++ b/include/tritonblas/kernels/stages/matrix_view.py
@@ -92,14 +92,14 @@ class InputView:
         return ptrs, mask
     
     @triton.jit
-    def load(self, tile: Tile, boundary: tl.constexpr = False, cache_modifier: tl.constexpr = ".cg"):
+    def load(self, tile: Tile, boundary: tl.constexpr = False, cache_modifier: tl.constexpr = None):
         """
         Load a tile from this matrix.
         
         Args:
             tile: Tile with coordinates and shape
             boundary: If True, apply boundary masking for partial tiles
-            cache_modifier: Cache modifier for load instruction
+            cache_modifier: Cache modifier for load instruction (default: None = compiler default)
         
         Returns:
             Loaded tile data [BLOCK_ROW, BLOCK_COL]
@@ -301,7 +301,7 @@ class OutputView:
         tl.store(ptrs, result, mask=mask)
     
     @triton.jit
-    def load(self, tile: Tile, boundary: tl.constexpr = False, cache_modifier: tl.constexpr = ".cg"):
+    def load(self, tile: Tile, boundary: tl.constexpr = False, cache_modifier: tl.constexpr = None):
         """
         Load a tile from this matrix (for read-modify-write patterns).
         """


### PR DESCRIPTION
## Summary

The composable stages advertise `.cg` as the default load `cache_modifier` in `GemmContext` and in the `InputView`/`OutputView` `load()` helpers. A full-grid MI300X sweep shows `.cg` is a poor default, so this aligns the *stages* defaults with what the shipping GEMM path already does (compiler default / `None`).

- `GemmContext(cache_modifier_a/b=".cg")` → `None`
- `InputView.load(..., cache_modifier=".cg")` → `None`
- `OutputView.load(..., cache_modifier=".cg")` → `None`

`persistent_matmul_lt` already passes `CACHE_MODIFIER_A/B = None`, so **the default library path is unchanged** — this only removes a ~15%-slower footgun for custom kernels built on the stages API.

## Evidence

Full sweep: **262,144 shapes** (64³, M/N/K ∈ 128..8192 step 128), fp16 TN, 8× MI300X (`gfx942`), Triton 3.6.0. Same tile + same inputs per shape across modifiers (apples-to-apples), L2 flush between timed reps.

| modifier | per-shape wins | mean GFLOP/s | mean % of best |
|---|---:|---:|---:|
| `.ca` (cache-all) | 51.6% | 282,497 | 99.0% |
| `None` / compiler default | 45.5% | 281,255 | 98.4% |
| `.cg` (old stages default) | 2.9% | 239,671 | 86.2% |

- `.cg` is slower than the compiler default on **94.2%** of shapes; default is **1.15× / +15.2%** faster on average.
- `.cg` is best on only 2.9% of shapes and averages 86% of achievable throughput.
- `.ca` edges out `None` on average (+0.71% mean) but is shape-dependent (helps small GEMMs, ~neutral/slightly worse on large) with a heavier regression tail, so `None` is chosen as the safe default here. Per-shape modifier selection is a reasonable follow-up.

## Test plan

- [ ] CI GEMM correctness/perf suites pass on MI300X (`gfx942`).
- [ ] Sanity: a stages-based kernel constructed without an explicit `cache_modifier` compiles and runs (now uses compiler default).

Made with [Cursor](https://cursor.com)